### PR TITLE
fix: add discriminated union fallback test

### DIFF
--- a/output/csharp/src/Seam.Test/Client/SeamTests.cs
+++ b/output/csharp/src/Seam.Test/Client/SeamTests.cs
@@ -336,4 +336,3 @@ public class UnitTest1 : SeamConnectTest
         }
     }
 }
-

--- a/output/csharp/src/Seam/Seam.csproj
+++ b/output/csharp/src/Seam/Seam.csproj
@@ -7,7 +7,7 @@
 
   <PackageId>Seam</PackageId>
 
-  <PackageVersion>0.94.1</PackageVersion>
+  <PackageVersion>0.95.0</PackageVersion>
 
   <Authors>Seam</Authors>
 


### PR DESCRIPTION
just makes sure the fixes in https://github.com/seamapi/nextlove-sdk-generator/pull/152 is working for ALL discriminated unions.

bit of a gnarly test but uses reflection to make sure we don't have to hardcode all possible properties.