### PR TITLE
improve namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Use [nuget](https://www.nuget.org/packages/Seam) to install.
 ## Usage
 
 ```csharp
-var seam = new Seam.Client.Seam(apiToken: "YOUR_API_KEY");
+using Seam.Client;
+
+var seam = new SeamClient(apiToken: "YOUR_API_KEY");
 
 var myDevices = seam.Devices.List();
 

--- a/output/csharp/src/Seam.Test/SeamConnectTest.cs
+++ b/output/csharp/src/Seam.Test/SeamConnectTest.cs
@@ -1,10 +1,10 @@
-namespace Seam.Test;
-
 using Seam.Client;
+
+namespace Seam.Test;
 
 public class SeamConnectTest : IDisposable
 {
-    public Seam seam;
+    public SeamClient seam;
 
     private static readonly Random random = new();
 
@@ -17,7 +17,7 @@ public class SeamConnectTest : IDisposable
                 .ToArray()
         );
 
-        seam = new Seam(
+        seam = new SeamClient(
             basePath: string.Format("https://{0}.fakeseamconnect.seam.vc", r),
             apiToken: "seam_apikey1_token"
         );

--- a/output/csharp/src/Seam/Api/AccessCodes.cs
+++ b/output/csharp/src/Seam/Api/AccessCodes.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class AccessCodes
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public AccessCodes(ISeam seam)
+        public AccessCodes(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -928,12 +928,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.AccessCodes AccessCodes => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.AccessCodes AccessCodes { get; }
     }

--- a/output/csharp/src/Seam/Api/ActionAttempts.cs
+++ b/output/csharp/src/Seam/Api/ActionAttempts.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class ActionAttempts
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public ActionAttempts(ISeam seam)
+        public ActionAttempts(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -137,12 +137,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.ActionAttempts ActionAttempts => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.ActionAttempts ActionAttempts { get; }
     }

--- a/output/csharp/src/Seam/Api/ClientSessions.cs
+++ b/output/csharp/src/Seam/Api/ClientSessions.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class ClientSessions
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public ClientSessions(ISeam seam)
+        public ClientSessions(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -307,12 +307,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.ClientSessions ClientSessions => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.ClientSessions ClientSessions { get; }
     }

--- a/output/csharp/src/Seam/Api/ClimateSettingSchedulesThermostats.cs
+++ b/output/csharp/src/Seam/Api/ClimateSettingSchedulesThermostats.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class ClimateSettingSchedulesThermostats
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public ClimateSettingSchedulesThermostats(ISeam seam)
+        public ClimateSettingSchedulesThermostats(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -364,13 +364,17 @@ namespace Seam.Api
             [JsonConstructorAttribute]
             protected ListRequest() { }
 
-            public ListRequest(string deviceId = default)
+            public ListRequest(string deviceId = default, string? userIdentifierKey = default)
             {
                 DeviceId = deviceId;
+                UserIdentifierKey = userIdentifierKey;
             }
 
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
+
+            [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
+            public string? UserIdentifierKey { get; set; }
         }
 
         [DataContract(Name = "listResponse_response")]
@@ -401,9 +405,12 @@ namespace Seam.Api
                 .Data.ClimateSettingSchedules;
         }
 
-        public List<ClimateSettingSchedule> List(string deviceId = default)
+        public List<ClimateSettingSchedule> List(
+            string deviceId = default,
+            string? userIdentifierKey = default
+        )
         {
-            return List(new ListRequest(deviceId: deviceId));
+            return List(new ListRequest(deviceId: deviceId, userIdentifierKey: userIdentifierKey));
         }
 
         public async Task<List<ClimateSettingSchedule>> ListAsync(ListRequest request)
@@ -420,9 +427,16 @@ namespace Seam.Api
                 .ClimateSettingSchedules;
         }
 
-        public async Task<List<ClimateSettingSchedule>> ListAsync(string deviceId = default)
+        public async Task<List<ClimateSettingSchedule>> ListAsync(
+            string deviceId = default,
+            string? userIdentifierKey = default
+        )
         {
-            return (await ListAsync(new ListRequest(deviceId: deviceId)));
+            return (
+                await ListAsync(
+                    new ListRequest(deviceId: deviceId, userIdentifierKey: userIdentifierKey)
+                )
+            );
         }
 
         [DataContract(Name = "updateRequest_request")]
@@ -678,13 +692,13 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.ClimateSettingSchedulesThermostats ClimateSettingSchedulesThermostats =>
             new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.ClimateSettingSchedulesThermostats ClimateSettingSchedulesThermostats { get; }
     }

--- a/output/csharp/src/Seam/Api/ConnectWebviews.cs
+++ b/output/csharp/src/Seam/Api/ConnectWebviews.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class ConnectWebviews
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public ConnectWebviews(ISeam seam)
+        public ConnectWebviews(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -415,12 +415,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.ConnectWebviews ConnectWebviews => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.ConnectWebviews ConnectWebviews { get; }
     }

--- a/output/csharp/src/Seam/Api/ConnectedAccounts.cs
+++ b/output/csharp/src/Seam/Api/ConnectedAccounts.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class ConnectedAccounts
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public ConnectedAccounts(ISeam seam)
+        public ConnectedAccounts(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -142,12 +142,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.ConnectedAccounts ConnectedAccounts => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.ConnectedAccounts ConnectedAccounts { get; }
     }

--- a/output/csharp/src/Seam/Api/Devices.cs
+++ b/output/csharp/src/Seam/Api/Devices.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class Devices
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public Devices(ISeam seam)
+        public Devices(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -522,12 +522,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.Devices Devices => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.Devices Devices { get; }
     }

--- a/output/csharp/src/Seam/Api/Events.cs
+++ b/output/csharp/src/Seam/Api/Events.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class Events
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public Events(ISeam seam)
+        public Events(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -465,12 +465,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.Events Events => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.Events Events { get; }
     }

--- a/output/csharp/src/Seam/Api/Locks.cs
+++ b/output/csharp/src/Seam/Api/Locks.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class Locks
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public Locks(ISeam seam)
+        public Locks(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -151,12 +151,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.Locks Locks => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.Locks Locks { get; }
     }

--- a/output/csharp/src/Seam/Api/NoiseThresholdsNoiseSensors.cs
+++ b/output/csharp/src/Seam/Api/NoiseThresholdsNoiseSensors.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class NoiseThresholdsNoiseSensors
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public NoiseThresholdsNoiseSensors(ISeam seam)
+        public NoiseThresholdsNoiseSensors(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -527,12 +527,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.NoiseThresholdsNoiseSensors NoiseThresholdsNoiseSensors => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.NoiseThresholdsNoiseSensors NoiseThresholdsNoiseSensors { get; }
     }

--- a/output/csharp/src/Seam/Api/Thermostats.cs
+++ b/output/csharp/src/Seam/Api/Thermostats.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class Thermostats
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public Thermostats(ISeam seam)
+        public Thermostats(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -524,12 +524,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.Thermostats Thermostats => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.Thermostats Thermostats { get; }
     }

--- a/output/csharp/src/Seam/Api/UnmanagedAccessCodes.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessCodes.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class UnmanagedAccessCodes
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public UnmanagedAccessCodes(ISeam seam)
+        public UnmanagedAccessCodes(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -91,12 +91,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.UnmanagedAccessCodes UnmanagedAccessCodes => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.UnmanagedAccessCodes UnmanagedAccessCodes { get; }
     }

--- a/output/csharp/src/Seam/Api/UnmanagedDevices.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedDevices.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class UnmanagedDevices
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public UnmanagedDevices(ISeam seam)
+        public UnmanagedDevices(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -527,12 +527,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.UnmanagedDevices UnmanagedDevices => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.UnmanagedDevices UnmanagedDevices { get; }
     }

--- a/output/csharp/src/Seam/Api/Webhooks.cs
+++ b/output/csharp/src/Seam/Api/Webhooks.cs
@@ -10,9 +10,9 @@ namespace Seam.Api
 {
     public class Webhooks
     {
-        private ISeam _seam;
+        private ISeamClient _seam;
 
-        public Webhooks(ISeam seam)
+        public Webhooks(ISeamClient seam)
         {
             _seam = seam;
         }
@@ -140,12 +140,12 @@ namespace Seam.Api
 
 namespace Seam.Client
 {
-    public partial class Seam
+    public partial class SeamClient
     {
         public Api.Webhooks Webhooks => new(this);
     }
 
-    public partial interface ISeam
+    public partial interface ISeamClient
     {
         public Api.Webhooks Webhooks { get; }
     }

--- a/output/csharp/src/Seam/Client/Seam.cs
+++ b/output/csharp/src/Seam/Client/Seam.cs
@@ -168,13 +168,13 @@ namespace Seam.Client
         public DataFormat DataFormat => DataFormat.Json;
     }
 
-    public partial interface ISeam : ISynchronousSeam, IAsynchronousSeam, IDisposable { }
+    public partial interface ISeamClient : ISynchronousSeam, IAsynchronousSeam, IDisposable { }
 
     /// <summary>
     /// Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
     /// encapsulating general REST accessor use cases.
     /// </summary>
-    public partial class Seam : ISeam
+    public partial class SeamClient : ISeamClient
     {
         private readonly string _baseUrl;
         private readonly string _apiToken;
@@ -213,7 +213,7 @@ namespace Seam.Client
         /// <param name="basePath">The target service's base path in URL format.</param>
         /// <param name="apiToken">The target service's API Token.</param>
         /// <exception cref="ArgumentException"></exception>
-        public Seam(string apiToken)
+        public SeamClient(string apiToken)
             : this(GlobalSeamRequestConfiguration.Instance.BasePath, apiToken) { }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Seam.Client
         /// <param name="basePath">The target service's base path in URL format.</param>
         /// <param name="apiToken">The target service's API Token.</param>
         /// <exception cref="ArgumentException"></exception>
-        public Seam(string basePath, string apiToken)
+        public SeamClient(string basePath, string apiToken)
         {
             if (string.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");
@@ -1034,5 +1034,15 @@ namespace Seam.Client
 
         #endregion ISynchronousClient
         public void Dispose() { }
+    }
+
+    [Obsolete("Please use Seam.Client.SeamClient instead")]
+    public class Seam : SeamClient
+    {
+        public Seam(string apiToken)
+            : base(apiToken) { }
+
+        public Seam(string basePath, string apiToken)
+            : base(basePath, apiToken) { }
     }
 }

--- a/output/csharp/src/Seam/Model/AcsAccessGroup.cs
+++ b/output/csharp/src/Seam/Model/AcsAccessGroup.cs
@@ -19,6 +19,8 @@ namespace Seam.Model
             string name = default,
             AcsAccessGroup.AccessGroupTypeEnum accessGroupType = default,
             string accessGroupTypeDisplayName = default,
+            AcsAccessGroup.ExternalTypeEnum externalType = default,
+            string externalTypeDisplayName = default,
             string createdAt = default
         )
         {
@@ -28,11 +30,20 @@ namespace Seam.Model
             Name = name;
             AccessGroupType = accessGroupType;
             AccessGroupTypeDisplayName = accessGroupTypeDisplayName;
+            ExternalType = externalType;
+            ExternalTypeDisplayName = externalTypeDisplayName;
             CreatedAt = createdAt;
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public enum AccessGroupTypeEnum
+        {
+            [EnumMember(Value = "pti_unit")]
+            PtiUnit = 0
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum ExternalTypeEnum
         {
             [EnumMember(Value = "pti_unit")]
             PtiUnit = 0
@@ -59,6 +70,16 @@ namespace Seam.Model
             EmitDefaultValue = false
         )]
         public string AccessGroupTypeDisplayName { get; set; }
+
+        [DataMember(Name = "external_type", IsRequired = true, EmitDefaultValue = false)]
+        public AcsAccessGroup.ExternalTypeEnum ExternalType { get; set; }
+
+        [DataMember(
+            Name = "external_type_display_name",
+            IsRequired = true,
+            EmitDefaultValue = false
+        )]
+        public string ExternalTypeDisplayName { get; set; }
 
         [DataMember(Name = "created_at", IsRequired = true, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }

--- a/output/csharp/src/Seam/Model/AcsSystem.cs
+++ b/output/csharp/src/Seam/Model/AcsSystem.cs
@@ -14,6 +14,8 @@ namespace Seam.Model
 
         public AcsSystem(
             string acsSystemId = default,
+            AcsSystem.ExternalTypeEnum externalType = default,
+            string externalTypeDisplayName = default,
             AcsSystem.SystemTypeEnum systemType = default,
             string systemTypeDisplayName = default,
             string name = default,
@@ -21,10 +23,22 @@ namespace Seam.Model
         )
         {
             AcsSystemId = acsSystemId;
+            ExternalType = externalType;
+            ExternalTypeDisplayName = externalTypeDisplayName;
             SystemType = systemType;
             SystemTypeDisplayName = systemTypeDisplayName;
             Name = name;
             CreatedAt = createdAt;
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum ExternalTypeEnum
+        {
+            [EnumMember(Value = "pti_site")]
+            PtiSite = 0,
+
+            [EnumMember(Value = "alta_org")]
+            AltaOrg = 1
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -39,6 +53,16 @@ namespace Seam.Model
 
         [DataMember(Name = "acs_system_id", IsRequired = true, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
+
+        [DataMember(Name = "external_type", IsRequired = true, EmitDefaultValue = false)]
+        public AcsSystem.ExternalTypeEnum ExternalType { get; set; }
+
+        [DataMember(
+            Name = "external_type_display_name",
+            IsRequired = true,
+            EmitDefaultValue = false
+        )]
+        public string ExternalTypeDisplayName { get; set; }
 
         [DataMember(Name = "system_type", IsRequired = true, EmitDefaultValue = false)]
         public AcsSystem.SystemTypeEnum SystemType { get; set; }

--- a/output/csharp/src/Seam/Model/AcsUser.cs
+++ b/output/csharp/src/Seam/Model/AcsUser.cs
@@ -18,6 +18,9 @@ namespace Seam.Model
             string workspaceId = default,
             string createdAt = default,
             string displayName = default,
+            AcsUser.ExternalTypeEnum externalType = default,
+            string externalTypeDisplayName = default,
+            bool isBeingDeleted = default,
             string? fullName = default,
             string? email = default,
             string? phoneNumber = default
@@ -28,9 +31,19 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
             CreatedAt = createdAt;
             DisplayName = displayName;
+            ExternalType = externalType;
+            ExternalTypeDisplayName = externalTypeDisplayName;
+            IsBeingDeleted = isBeingDeleted;
             FullName = fullName;
             Email = email;
             PhoneNumber = phoneNumber;
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum ExternalTypeEnum
+        {
+            [EnumMember(Value = "pti_user")]
+            PtiUser = 0
         }
 
         [DataMember(Name = "acs_user_id", IsRequired = true, EmitDefaultValue = false)]
@@ -47,6 +60,19 @@ namespace Seam.Model
 
         [DataMember(Name = "display_name", IsRequired = true, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
+
+        [DataMember(Name = "external_type", IsRequired = true, EmitDefaultValue = false)]
+        public AcsUser.ExternalTypeEnum ExternalType { get; set; }
+
+        [DataMember(
+            Name = "external_type_display_name",
+            IsRequired = true,
+            EmitDefaultValue = false
+        )]
+        public string ExternalTypeDisplayName { get; set; }
+
+        [DataMember(Name = "is_being_deleted", IsRequired = true, EmitDefaultValue = false)]
+        public bool IsBeingDeleted { get; set; }
 
         [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
         public string? FullName { get; set; }

--- a/output/csharp/src/Seam/README.md
+++ b/output/csharp/src/Seam/README.md
@@ -3,7 +3,9 @@
 ## Usage
 
 ```csharp
-var seam = new Seam.Client.Seam(apiToken: "YOUR_API_KEY");
+using Seam.Client;
+
+var seam = new SeamClient(apiToken: "YOUR_API_KEY");
 
 var myDevices = seam.Devices.List();
 

--- a/output/csharp/src/Seam/Seam.csproj
+++ b/output/csharp/src/Seam/Seam.csproj
@@ -7,7 +7,7 @@
 
     <PackageId>Seam</PackageId>
 
-    <PackageVersion>0.1.6</PackageVersion>
+    <PackageVersion>0.1.7</PackageVersion>
 
     <Authors>Seam</Authors>
 

--- a/src/templates/dataclass.ts
+++ b/src/templates/dataclass.ts
@@ -82,7 +82,10 @@ export const generateDataclassFileForRoutes = (
 ) => {
   const classStatements: cs.Statement[] = []
 
-  const seamInterfaceType = new cs.TypeNode(new cs.TokenNode('ISeam'), false)
+  const seamInterfaceType = new cs.TypeNode(
+    new cs.TokenNode('ISeamClient'),
+    false,
+  )
   const seamInterfaceName = new cs.TokenNode('_seam')
 
   const seamClient = new cs.FieldDeclaration(
@@ -96,7 +99,7 @@ export const generateDataclassFileForRoutes = (
     undefined,
     new cs.MethodNode(new cs.TokenNode(class_name), [
       new cs.ParameterNode(
-        new cs.TypeNode(new cs.TokenNode('ISeam')),
+        new cs.TypeNode(new cs.TokenNode('ISeamClient')),
         new cs.TokenNode('seam'),
       ),
     ]),
@@ -280,7 +283,7 @@ export const generateDataclassFileForRoutes = (
 
   const extendedClass = new cs.Class(
     new cs.ClassDeclarationSpecifier(
-      new cs.TokenNode('Seam'),
+      new cs.TokenNode('SeamClient'),
       undefined,
       new cs.VisibilityModifiers(['public', 'partial']),
     ),
@@ -306,7 +309,7 @@ export const generateDataclassFileForRoutes = (
 
   const extendedInterface = new cs.Class(
     new cs.ClassDeclarationSpecifier(
-      new cs.TokenNode('ISeam'),
+      new cs.TokenNode('ISeamClient'),
       undefined,
       new cs.VisibilityModifiers(['public', 'partial']),
       new cs.TokenNode('interface'),

--- a/src/templates/fs/src/Seam/Client/Seam.cs
+++ b/src/templates/fs/src/Seam/Client/Seam.cs
@@ -168,13 +168,13 @@ namespace Seam.Client
         public DataFormat DataFormat => DataFormat.Json;
     }
 
-    public partial interface ISeam : ISynchronousSeam, IAsynchronousSeam, IDisposable { }
+    public partial interface ISeamClient : ISynchronousSeam, IAsynchronousSeam, IDisposable { }
 
     /// <summary>
     /// Provides a default implementation of an Api client (both synchronous and asynchronous implementations),
     /// encapsulating general REST accessor use cases.
     /// </summary>
-    public partial class Seam : ISeam
+    public partial class SeamClient : ISeamClient
     {
         private readonly string _baseUrl;
         private readonly string _apiToken;
@@ -213,7 +213,7 @@ namespace Seam.Client
         /// <param name="basePath">The target service's base path in URL format.</param>
         /// <param name="apiToken">The target service's API Token.</param>
         /// <exception cref="ArgumentException"></exception>
-        public Seam(string apiToken)
+        public SeamClient(string apiToken)
             : this(GlobalSeamRequestConfiguration.Instance.BasePath, apiToken) { }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Seam.Client
         /// <param name="basePath">The target service's base path in URL format.</param>
         /// <param name="apiToken">The target service's API Token.</param>
         /// <exception cref="ArgumentException"></exception>
-        public Seam(string basePath, string apiToken)
+        public SeamClient(string basePath, string apiToken)
         {
             if (string.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");
@@ -1034,5 +1034,15 @@ namespace Seam.Client
 
         #endregion ISynchronousClient
         public void Dispose() { }
+    }
+
+    [Obsolete("Please use Seam.Client.SeamClient instead")]
+    public class Seam : SeamClient
+    {
+        public Seam(string apiToken)
+            : base(apiToken) { }
+
+        public Seam(string basePath, string apiToken)
+            : base(basePath, apiToken) { }
     }
 }


### PR DESCRIPTION
This PR: 

 - Renames `Seam` to `SeamClient`
 - Introduces a class `Seam` that extends `SeamClient` and copies its constructors, with a deprecated message (for backwards compatibility)

This comes from me realizing that the `Seam` class conflicts with the `Seam` namespace for end-users. This was forcing users to do `new Seam.Client.Seam(...)`, even if they had imported `Seam.Client`.

Now, users can do:

```
using Seam.Client;

new SeamClient(...)
```