### PR TITLE
Bump actions/download-artifact to version 4

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -34,7 +34,7 @@ jobs:
           install_dependencies: 'false'
           node_auth_token: ${{ secrets.node_auth_token }}
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
           path: .

--- a/output/csharp/src/Seam/Seam.csproj
+++ b/output/csharp/src/Seam/Seam.csproj
@@ -7,7 +7,7 @@
 
   <PackageId>Seam</PackageId>
 
-  <PackageVersion>0.25.0</PackageVersion>
+  <PackageVersion>0.25.1</PackageVersion>
 
   <Authors>Seam</Authors>
 


### PR DESCRIPTION
Previous version fails CI on main https://github.com/seamapi/csharp/actions/runs/13058071105/job/36434155226

![image](https://github.com/user-attachments/assets/3824fead-c6e3-4482-8ee0-fb5624086765)
