### PR TITLE
Bump actions/upload-artifact to version 4

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Package
         run: npm pack
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-${{ github.sha }}
           if-no-files-found: error

--- a/output/csharp/src/Seam/Seam.csproj
+++ b/output/csharp/src/Seam/Seam.csproj
@@ -7,7 +7,7 @@
 
   <PackageId>Seam</PackageId>
 
-  <PackageVersion>0.24.0</PackageVersion>
+  <PackageVersion>0.25.0</PackageVersion>
 
   <Authors>Seam</Authors>
 


### PR DESCRIPTION
Previous version fails CI on main https://github.com/seamapi/csharp/actions/runs/13056942932/job/36430257164

![image](https://github.com/user-attachments/assets/11954869-90e2-449f-b28b-a05cbd26f541)
