### PR TITLE
fix: Bump RestSharp to 112.1.0

### DIFF
--- a/output/csharp/src/Seam/Seam.csproj
+++ b/output/csharp/src/Seam/Seam.csproj
@@ -33,7 +33,7 @@
   <PackageReference Include="JsonSubTypes" Version="2.0.1" />
   <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   <PackageReference Include="Polly" Version="7.2.4" />
-  <PackageReference Include="RestSharp" Version="110.2.0" />
+  <PackageReference Include="RestSharp" Version="112.1.0" />
 </ItemGroup>
 
 </Project>

--- a/src/generate-csproj.ts
+++ b/src/generate-csproj.ts
@@ -41,7 +41,7 @@ export const csprojTemplate = (version: string, dotNetVersions: string[]) =>
   <PackageReference Include="JsonSubTypes" Version="2.0.1" />
   <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   <PackageReference Include="Polly" Version="7.2.4" />
-  <PackageReference Include="RestSharp" Version="110.2.0" />
+  <PackageReference Include="RestSharp" Version="112.1.0" />
 </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Currently, when using Seam SDK, `dotnet build` emits the following warning:

```
warning NU1902: Package 'RestSharp' 110.2.0 has a known moderate severity vulnerability,
https://github.com/advisories/GHSA-4rr6-2v9v-wcpc
```

See https://github.com/advisories/GHSA-4rr6-2v9v-wcpc for details.

The latest stable release of RestSharp is [112.1.0](https://github.com/restsharp/RestSharp/releases/tag/112.1.0), although the issue was addressed in [112.0.0](https://github.com/restsharp/RestSharp/releases/tag/112.0.0).
