### PR TITLE
fix: Extend device provider, type and manufacturer enums

### DIFF
--- a/output/csharp/src/Seam/Api/ConnectWebviews.cs
+++ b/output/csharp/src/Seam/Api/ConnectWebviews.cs
@@ -179,7 +179,28 @@ namespace Seam.Api
                 HidCm = 38,
 
                 [EnumMember(Value = "google_nest")]
-                GoogleNest = 39
+                GoogleNest = 39,
+
+                [EnumMember(Value = "dormakaba_community")]
+                DormakabaCommunity = 40,
+
+                [EnumMember(Value = "legic_connect")]
+                LegicConnect = 41,
+
+                [EnumMember(Value = "salto_ks")]
+                SaltoKs = 42,
+
+                [EnumMember(Value = "akiles")]
+                Akiles = 43,
+
+                [EnumMember(Value = "assa_abloy_vostio")]
+                AssaAbloyVostio = 44,
+
+                [EnumMember(Value = "assa_abloy_vostio_credential_service")]
+                AssaAbloyVostioCredentialService = 45,
+
+                [EnumMember(Value = "tado")]
+                Tado = 46
             }
 
             [JsonConverter(typeof(StringEnumConverter))]

--- a/output/csharp/src/Seam/Api/ConnectWebviews.cs
+++ b/output/csharp/src/Seam/Api/ConnectWebviews.cs
@@ -197,10 +197,7 @@ namespace Seam.Api
                 AssaAbloyVostio = 44,
 
                 [EnumMember(Value = "assa_abloy_vostio_credential_service")]
-                AssaAbloyVostioCredentialService = 45,
-
-                [EnumMember(Value = "tado")]
-                Tado = 46
+                AssaAbloyVostioCredentialService = 45
             }
 
             [JsonConverter(typeof(StringEnumConverter))]

--- a/output/csharp/src/Seam/Api/Devices.cs
+++ b/output/csharp/src/Seam/Api/Devices.cs
@@ -305,7 +305,10 @@ namespace Seam.Api
                 IosPhone = 31,
 
                 [EnumMember(Value = "android_phone")]
-                AndroidPhone = 32
+                AndroidPhone = 32,
+
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33,
             }
 
             [JsonConverter(typeof(StringEnumConverter))]
@@ -408,7 +411,10 @@ namespace Seam.Api
                 IosPhone = 31,
 
                 [EnumMember(Value = "android_phone")]
-                AndroidPhone = 32
+                AndroidPhone = 32,
+    
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33
             }
 
             [JsonConverter(typeof(StringEnumConverter))]
@@ -514,7 +520,10 @@ namespace Seam.Api
                 Tedee = 32,
 
                 [EnumMember(Value = "honeywell_resideo")]
-                HoneywellResideo = 33
+                HoneywellResideo = 33,
+    
+                [EnumMember(Value = "akiles")]
+                Akiles = 34
             }
 
             [DataMember(

--- a/output/csharp/src/Seam/Api/Locks.cs
+++ b/output/csharp/src/Seam/Api/Locks.cs
@@ -247,7 +247,13 @@ namespace Seam.Api
                 IosPhone = 31,
 
                 [EnumMember(Value = "android_phone")]
-                AndroidPhone = 32
+                AndroidPhone = 32,
+    
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33,
+    
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33
             }
 
             [JsonConverter(typeof(StringEnumConverter))]
@@ -456,7 +462,10 @@ namespace Seam.Api
                 Tedee = 32,
 
                 [EnumMember(Value = "honeywell_resideo")]
-                HoneywellResideo = 33
+                HoneywellResideo = 33,
+    
+                [EnumMember(Value = "akiles")]
+                Akiles = 34
             }
 
             [DataMember(

--- a/output/csharp/src/Seam/Api/Locks.cs
+++ b/output/csharp/src/Seam/Api/Locks.cs
@@ -250,9 +250,6 @@ namespace Seam.Api
                 AndroidPhone = 32,
     
                 [EnumMember(Value = "akiles_lock")]
-                AkilesLock = 33,
-    
-                [EnumMember(Value = "akiles_lock")]
                 AkilesLock = 33
             }
 
@@ -356,7 +353,10 @@ namespace Seam.Api
                 IosPhone = 31,
 
                 [EnumMember(Value = "android_phone")]
-                AndroidPhone = 32
+                AndroidPhone = 32,
+    
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33
             }
 
             [JsonConverter(typeof(StringEnumConverter))]

--- a/output/csharp/src/Seam/Api/UnmanagedDevices.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedDevices.cs
@@ -252,7 +252,10 @@ namespace Seam.Api
                 IosPhone = 31,
 
                 [EnumMember(Value = "android_phone")]
-                AndroidPhone = 32
+                AndroidPhone = 32,
+
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33,
             }
 
             [JsonConverter(typeof(StringEnumConverter))]
@@ -355,7 +358,10 @@ namespace Seam.Api
                 IosPhone = 31,
 
                 [EnumMember(Value = "android_phone")]
-                AndroidPhone = 32
+                AndroidPhone = 32,
+
+                [EnumMember(Value = "akiles_lock")]
+                AkilesLock = 33,
             }
 
             [JsonConverter(typeof(StringEnumConverter))]
@@ -461,7 +467,10 @@ namespace Seam.Api
                 Tedee = 32,
 
                 [EnumMember(Value = "honeywell_resideo")]
-                HoneywellResideo = 33
+                HoneywellResideo = 33,
+    
+                [EnumMember(Value = "akiles")]
+                Akiles = 34
             }
 
             [DataMember(

--- a/output/csharp/src/Seam/Model/Device.cs
+++ b/output/csharp/src/Seam/Model/Device.cs
@@ -152,7 +152,10 @@ namespace Seam.Model
             IosPhone = 31,
 
             [EnumMember(Value = "android_phone")]
-            AndroidPhone = 32
+            AndroidPhone = 32,
+
+            [EnumMember(Value = "akiles_lock")]
+            AkilesLock = 33,
         }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/output/csharp/src/Seam/Model/DeviceProvider.cs
+++ b/output/csharp/src/Seam/Model/DeviceProvider.cs
@@ -156,7 +156,10 @@ namespace Seam.Model
             AssaAbloyVostio = 41,
 
             [EnumMember(Value = "assa_abloy_vostio_credential_service")]
-            AssaAbloyVostioCredentialService = 42
+            AssaAbloyVostioCredentialService = 42,
+
+            [EnumMember(Value = "tado")]
+            Tado = 42
         }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/output/csharp/src/Seam/Model/DeviceProvider.cs
+++ b/output/csharp/src/Seam/Model/DeviceProvider.cs
@@ -138,7 +138,25 @@ namespace Seam.Model
             HoneywellResideo = 35,
 
             [EnumMember(Value = "latch")]
-            Latch = 36
+            Latch = 36,
+
+            [EnumMember(Value = "dormakaba_community")]
+            DormakabaCommunity = 37,
+
+            [EnumMember(Value = "legic_connect")]
+            LegicConnect = 38,
+
+            [EnumMember(Value = "salto_ks")]
+            SaltoKs = 39,
+
+            [EnumMember(Value = "akiles")]
+            Akiles = 40,
+
+            [EnumMember(Value = "assa_abloy_vostio")]
+            AssaAbloyVostio = 41,
+
+            [EnumMember(Value = "assa_abloy_vostio_credential_service")]
+            AssaAbloyVostioCredentialService = 42
         }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/output/csharp/src/Seam/Model/UnmanagedDevice.cs
+++ b/output/csharp/src/Seam/Model/UnmanagedDevice.cs
@@ -144,7 +144,10 @@ namespace Seam.Model
             IosPhone = 31,
 
             [EnumMember(Value = "android_phone")]
-            AndroidPhone = 32
+            AndroidPhone = 32,
+
+            [EnumMember(Value = "akiles_lock")]
+            AkilesLock = 33,
         }
 
         [JsonConverter(typeof(StringEnumConverter))]


### PR DESCRIPTION
- **Extend AcceptedProvidersEnum**
- **Extend device type and manufacturer enums**
- **Extend device type and manufacturer enums on Locks client**
- **Extend device type and manufacturer enums on UnmanagedDevices client**
- **Extend DeviceProvider enum model**
- **Extend device type enum on UnmanagedDevice client**
