### PR TITLE
feat: Add XML docs and Obsolete annotations

### DIFF
--- a/codegen/layouts/partials/data-member.hbs
+++ b/codegen/layouts/partials/data-member.hbs
@@ -1,2 +1,3 @@
+{{> documentation}}
 [DataMember(Name = "{{snakeName}}", IsRequired = {{isRequired}}, EmitDefaultValue = false)]
 public {{#if isOverride}}override {{/if}}{{type}} {{pascalName}} {{#if getOnly}}{ get; }{{else}}{ get; set; }{{/if}}{{#if initializer}} = {{initializer}};{{/if}}

--- a/codegen/layouts/partials/documentation.hbs
+++ b/codegen/layouts/partials/documentation.hbs
@@ -1,0 +1,3 @@
+{{#if documentation}}{{csDoc documentation}}
+{{/if}}{{#if obsoleteMessage}}[Obsolete("{{csString obsoleteMessage}}")]
+{{/if}}

--- a/codegen/layouts/partials/enum-def.hbs
+++ b/codegen/layouts/partials/enum-def.hbs
@@ -1,9 +1,11 @@
+{{> documentation}}
 {{#if isString}}
 [JsonConverter(typeof(SafeStringEnumConverter))]
 {{/if}}
 public enum {{name}}
 {
 {{#each members}}
+{{> documentation}}
 [EnumMember(Value = {{#if ../isString}}"{{value}}"{{else}}{{value}}{{/if}})]
 {{identifier}} = {{assign}},
 {{#unless @last}}

--- a/codegen/layouts/partials/model-class.hbs
+++ b/codegen/layouts/partials/model-class.hbs
@@ -1,3 +1,4 @@
+{{> documentation}}
 [DataContract(Name = "{{dataContractName}}")]
 public class {{className}}{{#if baseClass}} : {{baseClass}}{{/if}}
 {

--- a/codegen/layouts/partials/route-methods.hbs
+++ b/codegen/layouts/partials/route-methods.hbs
@@ -1,3 +1,4 @@
+{{> documentation}}
 public {{#if isVoid}}void{{else}}{{returnType}}{{/if}} {{methodName}}({{methodName}}Request request)
 {
 var requestOptions = new RequestOptions();
@@ -9,6 +10,7 @@ return _seam.Post<{{responseTypeArg}}>("{{path}}", requestOptions).Data.{{return
 {{/if}}
 }
 
+{{> documentation}}
 public {{#if isVoid}}void{{else}}{{returnType}}{{/if}} {{methodName}}({{csParams params}})
 {
 {{#if isVoid}}
@@ -18,6 +20,7 @@ return {{methodName}}(new {{methodName}}Request({{csNamedArgs params}}));
 {{/if}}
 }
 
+{{> documentation}}
 public async {{#if isVoid}}Task{{else}}Task<{{returnType}}>{{/if}} {{methodName}}Async({{methodName}}Request request)
 {
 var requestOptions = new RequestOptions();
@@ -29,6 +32,7 @@ return (await _seam.PostAsync<{{responseTypeArg}}>("{{path}}", requestOptions)).
 {{/if}}
 }
 
+{{> documentation}}
 public async {{#if isVoid}}Task{{else}}Task<{{returnType}}>{{/if}} {{methodName}}Async({{csParams params}})
 {
 {{#if isVoid}}

--- a/codegen/lib/build-model.ts
+++ b/codegen/lib/build-model.ts
@@ -68,14 +68,24 @@ const safeWrapEnumValue = (value: string): string => {
   return isAlpha ? value : `_${value}`
 }
 
-const buildEnum = (propertyName: string, enumValues: string[]): CsEnum => {
+interface EnumValue {
+  name: string
+  description: string
+  deprecationMessage?: string
+}
+
+const buildEnum = (propertyName: string, enumValues: EnumValue[]): CsEnum => {
   const name = pascalCase(`${propertyName}Enum`)
   const members = [
     { identifier: 'Unrecognized', assign: 0, value: 'unrecognized' },
     ...enumValues.map((value, i) => ({
-      identifier: safeWrapEnumValue(pascalCase(value)),
+      identifier: safeWrapEnumValue(pascalCase(value.name)),
       assign: i + 1,
-      value,
+      value: value.name,
+      documentation: value.description,
+      ...(value.deprecationMessage != null
+        ? { obsoleteMessage: value.deprecationMessage }
+        : {}),
     })),
   ]
   return { name, isString: true, members }
@@ -86,6 +96,8 @@ const buildEnum = (propertyName: string, enumValues: string[]): CsEnum => {
 // into class-model properties, nested enums, sibling classes, and unions.
 interface Field {
   name: string
+  description: string
+  deprecationMessage?: string
   isRequired: boolean
   nullable: boolean
   kind: Kind
@@ -93,7 +105,7 @@ interface Field {
 
 type Kind =
   | { t: 'prim'; cs: string }
-  | { t: 'enum'; values: string[] }
+  | { t: 'enum'; values: EnumValue[] }
   | { t: 'object'; fields: Field[] }
   | { t: 'list'; item: Kind }
   | { t: 'union'; discriminator: string; variants: Variant[] }
@@ -104,10 +116,25 @@ type Kind =
 interface Variant {
   value: string
   fields: Field[]
+  description?: string
+  deprecationMessage?: string
 }
 
-const enumValueNames = (values: Array<{ name: string }>): string[] =>
-  values.map((v) => v.name)
+const normalizeEnumValues = (
+  values: Array<{
+    name: string
+    description: string
+    isDeprecated: boolean
+    deprecationMessage: string
+  }>,
+): EnumValue[] =>
+  values.map((value) => ({
+    name: value.name,
+    description: value.description,
+    ...(value.isDeprecated
+      ? { deprecationMessage: value.deprecationMessage || 'Deprecated.' }
+      : {}),
+  }))
 
 // Reads the single discriminator enum value carried by a union variant, e.g.
 // the one member of the variant's `error_code`/`action_type` enum.
@@ -116,7 +143,7 @@ const discriminatorValue = (
   discriminator: string,
 ): string | undefined => {
   const field = fields.find((f) => f.name === discriminator)
-  if (field?.kind.t === 'enum') return field.kind.values[0]
+  if (field?.kind.t === 'enum') return field.kind.values[0]?.name
   return undefined
 }
 
@@ -132,7 +159,7 @@ const normalizeItemKind = (property: Property): Kind => {
     case 'number':
       return { t: 'prim', cs: property.isItemInt ? 'int' : 'float' }
     case 'enum':
-      return { t: 'enum', values: enumValueNames(property.itemEnumValues) }
+      return { t: 'enum', values: normalizeEnumValues(property.itemEnumValues) }
     case 'record':
       return { t: 'prim', cs: 'object' }
     case 'object':
@@ -164,6 +191,10 @@ const normalizeProperty = (property: Property): Field => {
   // nullable, so a value that may be absent or null is representable.
   const base = {
     name: property.name,
+    description: property.description,
+    ...(property.isDeprecated
+      ? { deprecationMessage: property.deprecationMessage || 'Deprecated.' }
+      : {}),
     isRequired: false,
     nullable: property.isNullable || property.isOptional,
   }
@@ -184,7 +215,7 @@ const normalizeProperty = (property: Property): Field => {
     case 'enum':
       return {
         ...base,
-        kind: { t: 'enum', values: enumValueNames(property.values) },
+        kind: { t: 'enum', values: normalizeEnumValues(property.values) },
       }
     case 'object':
       return {
@@ -215,7 +246,10 @@ const normalizeParameterItemKind = (parameter: Parameter): Kind => {
     case 'boolean':
       return { t: 'prim', cs: 'bool' }
     case 'enum':
-      return { t: 'enum', values: enumValueNames(parameter.itemEnumValues) }
+      return {
+        t: 'enum',
+        values: normalizeEnumValues(parameter.itemEnumValues),
+      }
     case 'record':
       return { t: 'prim', cs: 'object' }
     case 'object':
@@ -244,6 +278,10 @@ const normalizeParameter = (parameter: Parameter): Field => {
   // Endpoint parameters carry `isRequired`; optional parameters become nullable.
   const base = {
     name: parameter.name,
+    description: parameter.description,
+    ...(parameter.isDeprecated
+      ? { deprecationMessage: parameter.deprecationMessage || 'Deprecated.' }
+      : {}),
     isRequired: parameter.isRequired,
     nullable: !parameter.isRequired,
   }
@@ -264,7 +302,7 @@ const normalizeParameter = (parameter: Parameter): Field => {
     case 'enum':
       return {
         ...base,
-        kind: { t: 'enum', values: enumValueNames(parameter.values) },
+        kind: { t: 'enum', values: normalizeEnumValues(parameter.values) },
       }
     case 'object':
       return {
@@ -292,6 +330,8 @@ interface BuildClassOptions {
   discriminator?: { name: string; value: string; base: string }
   // Property names lifted onto the union's abstract base; emitted as overrides.
   overrideNames?: Set<string> | undefined
+  documentation?: string
+  obsoleteMessage?: string
 }
 
 interface BuiltClass {
@@ -306,7 +346,14 @@ const buildClass = (
   fields: Field[],
   options: BuildClassOptions,
 ): BuiltClass => {
-  const { resourceType, namespace, discriminator, overrideNames } = options
+  const {
+    resourceType,
+    namespace,
+    discriminator,
+    overrideNames,
+    documentation,
+    obsoleteMessage,
+  } = options
   const nested: CsNested[] = []
   const siblings: CsClass[] = []
   const nestedByKey = new Map<string, CsNested>()
@@ -316,14 +363,22 @@ const buildClass = (
     nestedByKey.set(key, value)
   }
 
-  const csType = (kind: Kind, fieldName: string, nullable: boolean): string => {
+  const csType = (
+    kind: Kind,
+    fieldName: string,
+    nullable: boolean,
+    documentation?: string,
+  ): string => {
     switch (kind.t) {
       case 'prim':
         return withNullable(kind.cs, nullable)
       case 'ref':
         return kind.cs
       case 'enum': {
-        const csEnum = buildEnum(fieldName, kind.values)
+        const csEnum = {
+          ...buildEnum(fieldName, kind.values),
+          ...(documentation != null ? { documentation } : {}),
+        }
         setNested(csEnum.name, { enum: csEnum })
         return withNullable(`${className}.${csEnum.name}`, nullable)
       }
@@ -338,7 +393,7 @@ const buildClass = (
       }
       case 'list':
         return withNullable(
-          `List<${csType(kind.item, fieldName, false)}>`,
+          `List<${csType(kind.item, fieldName, false, documentation)}>`,
           nullable,
         )
       case 'union': {
@@ -368,10 +423,14 @@ const buildClass = (
     pascalName: pascalCase(field.name),
     camelName: camelIdentifier(field.name),
     snakeName: snakeCase(field.name),
-    type: csType(field.kind, field.name, field.nullable),
+    type: csType(field.kind, field.name, field.nullable, field.description),
     isRequired: field.isRequired,
     isOverride: overrideNames?.has(field.name) ?? false,
     getOnly: false,
+    documentation: field.description,
+    ...(field.deprecationMessage != null
+      ? { obsoleteMessage: field.deprecationMessage }
+      : {}),
   })
 
   const properties: CsProperty[] = []
@@ -397,6 +456,8 @@ const buildClass = (
     ...(discriminator != null ? { baseClass: discriminator.base } : {}),
     nested,
     properties,
+    ...(documentation != null ? { documentation } : {}),
+    ...(obsoleteMessage != null ? { obsoleteMessage } : {}),
   }
 
   return { main, siblings, properties }
@@ -454,6 +515,12 @@ const buildUnion = (
         base: className,
       },
       overrideNames,
+      ...(variant.description != null
+        ? { documentation: variant.description }
+        : {}),
+      ...(variant.deprecationMessage != null
+        ? { obsoleteMessage: variant.deprecationMessage }
+        : {}),
     })
     subclasses.push(built.main, ...built.siblings)
     known.push([subName, variant.value])
@@ -508,6 +575,10 @@ export const buildModelFile = (
   const built = buildClass(name, resource.properties.map(normalizeProperty), {
     resourceType: 'model',
     namespace: MODEL_NAMESPACE,
+    documentation: resource.description,
+    ...(resource.isDeprecated
+      ? { obsoleteMessage: resource.deprecationMessage || 'Deprecated.' }
+      : {}),
   })
   return { name, file: { decls: [built.main, ...built.siblings] } }
 }
@@ -533,6 +604,13 @@ export const buildActionAttemptFile = (
     actionAttempts.map((actionAttempt) => ({
       value: actionAttempt.actionAttemptType,
       fields: actionAttempt.properties.map(normalizeProperty),
+      description: actionAttempt.description,
+      ...(actionAttempt.isDeprecated
+        ? {
+            deprecationMessage:
+              actionAttempt.deprecationMessage || 'Deprecated.',
+          }
+        : {}),
     })),
   )
 
@@ -545,6 +623,10 @@ export const buildEventFile = (
     events.map((event) => ({
       value: event.eventType,
       fields: event.properties.map(normalizeProperty),
+      description: event.description,
+      ...(event.isDeprecated
+        ? { deprecationMessage: event.deprecationMessage || 'Deprecated.' }
+        : {}),
     })),
   )
 
@@ -591,8 +673,21 @@ export const buildApiFile = (
     const request = buildClass(
       pascalCase(`${endpoint.name}_request`),
       endpoint.request.parameters.map(normalizeParameter),
-      { resourceType: 'request' },
+      {
+        resourceType: 'request',
+        documentation: `Request parameters for ${endpoint.title}.`,
+        ...(endpoint.isDeprecated
+          ? { obsoleteMessage: endpoint.deprecationMessage || 'Deprecated.' }
+          : {}),
+      },
     )
+
+    const routeDocumentation = {
+      documentation: endpoint.description,
+      ...(endpoint.isDeprecated
+        ? { obsoleteMessage: endpoint.deprecationMessage || 'Deprecated.' }
+        : {}),
+    }
 
     const returned = responseReturn(endpoint.response, modelTypes)
     const isVoid = returned == null
@@ -607,6 +702,7 @@ export const buildApiFile = (
         responseTypeArg: 'object',
         isVoid: true,
         params: request.properties,
+        ...routeDocumentation,
       }
     }
 
@@ -619,6 +715,7 @@ export const buildApiFile = (
       [
         {
           name: responseKey,
+          description: endpoint.response.description,
           isRequired: false,
           nullable: false,
           kind: { t: 'ref', cs: returnType },
@@ -639,6 +736,7 @@ export const buildApiFile = (
       returnType,
       isVoid: false,
       params: request.properties,
+      ...routeDocumentation,
     }
   })
 

--- a/codegen/lib/class-model.ts
+++ b/codegen/lib/class-model.ts
@@ -12,12 +12,15 @@ export interface CsEnumMember {
   // The value rendered inside [EnumMember(Value = ...)]. Strings are quoted by
   // the template (isString), numbers are emitted bare.
   value: string | number
+  documentation?: string
+  obsoleteMessage?: string
 }
 
 export interface CsEnum {
   name: string
   isString: boolean
   members: CsEnumMember[]
+  documentation?: string
 }
 
 // A resolved property: one [DataMember] declaration plus its constructor
@@ -34,6 +37,8 @@ export interface CsProperty {
   getOnly: boolean
   // A constant initializer appended to the property, e.g. ` = "LOCK_DOOR"`.
   initializer?: string
+  documentation?: string
+  obsoleteMessage?: string
 }
 
 // An extra member nested inside a class body (before the properties): an inline
@@ -52,6 +57,8 @@ export interface CsClass {
   baseClass?: string
   nested: CsNested[]
   properties: CsProperty[]
+  documentation?: string
+  obsoleteMessage?: string
 }
 
 // The abstract base of a discriminated union.
@@ -103,6 +110,8 @@ export interface CsRoute {
   isVoid: boolean
   // Expanded-overload parameters (the request class properties).
   params: CsProperty[]
+  documentation?: string
+  obsoleteMessage?: string
 }
 
 // A generated Api file (output/csharp/src/Seam/Api/<Name>.cs).

--- a/codegen/lib/handlebars-helpers.ts
+++ b/codegen/lib/handlebars-helpers.ts
@@ -4,6 +4,33 @@ export const identity = (x: unknown): unknown => x
 
 export const eq = (a: unknown, b: unknown): boolean => a === b
 
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+
+// Render schema prose as C# XML documentation. Prefix every line so multi-line
+// Markdown remains valid compiler documentation while XML-significant input is
+// harmless.
+export const csDoc = (documentation?: string): string => {
+  const text = documentation?.trim()
+  if (!text) return ''
+  return [
+    '/// <summary>',
+    ...escapeXml(text)
+      .split(/\r?\n/u)
+      .map((line) => `/// ${line}`),
+    '/// </summary>',
+  ].join('\n')
+}
+
+// Escape a schema-supplied deprecation reason for a C# string literal.
+export const csString = (value?: string): string =>
+  (value ?? 'Deprecated.').replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+
 // Comma-joined constructor / method parameter list: `Type name = default, ...`.
 export const csParams = (properties: CsProperty[]): string =>
   (properties ?? []).map((p) => `${p.type} ${p.camelName} = default`).join(', ')

--- a/output/csharp/src/Seam/Api/AccessCodes.cs
+++ b/output/csharp/src/Seam/Api/AccessCodes.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create an Access Code.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -61,6 +64,9 @@ namespace Seam.Api
                 UseOfflineAccessCode = useOfflineAccessCode;
             }
 
+            /// <summary>
+            /// Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum MaxTimeRoundingEnum
             {
@@ -80,6 +86,9 @@ namespace Seam.Api
                 _1d = 4,
             }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+            /// </summary>
             [DataMember(
                 Name = "allow_external_modification",
                 IsRequired = false,
@@ -94,18 +103,33 @@ namespace Seam.Api
             )]
             public bool? AttemptForOfflineDevice { get; set; }
 
+            /// <summary>
+            /// Code to be used for access.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// Key to identify access codes that should have the same code. Any two access codes with the same `common_code_key` are guaranteed to have the same `code`. See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+            /// </summary>
             [DataMember(Name = "common_code_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CommonCodeKey { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to create the new access code.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+            /// </summary>
             [DataMember(
                 Name = "is_external_modification_allowed",
                 IsRequired = false,
@@ -113,6 +137,9 @@ namespace Seam.Api
             )]
             public bool? IsExternalModificationAllowed { get; set; }
 
+            /// <summary>
+            /// Indicates whether the access code is an [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes).
+            /// </summary>
             [DataMember(
                 Name = "is_offline_access_code",
                 IsRequired = false,
@@ -120,15 +147,33 @@ namespace Seam.Api
             )]
             public bool? IsOfflineAccessCode { get; set; }
 
+            /// <summary>
+            /// Indicates whether the [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) is a single-use access code.
+            /// </summary>
             [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsOneTimeUse { get; set; }
 
+            /// <summary>
+            /// Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.
+            /// </summary>
             [DataMember(Name = "max_time_rounding", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequest.MaxTimeRoundingEnum? MaxTimeRounding { get; set; }
 
+            /// <summary>
+            /// Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+            ///
+            /// Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider&apos;s app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+            ///
+            /// To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider&apos;s app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+            ///
+            /// To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider&apos;s app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Indicates whether [native scheduling](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.
+            /// </summary>
             [DataMember(
                 Name = "prefer_native_scheduling",
                 IsRequired = false,
@@ -136,6 +181,9 @@ namespace Seam.Api
             )]
             public bool? PreferNativeScheduling { get; set; }
 
+            /// <summary>
+            /// Preferred code length. Only applicable if you do not specify a `code`. If the affected device does not support the preferred code length, Seam reverts to using the shortest supported code length.
+            /// </summary>
             [DataMember(
                 Name = "preferred_code_length",
                 IsRequired = false,
@@ -143,9 +191,15 @@ namespace Seam.Api
             )]
             public float? PreferredCodeLength { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether to use a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).
+            /// </summary>
             [DataMember(
                 Name = "use_backup_access_code_pool",
                 IsRequired = false,
@@ -153,6 +207,7 @@ namespace Seam.Api
             )]
             public bool? UseBackupAccessCodePool { get; set; }
 
+            [Obsolete("Use `is_offline_access_code` instead.")]
             [DataMember(
                 Name = "use_offline_access_code",
                 IsRequired = false,
@@ -191,6 +246,9 @@ namespace Seam.Api
                 AccessCode = accessCode;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_code", IsRequired = false, EmitDefaultValue = false)]
             public AccessCode AccessCode { get; set; }
 
@@ -214,6 +272,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [access code](https://docs.seam.co/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.
+        /// </summary>
         public AccessCode Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -223,6 +284,9 @@ namespace Seam.Api
                 .Data.AccessCode;
         }
 
+        /// <summary>
+        /// Creates a new [access code](https://docs.seam.co/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.
+        /// </summary>
         public AccessCode Create(
             bool? allowExternalModification = default,
             bool? attemptForOfflineDevice = default,
@@ -264,6 +328,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [access code](https://docs.seam.co/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.
+        /// </summary>
         public async Task<AccessCode> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -273,6 +340,9 @@ namespace Seam.Api
                 .AccessCode;
         }
 
+        /// <summary>
+        /// Creates a new [access code](https://docs.seam.co/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.
+        /// </summary>
         public async Task<AccessCode> CreateAsync(
             bool? allowExternalModification = default,
             bool? attemptForOfflineDevice = default,
@@ -316,6 +386,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Create Multiple Linked Access Codes.
+        /// </summary>
         [DataContract(Name = "createMultipleRequest_request")]
         public class CreateMultipleRequest
         {
@@ -352,6 +425,9 @@ namespace Seam.Api
                 UseBackupAccessCodePool = useBackupAccessCodePool;
             }
 
+            /// <summary>
+            /// Desired behavior if any device cannot share a code. If `throw` (default), no access codes will be created if any device cannot share a code. If `create_random_code`, a random code will be created on devices that cannot share a code.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum BehaviorWhenCodeCannotBeSharedEnum
             {
@@ -365,6 +441,9 @@ namespace Seam.Api
                 CreateRandomCode = 2,
             }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+            /// </summary>
             [DataMember(
                 Name = "allow_external_modification",
                 IsRequired = false,
@@ -379,6 +458,9 @@ namespace Seam.Api
             )]
             public bool? AttemptForOfflineDevice { get; set; }
 
+            /// <summary>
+            /// Desired behavior if any device cannot share a code. If `throw` (default), no access codes will be created if any device cannot share a code. If `create_random_code`, a random code will be created on devices that cannot share a code.
+            /// </summary>
             [DataMember(
                 Name = "behavior_when_code_cannot_be_shared",
                 IsRequired = false,
@@ -386,15 +468,27 @@ namespace Seam.Api
             )]
             public CreateMultipleRequest.BehaviorWhenCodeCannotBeSharedEnum? BehaviorWhenCodeCannotBeShared { get; set; }
 
+            /// <summary>
+            /// Code to be used for access.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// IDs of the devices for which you want to create the new access codes.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = true, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+            /// </summary>
             [DataMember(
                 Name = "is_external_modification_allowed",
                 IsRequired = false,
@@ -402,9 +496,21 @@ namespace Seam.Api
             )]
             public bool? IsExternalModificationAllowed { get; set; }
 
+            /// <summary>
+            /// Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+            ///
+            /// Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider&apos;s app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+            ///
+            /// To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider&apos;s app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+            ///
+            /// To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider&apos;s app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Indicates whether [native scheduling](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.
+            /// </summary>
             [DataMember(
                 Name = "prefer_native_scheduling",
                 IsRequired = false,
@@ -412,6 +518,9 @@ namespace Seam.Api
             )]
             public bool? PreferNativeScheduling { get; set; }
 
+            /// <summary>
+            /// Preferred code length. If the affected devices do not support the preferred code length, Seam reverts to using the shortest supported code length.
+            /// </summary>
             [DataMember(
                 Name = "preferred_code_length",
                 IsRequired = false,
@@ -419,9 +528,15 @@ namespace Seam.Api
             )]
             public float? PreferredCodeLength { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether to use a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).
+            /// </summary>
             [DataMember(
                 Name = "use_backup_access_code_pool",
                 IsRequired = false,
@@ -460,6 +575,9 @@ namespace Seam.Api
                 AccessCodes = accessCodes;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_codes", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessCode> AccessCodes { get; set; }
 
@@ -483,6 +601,19 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates new [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Users with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.
+        ///
+        /// If you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.
+        ///
+        /// If you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.
+        ///
+        /// See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+        ///
+        /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+        /// </summary>
         public List<AccessCode> CreateMultiple(CreateMultipleRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -492,6 +623,19 @@ namespace Seam.Api
                 .Data.AccessCodes;
         }
 
+        /// <summary>
+        /// Creates new [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Users with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.
+        ///
+        /// If you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.
+        ///
+        /// If you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.
+        ///
+        /// See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+        ///
+        /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+        /// </summary>
         public List<AccessCode> CreateMultiple(
             bool? allowExternalModification = default,
             bool? attemptForOfflineDevice = default,
@@ -526,6 +670,19 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates new [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Users with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.
+        ///
+        /// If you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.
+        ///
+        /// If you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.
+        ///
+        /// See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+        ///
+        /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+        /// </summary>
         public async Task<List<AccessCode>> CreateMultipleAsync(CreateMultipleRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -540,6 +697,19 @@ namespace Seam.Api
                 .AccessCodes;
         }
 
+        /// <summary>
+        /// Creates new [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Users with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.
+        ///
+        /// If you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.
+        ///
+        /// If you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.
+        ///
+        /// See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).
+        ///
+        /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+        /// </summary>
         public async Task<List<AccessCode>> CreateMultipleAsync(
             bool? allowExternalModification = default,
             bool? attemptForOfflineDevice = default,
@@ -576,6 +746,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete an Access Code.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -588,9 +761,15 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the access code that you want to delete.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessCodeId { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to delete the access code.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
@@ -614,6 +793,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -621,11 +803,17 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         public void Delete(string accessCodeId = default, string? deviceId = default)
         {
             Delete(new DeleteRequest(accessCodeId: accessCodeId, deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Deletes an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -633,11 +821,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_codes/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         public async Task DeleteAsync(string accessCodeId = default, string? deviceId = default)
         {
             await DeleteAsync(new DeleteRequest(accessCodeId: accessCodeId, deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Request parameters for Generate a Code.
+        /// </summary>
         [DataContract(Name = "generateCodeRequest_request")]
         public class GenerateCodeRequest
         {
@@ -649,6 +843,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to generate a code.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -683,6 +880,9 @@ namespace Seam.Api
                 GeneratedCode = generatedCode;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "generated_code", IsRequired = false, EmitDefaultValue = false)]
             public AccessCode GeneratedCode { get; set; }
 
@@ -706,6 +906,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Generates a code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes), given a device ID.
+        /// </summary>
         public AccessCode GenerateCode(GenerateCodeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -715,11 +918,17 @@ namespace Seam.Api
                 .Data.GeneratedCode;
         }
 
+        /// <summary>
+        /// Generates a code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes), given a device ID.
+        /// </summary>
         public AccessCode GenerateCode(string deviceId = default)
         {
             return GenerateCode(new GenerateCodeRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Generates a code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes), given a device ID.
+        /// </summary>
         public async Task<AccessCode> GenerateCodeAsync(GenerateCodeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -734,11 +943,17 @@ namespace Seam.Api
                 .GeneratedCode;
         }
 
+        /// <summary>
+        /// Generates a code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes), given a device ID.
+        /// </summary>
         public async Task<AccessCode> GenerateCodeAsync(string deviceId = default)
         {
             return (await GenerateCodeAsync(new GenerateCodeRequest(deviceId: deviceId)));
         }
 
+        /// <summary>
+        /// Request parameters for Get an Access Code.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -756,12 +971,21 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessCodeId { get; set; }
 
+            /// <summary>
+            /// Code of the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// ID of the device containing the access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
@@ -796,6 +1020,9 @@ namespace Seam.Api
                 AccessCode = accessCode;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_code", IsRequired = false, EmitDefaultValue = false)]
             public AccessCode AccessCode { get; set; }
 
@@ -819,6 +1046,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public AccessCode Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -826,6 +1058,11 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/access_codes/get", requestOptions).Data.AccessCode;
         }
 
+        /// <summary>
+        /// Returns a specified [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public AccessCode Get(
             string? accessCodeId = default,
             string? code = default,
@@ -835,6 +1072,11 @@ namespace Seam.Api
             return Get(new GetRequest(accessCodeId: accessCodeId, code: code, deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Returns a specified [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public async Task<AccessCode> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -844,6 +1086,11 @@ namespace Seam.Api
                 .AccessCode;
         }
 
+        /// <summary>
+        /// Returns a specified [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public async Task<AccessCode> GetAsync(
             string? accessCodeId = default,
             string? code = default,
@@ -857,6 +1104,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Access Codes.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -888,33 +1138,63 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// IDs of the access codes that you want to retrieve. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "access_code_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessCodeIds { get; set; }
 
+            /// <summary>
+            /// ID of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Key of the access grant for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// ID of the access method for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessMethodId { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list access codes.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to list access codes. Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of access codes to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned access codes to include all records that satisfy a partial match using `name`, `code` or `access_code_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user by which to filter access codes.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -949,6 +1229,9 @@ namespace Seam.Api
                 AccessCodes = accessCodes;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_codes", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessCode> AccessCodes { get; set; }
 
@@ -972,6 +1255,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+        /// </summary>
         public List<AccessCode> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -979,6 +1267,11 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/access_codes/list", requestOptions).Data.AccessCodes;
         }
 
+        /// <summary>
+        /// Returns a list of all [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+        /// </summary>
         public List<AccessCode> List(
             List<string>? accessCodeIds = default,
             string? accessGrantId = default,
@@ -1008,6 +1301,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+        /// </summary>
         public async Task<List<AccessCode>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1017,6 +1315,11 @@ namespace Seam.Api
                 .AccessCodes;
         }
 
+        /// <summary>
+        /// Returns a list of all [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// Specify `device_id`, `access_code_ids`, `access_method_id`, `access_grant_id`, or `access_grant_key`.
+        /// </summary>
         public async Task<List<AccessCode>> ListAsync(
             List<string>? accessCodeIds = default,
             string? accessGrantId = default,
@@ -1048,6 +1351,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Pull a Backup Access Code.
+        /// </summary>
         [DataContract(Name = "pullBackupAccessCodeRequest_request")]
         public class PullBackupAccessCodeRequest
         {
@@ -1059,6 +1365,9 @@ namespace Seam.Api
                 AccessCodeId = accessCodeId;
             }
 
+            /// <summary>
+            /// ID of the access code for which you want to pull a backup access code.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessCodeId { get; set; }
 
@@ -1093,6 +1402,9 @@ namespace Seam.Api
                 AccessCode = accessCode;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_code", IsRequired = false, EmitDefaultValue = false)]
             public AccessCode AccessCode { get; set; }
 
@@ -1116,6 +1428,17 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Retrieves a backup access code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+        ///
+        /// A backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there&apos;s ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.
+        ///
+        /// You can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.
+        ///
+        /// You can only pull backup access codes for time-bound access codes.
+        ///
+        /// Before pulling a backup access code, make sure that the device&apos;s `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.
+        /// </summary>
         public AccessCode PullBackupAccessCode(PullBackupAccessCodeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1128,6 +1451,17 @@ namespace Seam.Api
                 .Data.AccessCode;
         }
 
+        /// <summary>
+        /// Retrieves a backup access code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+        ///
+        /// A backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there&apos;s ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.
+        ///
+        /// You can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.
+        ///
+        /// You can only pull backup access codes for time-bound access codes.
+        ///
+        /// Before pulling a backup access code, make sure that the device&apos;s `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.
+        /// </summary>
         public AccessCode PullBackupAccessCode(string accessCodeId = default)
         {
             return PullBackupAccessCode(
@@ -1135,6 +1469,17 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Retrieves a backup access code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+        ///
+        /// A backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there&apos;s ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.
+        ///
+        /// You can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.
+        ///
+        /// You can only pull backup access codes for time-bound access codes.
+        ///
+        /// Before pulling a backup access code, make sure that the device&apos;s `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.
+        /// </summary>
         public async Task<AccessCode> PullBackupAccessCodeAsync(PullBackupAccessCodeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1149,6 +1494,17 @@ namespace Seam.Api
                 .AccessCode;
         }
 
+        /// <summary>
+        /// Retrieves a backup access code for an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+        ///
+        /// A backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there&apos;s ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.
+        ///
+        /// You can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.
+        ///
+        /// You can only pull backup access codes for time-bound access codes.
+        ///
+        /// Before pulling a backup access code, make sure that the device&apos;s `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.
+        /// </summary>
         public async Task<AccessCode> PullBackupAccessCodeAsync(string accessCodeId = default)
         {
             return (
@@ -1158,6 +1514,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Report Device Access Code Constraints.
+        /// </summary>
         [DataContract(Name = "reportDeviceConstraintsRequest_request")]
         public class ReportDeviceConstraintsRequest
         {
@@ -1177,15 +1536,27 @@ namespace Seam.Api
                 SupportedCodeLengths = supportedCodeLengths;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to report constraints.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Maximum supported code length as an integer between 4 and 20, inclusive. You can specify either `min_code_length`/`max_code_length` or `supported_code_lengths`.
+            /// </summary>
             [DataMember(Name = "max_code_length", IsRequired = false, EmitDefaultValue = false)]
             public int? MaxCodeLength { get; set; }
 
+            /// <summary>
+            /// Minimum supported code length as an integer between 4 and 20, inclusive. You can specify either `min_code_length`/`max_code_length` or `supported_code_lengths`.
+            /// </summary>
             [DataMember(Name = "min_code_length", IsRequired = false, EmitDefaultValue = false)]
             public int? MinCodeLength { get; set; }
 
+            /// <summary>
+            /// Array of supported code lengths as integers between 4 and 20, inclusive. You can specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+            /// </summary>
             [DataMember(
                 Name = "supported_code_lengths",
                 IsRequired = false,
@@ -1213,6 +1584,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Enables you to report access code-related constraints for a device. Currently, supports reporting supported code length constraints for SmartThings devices.
+        ///
+        /// Specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+        /// </summary>
         public void ReportDeviceConstraints(ReportDeviceConstraintsRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1220,6 +1596,11 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/report_device_constraints", requestOptions);
         }
 
+        /// <summary>
+        /// Enables you to report access code-related constraints for a device. Currently, supports reporting supported code length constraints for SmartThings devices.
+        ///
+        /// Specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+        /// </summary>
         public void ReportDeviceConstraints(
             string deviceId = default,
             int? maxCodeLength = default,
@@ -1237,6 +1618,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Enables you to report access code-related constraints for a device. Currently, supports reporting supported code length constraints for SmartThings devices.
+        ///
+        /// Specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+        /// </summary>
         public async Task ReportDeviceConstraintsAsync(ReportDeviceConstraintsRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1247,6 +1633,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Enables you to report access code-related constraints for a device. Currently, supports reporting supported code length constraints for SmartThings devices.
+        ///
+        /// Specify either `supported_code_lengths` or `min_code_length`/`max_code_length`.
+        /// </summary>
         public async Task ReportDeviceConstraintsAsync(
             string deviceId = default,
             int? maxCodeLength = default,
@@ -1264,6 +1655,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an Access Code.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -1311,6 +1705,9 @@ namespace Seam.Api
                 UseOfflineAccessCode = useOfflineAccessCode;
             }
 
+            /// <summary>
+            /// Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum MaxTimeRoundingEnum
             {
@@ -1330,6 +1727,9 @@ namespace Seam.Api
                 _1d = 4,
             }
 
+            /// <summary>
+            /// Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum TypeEnum
             {
@@ -1343,9 +1743,15 @@ namespace Seam.Api
                 TimeBound = 2,
             }
 
+            /// <summary>
+            /// ID of the access code that you want to update.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessCodeId { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+            /// </summary>
             [DataMember(
                 Name = "allow_external_modification",
                 IsRequired = false,
@@ -1360,15 +1766,27 @@ namespace Seam.Api
             )]
             public bool? AttemptForOfflineDevice { get; set; }
 
+            /// <summary>
+            /// Code to be used for access.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// ID of the device containing the access code that you want to update.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.
+            /// </summary>
             [DataMember(
                 Name = "is_external_modification_allowed",
                 IsRequired = false,
@@ -1376,9 +1794,15 @@ namespace Seam.Api
             )]
             public bool? IsExternalModificationAllowed { get; set; }
 
+            /// <summary>
+            /// Indicates whether the access code is managed through Seam. Note that to convert an unmanaged access code into a managed access code, use `/access_codes/unmanaged/convert_to_managed`.
+            /// </summary>
             [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsManaged { get; set; }
 
+            /// <summary>
+            /// Indicates whether the access code is an [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes).
+            /// </summary>
             [DataMember(
                 Name = "is_offline_access_code",
                 IsRequired = false,
@@ -1386,15 +1810,33 @@ namespace Seam.Api
             )]
             public bool? IsOfflineAccessCode { get; set; }
 
+            /// <summary>
+            /// Indicates whether the [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) is a single-use access code.
+            /// </summary>
             [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsOneTimeUse { get; set; }
 
+            /// <summary>
+            /// Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.
+            /// </summary>
             [DataMember(Name = "max_time_rounding", IsRequired = false, EmitDefaultValue = false)]
             public UpdateRequest.MaxTimeRoundingEnum? MaxTimeRounding { get; set; }
 
+            /// <summary>
+            /// Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+            ///
+            /// Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider&apos;s app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+            ///
+            /// To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider&apos;s app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+            ///
+            /// To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider&apos;s app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Indicates whether [native scheduling](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.
+            /// </summary>
             [DataMember(
                 Name = "prefer_native_scheduling",
                 IsRequired = false,
@@ -1402,6 +1844,9 @@ namespace Seam.Api
             )]
             public bool? PreferNativeScheduling { get; set; }
 
+            /// <summary>
+            /// Preferred code length. Only applicable if you do not specify a `code`. If the affected device does not support the preferred code length, Seam reverts to using the shortest supported code length.
+            /// </summary>
             [DataMember(
                 Name = "preferred_code_length",
                 IsRequired = false,
@@ -1409,12 +1854,21 @@ namespace Seam.Api
             )]
             public float? PreferredCodeLength { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).
+            /// </summary>
             [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
             public UpdateRequest.TypeEnum? Type { get; set; }
 
+            /// <summary>
+            /// Indicates whether to use a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).
+            /// </summary>
             [DataMember(
                 Name = "use_backup_access_code_pool",
                 IsRequired = false,
@@ -1422,6 +1876,7 @@ namespace Seam.Api
             )]
             public bool? UseBackupAccessCodePool { get; set; }
 
+            [Obsolete("Use `is_offline_access_code` instead.")]
             [DataMember(
                 Name = "use_offline_access_code",
                 IsRequired = false,
@@ -1449,6 +1904,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified active or upcoming [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// See also [Modifying Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1456,6 +1916,11 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified active or upcoming [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// See also [Modifying Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes).
+        /// </summary>
         public void Update(
             string accessCodeId = default,
             bool? allowExternalModification = default,
@@ -1501,6 +1966,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified active or upcoming [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// See also [Modifying Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1508,6 +1978,11 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_codes/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified active or upcoming [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// See also [Modifying Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/modifying-access-codes).
+        /// </summary>
         public async Task UpdateAsync(
             string accessCodeId = default,
             bool? allowExternalModification = default,
@@ -1553,6 +2028,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update Multiple Linked Access Codes.
+        /// </summary>
         [DataContract(Name = "updateMultipleRequest_request")]
         public class UpdateMultipleRequest
         {
@@ -1572,15 +2050,33 @@ namespace Seam.Api
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Key that links the group of access codes, assigned on creation by `/access_codes/create_multiple`.
+            /// </summary>
             [DataMember(Name = "common_code_key", IsRequired = true, EmitDefaultValue = false)]
             public string CommonCodeKey { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Name of the new access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes.
+            ///
+            /// Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider&apos;s app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`.
+            ///
+            /// To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider&apos;s app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints.
+            ///
+            /// To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider&apos;s app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new access code starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -1604,6 +2100,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Specify the `common_code_key` to identify the set of access codes that you want to update.
+        ///
+        /// See also [Update Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).
+        /// </summary>
         public void UpdateMultiple(UpdateMultipleRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1611,6 +2114,13 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/update_multiple", requestOptions);
         }
 
+        /// <summary>
+        /// Updates [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Specify the `common_code_key` to identify the set of access codes that you want to update.
+        ///
+        /// See also [Update Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).
+        /// </summary>
         public void UpdateMultiple(
             string commonCodeKey = default,
             string? endsAt = default,
@@ -1628,6 +2138,13 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Specify the `common_code_key` to identify the set of access codes that you want to update.
+        ///
+        /// See also [Update Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).
+        /// </summary>
         public async Task UpdateMultipleAsync(UpdateMultipleRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1635,6 +2152,13 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_codes/update_multiple", requestOptions);
         }
 
+        /// <summary>
+        /// Updates [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes) that share a common code across multiple devices.
+        ///
+        /// Specify the `common_code_key` to identify the set of access codes that you want to update.
+        ///
+        /// See also [Update Linked Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).
+        /// </summary>
         public async Task UpdateMultipleAsync(
             string commonCodeKey = default,
             string? endsAt = default,

--- a/output/csharp/src/Seam/Api/AccessGrants.cs
+++ b/output/csharp/src/Seam/Api/AccessGrants.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create an Access Grant.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -59,18 +62,33 @@ namespace Seam.Api
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// ID of user identity for whom access is being granted.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// When used, creates a new user identity with the given details, and grants them access.
+            /// </summary>
             [DataMember(Name = "user_identity", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestUserIdentity? UserIdentity { get; set; }
 
+            /// <summary>
+            /// Unique key for the access grant within the workspace.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// Set of IDs of the [entrances](https://docs.seam.co/api/acs/systems/list) to which access is being granted.
+            /// </summary>
             [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// ID of the customization profile to apply to the Access Grant and its access methods.
+            /// </summary>
             [DataMember(
                 Name = "customization_profile_id",
                 IsRequired = false,
@@ -78,18 +96,29 @@ namespace Seam.Api
             )]
             public string? CustomizationProfileId { get; set; }
 
+            /// <summary>
+            /// Set of IDs of the [devices](https://docs.seam.co/api/devices/list) to which access is being granted.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new grant ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            [Obsolete("Create a space first, then reference it using `space_ids`.")]
             [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestLocation? Location { get; set; }
 
+            [Obsolete("Use `space_ids`.")]
             [DataMember(Name = "location_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? LocationIds { get; set; }
 
+            /// <summary>
+            /// Name for the access grant.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -100,15 +129,27 @@ namespace Seam.Api
             )]
             public List<CreateRequestRequestedAccessMethods> RequestedAccessMethods { get; set; }
 
+            /// <summary>
+            /// Reservation key for the access grant.
+            /// </summary>
             [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ReservationKey { get; set; }
 
+            /// <summary>
+            /// Set of IDs of existing spaces to which access is being granted.
+            /// </summary>
             [DataMember(Name = "space_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceIds { get; set; }
 
+            /// <summary>
+            /// Set of keys of existing spaces to which access is being granted.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new grant starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -151,15 +192,27 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// Unique email address for the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the user associated with the user identity.
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
             public string? FullName { get; set; }
 
+            /// <summary>
+            /// Unique phone number for the user identity in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, +15555550100).
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Unique key for the user identity.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -200,12 +253,17 @@ namespace Seam.Api
                 Name = name;
             }
 
+            [Obsolete("Use `acs_entrance_ids` at the top level.")]
             [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsEntranceIds { get; set; }
 
+            [Obsolete("Use `device_ids` at the top level.")]
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Name of the location.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -246,6 +304,9 @@ namespace Seam.Api
                 Mode = mode;
             }
 
+            /// <summary>
+            /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ModeEnum
             {
@@ -265,9 +326,15 @@ namespace Seam.Api
                 CloudKey = 4,
             }
 
+            /// <summary>
+            /// Specific PIN code to use for this access method. Only applicable when mode is &apos;code&apos;.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// Maximum number of times the instant key can be used. Only applicable when mode is &apos;mobile_key&apos;. Defaults to 1 if not specified.
+            /// </summary>
             [DataMember(
                 Name = "instant_key_max_use_count",
                 IsRequired = false,
@@ -275,6 +342,9 @@ namespace Seam.Api
             )]
             public int? InstantKeyMaxUseCount { get; set; }
 
+            /// <summary>
+            /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            /// </summary>
             [DataMember(Name = "mode", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestRequestedAccessMethods.ModeEnum? Mode { get; set; }
 
@@ -309,6 +379,9 @@ namespace Seam.Api
                 AccessGrant = accessGrant;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_grant", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrant AccessGrant { get; set; }
 
@@ -332,6 +405,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [Access Grant](https://docs.seam.co/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.
+        /// </summary>
         public AccessGrant Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -341,6 +417,9 @@ namespace Seam.Api
                 .Data.AccessGrant;
         }
 
+        /// <summary>
+        /// Creates a new [Access Grant](https://docs.seam.co/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.
+        /// </summary>
         public AccessGrant Create(
             string? userIdentityId = default,
             CreateRequestUserIdentity? userIdentity = default,
@@ -380,6 +459,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [Access Grant](https://docs.seam.co/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.
+        /// </summary>
         public async Task<AccessGrant> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -389,6 +471,9 @@ namespace Seam.Api
                 .AccessGrant;
         }
 
+        /// <summary>
+        /// Creates a new [Access Grant](https://docs.seam.co/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.
+        /// </summary>
         public async Task<AccessGrant> CreateAsync(
             string? userIdentityId = default,
             CreateRequestUserIdentity? userIdentity = default,
@@ -430,6 +515,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete an Access Grant.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -441,6 +529,9 @@ namespace Seam.Api
                 AccessGrantId = accessGrantId;
             }
 
+            /// <summary>
+            /// ID of Access Grant to delete.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessGrantId { get; set; }
 
@@ -464,6 +555,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Delete an Access Grant.
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -471,11 +565,17 @@ namespace Seam.Api
             _seam.Post<object>("/access_grants/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Delete an Access Grant.
+        /// </summary>
         public void Delete(string accessGrantId = default)
         {
             Delete(new DeleteRequest(accessGrantId: accessGrantId));
         }
 
+        /// <summary>
+        /// Delete an Access Grant.
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -483,11 +583,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_grants/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Delete an Access Grant.
+        /// </summary>
         public async Task DeleteAsync(string accessGrantId = default)
         {
             await DeleteAsync(new DeleteRequest(accessGrantId: accessGrantId));
         }
 
+        /// <summary>
+        /// Request parameters for Get an Access Grant.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -500,9 +606,15 @@ namespace Seam.Api
                 AccessGrantKey = accessGrantKey;
             }
 
+            /// <summary>
+            /// ID of Access Grant to get.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Unique key of Access Grant to get.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
@@ -537,6 +649,9 @@ namespace Seam.Api
                 AccessGrant = accessGrant;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_grant", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrant AccessGrant { get; set; }
 
@@ -560,6 +675,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Get an Access Grant.
+        /// </summary>
         public AccessGrant Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -567,6 +685,9 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/access_grants/get", requestOptions).Data.AccessGrant;
         }
 
+        /// <summary>
+        /// Get an Access Grant.
+        /// </summary>
         public AccessGrant Get(string? accessGrantId = default, string? accessGrantKey = default)
         {
             return Get(
@@ -574,6 +695,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Get an Access Grant.
+        /// </summary>
         public async Task<AccessGrant> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -583,6 +707,9 @@ namespace Seam.Api
                 .AccessGrant;
         }
 
+        /// <summary>
+        /// Get an Access Grant.
+        /// </summary>
         public async Task<AccessGrant> GetAsync(
             string? accessGrantId = default,
             string? accessGrantKey = default
@@ -595,6 +722,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get related Access Grant resources.
+        /// </summary>
         [DataContract(Name = "getRelatedRequest_request")]
         public class GetRelatedRequest
         {
@@ -676,9 +806,15 @@ namespace Seam.Api
                 AccessMethods = 8,
             }
 
+            /// <summary>
+            /// IDs of the access grants that you want to get along with their related resources.
+            /// </summary>
             [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessGrantIds { get; set; }
 
+            /// <summary>
+            /// Keys of the access grants that you want to get along with their related resources.
+            /// </summary>
             [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessGrantKeys { get; set; }
 
@@ -719,6 +855,9 @@ namespace Seam.Api
                 Batch = batch;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "batch", IsRequired = false, EmitDefaultValue = false)]
             public Batch Batch { get; set; }
 
@@ -742,6 +881,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Grants.
+        /// </summary>
         public Batch GetRelated(GetRelatedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -751,6 +893,9 @@ namespace Seam.Api
                 .Data.Batch;
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Grants.
+        /// </summary>
         public Batch GetRelated(
             List<string>? accessGrantIds = default,
             List<string>? accessGrantKeys = default,
@@ -768,6 +913,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Grants.
+        /// </summary>
         public async Task<Batch> GetRelatedAsync(GetRelatedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -782,6 +930,9 @@ namespace Seam.Api
                 .Batch;
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Grants.
+        /// </summary>
         public async Task<Batch> GetRelatedAsync(
             List<string>? accessGrantIds = default,
             List<string>? accessGrantKeys = default,
@@ -801,6 +952,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Access Grants.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -838,42 +992,79 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access code by which you want to filter the list of Access Grants.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessCodeId { get; set; }
 
+            /// <summary>
+            /// IDs of the access grants to retrieve.
+            /// </summary>
             [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessGrantIds { get; set; }
 
+            /// <summary>
+            /// Filter Access Grants by access_grant_key. Use null to filter for Access Grants without an access_grant_key.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// ID of the entrance by which you want to filter the list of Access Grants.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// ID of the access system by which you want to filter the list of Access Grants.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list access grants.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// ID of the device by which you want to filter the list of Access Grants.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of access grants to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(Name = "location_id", IsRequired = false, EmitDefaultValue = false)]
             public string? LocationId { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// Filter Access Grants by reservation_key.
+            /// </summary>
             [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ReservationKey { get; set; }
 
+            /// <summary>
+            /// ID of the space by which you want to filter the list of Access Grants.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            /// <summary>
+            /// ID of user identity by which you want to filter the list of Access Grants.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -908,6 +1099,9 @@ namespace Seam.Api
                 AccessGrants = accessGrants;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_grants", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessGrant> AccessGrants { get; set; }
 
@@ -931,6 +1125,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets an Access Grant.
+        /// </summary>
         public List<AccessGrant> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -940,6 +1137,9 @@ namespace Seam.Api
                 .Data.AccessGrants;
         }
 
+        /// <summary>
+        /// Gets an Access Grant.
+        /// </summary>
         public List<AccessGrant> List(
             string? accessCodeId = default,
             List<string>? accessGrantIds = default,
@@ -975,6 +1175,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Gets an Access Grant.
+        /// </summary>
         public async Task<List<AccessGrant>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -984,6 +1187,9 @@ namespace Seam.Api
                 .AccessGrants;
         }
 
+        /// <summary>
+        /// Gets an Access Grant.
+        /// </summary>
         public async Task<List<AccessGrant>> ListAsync(
             string? accessCodeId = default,
             List<string>? accessGrantIds = default,
@@ -1021,6 +1227,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Add Requested Access Methods to Access Grant.
+        /// </summary>
         [DataContract(Name = "requestAccessMethodsRequest_request")]
         public class RequestAccessMethodsRequest
         {
@@ -1037,9 +1246,15 @@ namespace Seam.Api
                 RequestedAccessMethods = requestedAccessMethods;
             }
 
+            /// <summary>
+            /// ID of the Access Grant to add access methods to.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Array of requested access methods to add to the access grant.
+            /// </summary>
             [DataMember(
                 Name = "requested_access_methods",
                 IsRequired = true,
@@ -1084,6 +1299,9 @@ namespace Seam.Api
                 Mode = mode;
             }
 
+            /// <summary>
+            /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ModeEnum
             {
@@ -1103,9 +1321,15 @@ namespace Seam.Api
                 CloudKey = 4,
             }
 
+            /// <summary>
+            /// Specific PIN code to use for this access method. Only applicable when mode is &apos;code&apos;.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// Maximum number of times the instant key can be used. Only applicable when mode is &apos;mobile_key&apos;. Defaults to 1 if not specified.
+            /// </summary>
             [DataMember(
                 Name = "instant_key_max_use_count",
                 IsRequired = false,
@@ -1113,6 +1337,9 @@ namespace Seam.Api
             )]
             public int? InstantKeyMaxUseCount { get; set; }
 
+            /// <summary>
+            /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            /// </summary>
             [DataMember(Name = "mode", IsRequired = false, EmitDefaultValue = false)]
             public RequestAccessMethodsRequestRequestedAccessMethods.ModeEnum? Mode { get; set; }
 
@@ -1147,6 +1374,9 @@ namespace Seam.Api
                 AccessGrant = accessGrant;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_grant", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrant AccessGrant { get; set; }
 
@@ -1170,6 +1400,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds additional requested access methods to an existing Access Grant.
+        /// </summary>
         public AccessGrant RequestAccessMethods(RequestAccessMethodsRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1182,6 +1415,9 @@ namespace Seam.Api
                 .Data.AccessGrant;
         }
 
+        /// <summary>
+        /// Adds additional requested access methods to an existing Access Grant.
+        /// </summary>
         public AccessGrant RequestAccessMethods(
             string accessGrantId = default,
             List<RequestAccessMethodsRequestRequestedAccessMethods> requestedAccessMethods = default
@@ -1195,6 +1431,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Adds additional requested access methods to an existing Access Grant.
+        /// </summary>
         public async Task<AccessGrant> RequestAccessMethodsAsync(
             RequestAccessMethodsRequest request
         )
@@ -1211,6 +1450,9 @@ namespace Seam.Api
                 .AccessGrant;
         }
 
+        /// <summary>
+        /// Adds additional requested access methods to an existing Access Grant.
+        /// </summary>
         public async Task<AccessGrant> RequestAccessMethodsAsync(
             string accessGrantId = default,
             List<RequestAccessMethodsRequestRequestedAccessMethods> requestedAccessMethods = default
@@ -1226,6 +1468,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an Access Grant.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -1247,18 +1492,33 @@ namespace Seam.Api
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// ID of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Key of the Access Grant to update. Provide either `access_grant_id` or `access_grant_key`.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the grant ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Display name for the access grant.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the grant starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -1282,6 +1542,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates an existing Access Grant&apos;s time window.
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1289,6 +1552,9 @@ namespace Seam.Api
             _seam.Post<object>("/access_grants/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates an existing Access Grant&apos;s time window.
+        /// </summary>
         public void Update(
             string? accessGrantId = default,
             string? accessGrantKey = default,
@@ -1308,6 +1574,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates an existing Access Grant&apos;s time window.
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1315,6 +1584,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_grants/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates an existing Access Grant&apos;s time window.
+        /// </summary>
         public async Task UpdateAsync(
             string? accessGrantId = default,
             string? accessGrantKey = default,

--- a/output/csharp/src/Seam/Api/AccessGroupsAcs.cs
+++ b/output/csharp/src/Seam/Api/AccessGroupsAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Add an ACS User to an Access Group.
+        /// </summary>
         [DataContract(Name = "addUserRequest_request")]
         public class AddUserRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access group to which you want to add an access system user.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the desired user identity that you want to add to an access group. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -64,6 +76,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void AddUser(AddUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,6 +86,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/access_groups/add_user", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void AddUser(
             string acsAccessGroupId = default,
             string? acsUserId = default,
@@ -86,6 +104,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task AddUserAsync(AddUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -93,6 +114,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/access_groups/add_user", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task AddUserAsync(
             string acsAccessGroupId = default,
             string? acsUserId = default,
@@ -108,6 +132,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete an Access Group.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -119,6 +146,9 @@ namespace Seam.Api
                 AcsAccessGroupId = acsAccessGroupId;
             }
 
+            /// <summary>
+            /// ID of the access group that you want to delete.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
@@ -142,6 +172,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -149,11 +182,17 @@ namespace Seam.Api
             _seam.Post<object>("/acs/access_groups/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void Delete(string acsAccessGroupId = default)
         {
             Delete(new DeleteRequest(acsAccessGroupId: acsAccessGroupId));
         }
 
+        /// <summary>
+        /// Deletes a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -161,11 +200,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/access_groups/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task DeleteAsync(string acsAccessGroupId = default)
         {
             await DeleteAsync(new DeleteRequest(acsAccessGroupId: acsAccessGroupId));
         }
 
+        /// <summary>
+        /// Request parameters for Get an Access Group.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -177,6 +222,9 @@ namespace Seam.Api
                 AcsAccessGroupId = acsAccessGroupId;
             }
 
+            /// <summary>
+            /// ID of the access group that you want to get.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
@@ -211,6 +259,9 @@ namespace Seam.Api
                 AcsAccessGroup = acsAccessGroup;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_access_group", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroup AcsAccessGroup { get; set; }
 
@@ -234,6 +285,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public AcsAccessGroup Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -243,11 +297,17 @@ namespace Seam.Api
                 .Data.AcsAccessGroup;
         }
 
+        /// <summary>
+        /// Returns a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public AcsAccessGroup Get(string acsAccessGroupId = default)
         {
             return Get(new GetRequest(acsAccessGroupId: acsAccessGroupId));
         }
 
+        /// <summary>
+        /// Returns a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<AcsAccessGroup> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -257,11 +317,17 @@ namespace Seam.Api
                 .AcsAccessGroup;
         }
 
+        /// <summary>
+        /// Returns a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<AcsAccessGroup> GetAsync(string acsAccessGroupId = default)
         {
             return (await GetAsync(new GetRequest(acsAccessGroupId: acsAccessGroupId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Access Groups.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -281,15 +347,27 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system for which you want to retrieve all access groups.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user for which you want to retrieve all access groups.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned access groups to include all records that satisfy a partial match using `name` or `acs_access_group_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all access groups.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -324,6 +402,9 @@ namespace Seam.Api
                 AcsAccessGroups = acsAccessGroups;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_access_groups", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsAccessGroup> AcsAccessGroups { get; set; }
 
@@ -347,6 +428,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access groups](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public List<AcsAccessGroup> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -356,6 +440,9 @@ namespace Seam.Api
                 .Data.AcsAccessGroups;
         }
 
+        /// <summary>
+        /// Returns a list of all [access groups](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public List<AcsAccessGroup> List(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -373,6 +460,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [access groups](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<List<AcsAccessGroup>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -382,6 +472,9 @@ namespace Seam.Api
                 .AcsAccessGroups;
         }
 
+        /// <summary>
+        /// Returns a list of all [access groups](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<List<AcsAccessGroup>> ListAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -401,6 +494,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Entrances Accessible to an Access Group.
+        /// </summary>
         [DataContract(Name = "listAccessibleEntrancesRequest_request")]
         public class ListAccessibleEntrancesRequest
         {
@@ -412,6 +508,9 @@ namespace Seam.Api
                 AcsAccessGroupId = acsAccessGroupId;
             }
 
+            /// <summary>
+            /// ID of the access group for which you want to retrieve all accessible entrances.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
@@ -446,6 +545,9 @@ namespace Seam.Api
                 AcsEntrances = acsEntrances;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsEntrance> AcsEntrances { get; set; }
 
@@ -469,6 +571,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(ListAccessibleEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -481,6 +586,9 @@ namespace Seam.Api
                 .Data.AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(string acsAccessGroupId = default)
         {
             return ListAccessibleEntrances(
@@ -488,6 +596,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             ListAccessibleEntrancesRequest request
         )
@@ -504,6 +615,9 @@ namespace Seam.Api
                 .AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             string acsAccessGroupId = default
         )
@@ -515,6 +629,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List ACS Users in an Access Group.
+        /// </summary>
         [DataContract(Name = "listUsersRequest_request")]
         public class ListUsersRequest
         {
@@ -526,6 +643,9 @@ namespace Seam.Api
                 AcsAccessGroupId = acsAccessGroupId;
             }
 
+            /// <summary>
+            /// ID of the access group for which you want to retrieve all access system users.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
@@ -560,6 +680,9 @@ namespace Seam.Api
                 AcsUsers = acsUsers;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_users", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsUser> AcsUsers { get; set; }
 
@@ -583,6 +706,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public List<AcsUser> ListUsers(ListUsersRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -592,11 +718,17 @@ namespace Seam.Api
                 .Data.AcsUsers;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public List<AcsUser> ListUsers(string acsAccessGroupId = default)
         {
             return ListUsers(new ListUsersRequest(acsAccessGroupId: acsAccessGroupId));
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<List<AcsUser>> ListUsersAsync(ListUsersRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -611,11 +743,17 @@ namespace Seam.Api
                 .AcsUsers;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task<List<AcsUser>> ListUsersAsync(string acsAccessGroupId = default)
         {
             return (await ListUsersAsync(new ListUsersRequest(acsAccessGroupId: acsAccessGroupId)));
         }
 
+        /// <summary>
+        /// Request parameters for Remove an ACS User from an Access Group.
+        /// </summary>
         [DataContract(Name = "removeUserRequest_request")]
         public class RemoveUserRequest
         {
@@ -633,12 +771,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access group from which you want to remove an access system user.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to remove from an access group.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity associated with the user that you want to remove from an access group.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -662,6 +809,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void RemoveUser(RemoveUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -669,6 +819,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/access_groups/remove_user", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void RemoveUser(
             string acsAccessGroupId = default,
             string? acsUserId = default,
@@ -684,6 +837,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task RemoveUserAsync(RemoveUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -691,6 +847,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/access_groups/remove_user", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task RemoveUserAsync(
             string acsAccessGroupId = default,
             string? acsUserId = default,

--- a/output/csharp/src/Seam/Api/AccessMethods.cs
+++ b/output/csharp/src/Seam/Api/AccessMethods.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Assign a Card Credential to an Access Method.
+        /// </summary>
         [DataContract(Name = "assignCardRequest_request")]
         public class AssignCardRequest
         {
@@ -30,9 +33,15 @@ namespace Seam.Api
                 CardNumber = cardNumber;
             }
 
+            /// <summary>
+            /// ID of the `access_method` to assign the credential to.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessMethodId { get; set; }
 
+            /// <summary>
+            /// Card number of the credential to assign.
+            /// </summary>
             [DataMember(Name = "card_number", IsRequired = true, EmitDefaultValue = false)]
             public string CardNumber { get; set; }
 
@@ -67,6 +76,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -90,6 +102,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Assigns a pre-registered card credential, identified by `card_number`, to a card-mode access method. Use this endpoint for access systems that use pre-registered cards, where a physical card must be associated with an access method before it can be used for access. Assigning a card credential also triggers issuance of the access method.
+        /// </summary>
         public ActionAttempt AssignCard(AssignCardRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -99,6 +114,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Assigns a pre-registered card credential, identified by `card_number`, to a card-mode access method. Use this endpoint for access systems that use pre-registered cards, where a physical card must be associated with an access method before it can be used for access. Assigning a card credential also triggers issuance of the access method.
+        /// </summary>
         public ActionAttempt AssignCard(
             string accessMethodId = default,
             string cardNumber = default
@@ -109,6 +127,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Assigns a pre-registered card credential, identified by `card_number`, to a card-mode access method. Use this endpoint for access systems that use pre-registered cards, where a physical card must be associated with an access method before it can be used for access. Assigning a card credential also triggers issuance of the access method.
+        /// </summary>
         public async Task<ActionAttempt> AssignCardAsync(AssignCardRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -123,6 +144,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Assigns a pre-registered card credential, identified by `card_number`, to a card-mode access method. Use this endpoint for access systems that use pre-registered cards, where a physical card must be associated with an access method before it can be used for access. Assigning a card credential also triggers issuance of the access method.
+        /// </summary>
         public async Task<ActionAttempt> AssignCardAsync(
             string accessMethodId = default,
             string cardNumber = default
@@ -135,6 +159,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete an Access Method.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -152,12 +179,21 @@ namespace Seam.Api
                 ReservationKey = reservationKey;
             }
 
+            /// <summary>
+            /// ID of access method to delete.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessMethodId { get; set; }
 
+            /// <summary>
+            /// ID of access grant whose access methods should be deleted.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Reservation key of the access grant whose access methods should be deleted.
+            /// </summary>
             [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ReservationKey { get; set; }
 
@@ -181,6 +217,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes an access method.
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -188,6 +227,9 @@ namespace Seam.Api
             _seam.Post<object>("/access_methods/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes an access method.
+        /// </summary>
         public void Delete(
             string? accessMethodId = default,
             string? accessGrantId = default,
@@ -203,6 +245,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Deletes an access method.
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -210,6 +255,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_methods/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes an access method.
+        /// </summary>
         public async Task DeleteAsync(
             string? accessMethodId = default,
             string? accessGrantId = default,
@@ -225,6 +273,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Encode an Access Method.
+        /// </summary>
         [DataContract(Name = "encodeRequest_request")]
         public class EncodeRequest
         {
@@ -237,9 +288,15 @@ namespace Seam.Api
                 AcsEncoderId = acsEncoderId;
             }
 
+            /// <summary>
+            /// ID of the `access_method` to encode onto a card.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessMethodId { get; set; }
 
+            /// <summary>
+            /// ID of the `acs_encoder` to use to encode the `access_method`.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
@@ -274,6 +331,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -297,6 +357,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public ActionAttempt Encode(EncodeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -306,6 +369,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public ActionAttempt Encode(string accessMethodId = default, string acsEncoderId = default)
         {
             return Encode(
@@ -313,6 +379,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<ActionAttempt> EncodeAsync(EncodeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -322,6 +391,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<ActionAttempt> EncodeAsync(
             string accessMethodId = default,
             string acsEncoderId = default
@@ -334,6 +406,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get an Access Method.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -345,6 +420,9 @@ namespace Seam.Api
                 AccessMethodId = accessMethodId;
             }
 
+            /// <summary>
+            /// ID of access method to get.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessMethodId { get; set; }
 
@@ -379,6 +457,9 @@ namespace Seam.Api
                 AccessMethod = accessMethod;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_method", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethod AccessMethod { get; set; }
 
@@ -402,6 +483,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets an access method.
+        /// </summary>
         public AccessMethod Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -409,11 +493,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/access_methods/get", requestOptions).Data.AccessMethod;
         }
 
+        /// <summary>
+        /// Gets an access method.
+        /// </summary>
         public AccessMethod Get(string accessMethodId = default)
         {
             return Get(new GetRequest(accessMethodId: accessMethodId));
         }
 
+        /// <summary>
+        /// Gets an access method.
+        /// </summary>
         public async Task<AccessMethod> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -423,11 +513,17 @@ namespace Seam.Api
                 .AccessMethod;
         }
 
+        /// <summary>
+        /// Gets an access method.
+        /// </summary>
         public async Task<AccessMethod> GetAsync(string accessMethodId = default)
         {
             return (await GetAsync(new GetRequest(accessMethodId: accessMethodId)));
         }
 
+        /// <summary>
+        /// Request parameters for Get related Access Method resources.
+        /// </summary>
         [DataContract(Name = "getRelatedRequest_request")]
         public class GetRelatedRequest
         {
@@ -507,6 +603,9 @@ namespace Seam.Api
                 AcsCredentials = 8,
             }
 
+            /// <summary>
+            /// IDs of the access methods that you want to get along with their related resources.
+            /// </summary>
             [DataMember(Name = "access_method_ids", IsRequired = true, EmitDefaultValue = false)]
             public List<string> AccessMethodIds { get; set; }
 
@@ -547,6 +646,9 @@ namespace Seam.Api
                 Batch = batch;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "batch", IsRequired = false, EmitDefaultValue = false)]
             public Batch Batch { get; set; }
 
@@ -570,6 +672,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Methods.
+        /// </summary>
         public Batch GetRelated(GetRelatedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -579,6 +684,9 @@ namespace Seam.Api
                 .Data.Batch;
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Methods.
+        /// </summary>
         public Batch GetRelated(
             List<string> accessMethodIds = default,
             List<GetRelatedRequest.ExcludeEnum>? exclude = default,
@@ -594,6 +702,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Methods.
+        /// </summary>
         public async Task<Batch> GetRelatedAsync(GetRelatedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -608,6 +719,9 @@ namespace Seam.Api
                 .Batch;
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Access Methods.
+        /// </summary>
         public async Task<Batch> GetRelatedAsync(
             List<string> accessMethodIds = default,
             List<GetRelatedRequest.ExcludeEnum>? exclude = default,
@@ -625,6 +739,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Access Methods.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -648,21 +765,39 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// ID of the access code for which you want to retrieve all access methods.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessCodeId { get; set; }
 
+            /// <summary>
+            /// ID of Access Grant to list access methods for.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Key of Access Grant to list access methods for.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// ID of the entrance for which you want to retrieve all access methods.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to retrieve all access methods.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to retrieve all access methods.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
@@ -697,6 +832,9 @@ namespace Seam.Api
                 AccessMethods = accessMethods;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_methods", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessMethod> AccessMethods { get; set; }
 
@@ -720,6 +858,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Lists all access methods, usually filtered by Access Grant.
+        /// </summary>
         public List<AccessMethod> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -729,6 +870,9 @@ namespace Seam.Api
                 .Data.AccessMethods;
         }
 
+        /// <summary>
+        /// Lists all access methods, usually filtered by Access Grant.
+        /// </summary>
         public List<AccessMethod> List(
             string? accessCodeId = default,
             string? accessGrantId = default,
@@ -750,6 +894,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Lists all access methods, usually filtered by Access Grant.
+        /// </summary>
         public async Task<List<AccessMethod>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -759,6 +906,9 @@ namespace Seam.Api
                 .AccessMethods;
         }
 
+        /// <summary>
+        /// Lists all access methods, usually filtered by Access Grant.
+        /// </summary>
         public async Task<List<AccessMethod>> ListAsync(
             string? accessCodeId = default,
             string? accessGrantId = default,
@@ -782,6 +932,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Unlock a Door with an Access Method.
+        /// </summary>
         [DataContract(Name = "unlockDoorRequest_request")]
         public class UnlockDoorRequest
         {
@@ -797,9 +950,15 @@ namespace Seam.Api
                 AcsEntranceId = acsEntranceId;
             }
 
+            /// <summary>
+            /// ID of the cloud_key `access_method` to use for the unlock operation.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessMethodId { get; set; }
 
+            /// <summary>
+            /// ID of the entrance to unlock.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEntranceId { get; set; }
 
@@ -834,6 +993,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -857,6 +1019,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public ActionAttempt UnlockDoor(UnlockDoorRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -866,6 +1031,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public ActionAttempt UnlockDoor(
             string accessMethodId = default,
             string acsEntranceId = default
@@ -876,6 +1044,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public async Task<ActionAttempt> UnlockDoorAsync(UnlockDoorRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -890,6 +1061,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public async Task<ActionAttempt> UnlockDoorAsync(
             string accessMethodId = default,
             string acsEntranceId = default

--- a/output/csharp/src/Seam/Api/ActionAttempts.cs
+++ b/output/csharp/src/Seam/Api/ActionAttempts.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Action Attempt.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 ActionAttemptId = actionAttemptId;
             }
 
+            /// <summary>
+            /// ID of the action attempt that you want to get.
+            /// </summary>
             [DataMember(Name = "action_attempt_id", IsRequired = true, EmitDefaultValue = false)]
             public string ActionAttemptId { get; set; }
 
@@ -63,6 +69,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -86,6 +95,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).
+        /// </summary>
         public ActionAttempt Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -95,11 +107,17 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).
+        /// </summary>
         public ActionAttempt Get(string actionAttemptId = default)
         {
             return Get(new GetRequest(actionAttemptId: actionAttemptId));
         }
 
+        /// <summary>
+        /// Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).
+        /// </summary>
         public async Task<ActionAttempt> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -109,11 +127,17 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).
+        /// </summary>
         public async Task<ActionAttempt> GetAsync(string actionAttemptId = default)
         {
             return (await GetAsync(new GetRequest(actionAttemptId: actionAttemptId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Action Attempts.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -133,15 +157,27 @@ namespace Seam.Api
                 PageCursor = pageCursor;
             }
 
+            /// <summary>
+            /// IDs of the action attempts that you want to retrieve.
+            /// </summary>
             [DataMember(Name = "action_attempt_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ActionAttemptIds { get; set; }
 
+            /// <summary>
+            /// ID of the device to filter action attempts by.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public int? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
@@ -176,6 +212,9 @@ namespace Seam.Api
                 ActionAttempts = actionAttempts;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempts", IsRequired = false, EmitDefaultValue = false)]
             public List<ActionAttempt> ActionAttempts { get; set; }
 
@@ -199,6 +238,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.
+        /// </summary>
         public List<ActionAttempt> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -208,6 +250,9 @@ namespace Seam.Api
                 .Data.ActionAttempts;
         }
 
+        /// <summary>
+        /// Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.
+        /// </summary>
         public List<ActionAttempt> List(
             List<string>? actionAttemptIds = default,
             string? deviceId = default,
@@ -225,6 +270,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.
+        /// </summary>
         public async Task<List<ActionAttempt>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -234,6 +282,9 @@ namespace Seam.Api
                 .ActionAttempts;
         }
 
+        /// <summary>
+        /// Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.
+        /// </summary>
         public async Task<List<ActionAttempt>> ListAsync(
             List<string>? actionAttemptIds = default,
             string? deviceId = default,

--- a/output/csharp/src/Seam/Api/ClientSessions.cs
+++ b/output/csharp/src/Seam/Api/ClientSessions.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Client Session.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -45,9 +48,15 @@ namespace Seam.Api
                 UserIdentityIds = userIdentityIds;
             }
 
+            /// <summary>
+            /// IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) for which you want to create a client session.
+            /// </summary>
             [DataMember(Name = "connect_webview_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ConnectWebviewIds { get; set; }
 
+            /// <summary>
+            /// IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) for which you want to create a client session.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -55,21 +64,40 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Customer ID that you want to associate with the new client session.
+            /// </summary>
             [DataMember(Name = "customer_id", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerId { get; set; }
 
+            /// <summary>
+            /// Customer key that you want to associate with the new client session.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Date and time at which the client session should expire, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "expires_at", IsRequired = false, EmitDefaultValue = false)]
             public string? ExpiresAt { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user for whom you want to create a client session.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
+            /// <summary>
+            /// ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to create a client session.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+            /// </summary>
+            [Obsolete("Use `user_identity_id` instead.")]
             [DataMember(Name = "user_identity_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UserIdentityIds { get; set; }
 
@@ -104,6 +132,9 @@ namespace Seam.Api
                 ClientSession = clientSession;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "client_session", IsRequired = false, EmitDefaultValue = false)]
             public ClientSession ClientSession { get; set; }
 
@@ -127,6 +158,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public ClientSession Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -136,6 +170,9 @@ namespace Seam.Api
                 .Data.ClientSession;
         }
 
+        /// <summary>
+        /// Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public ClientSession Create(
             List<string>? connectWebviewIds = default,
             List<string>? connectedAccountIds = default,
@@ -161,6 +198,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task<ClientSession> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -172,6 +212,9 @@ namespace Seam.Api
                 .ClientSession;
         }
 
+        /// <summary>
+        /// Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task<ClientSession> CreateAsync(
             List<string>? connectWebviewIds = default,
             List<string>? connectedAccountIds = default,
@@ -199,6 +242,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Client Session.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -210,6 +256,9 @@ namespace Seam.Api
                 ClientSessionId = clientSessionId;
             }
 
+            /// <summary>
+            /// ID of the client session that you want to delete.
+            /// </summary>
             [DataMember(Name = "client_session_id", IsRequired = true, EmitDefaultValue = false)]
             public string ClientSessionId { get; set; }
 
@@ -233,6 +282,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -240,11 +292,17 @@ namespace Seam.Api
             _seam.Post<object>("/client_sessions/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public void Delete(string clientSessionId = default)
         {
             Delete(new DeleteRequest(clientSessionId: clientSessionId));
         }
 
+        /// <summary>
+        /// Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -252,11 +310,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/client_sessions/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task DeleteAsync(string clientSessionId = default)
         {
             await DeleteAsync(new DeleteRequest(clientSessionId: clientSessionId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Client Session.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -272,9 +336,15 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// ID of the client session that you want to get.
+            /// </summary>
             [DataMember(Name = "client_session_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ClientSessionId { get; set; }
 
+            /// <summary>
+            /// User identifier key associated with the client session that you want to get.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -309,6 +379,9 @@ namespace Seam.Api
                 ClientSession = clientSession;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "client_session", IsRequired = false, EmitDefaultValue = false)]
             public ClientSession ClientSession { get; set; }
 
@@ -332,6 +405,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public ClientSession Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -341,6 +417,9 @@ namespace Seam.Api
                 .Data.ClientSession;
         }
 
+        /// <summary>
+        /// Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public ClientSession Get(
             string? clientSessionId = default,
             string? userIdentifierKey = default
@@ -354,6 +433,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task<ClientSession> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -363,6 +445,9 @@ namespace Seam.Api
                 .ClientSession;
         }
 
+        /// <summary>
+        /// Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task<ClientSession> GetAsync(
             string? clientSessionId = default,
             string? userIdentifierKey = default
@@ -378,6 +463,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get or Create a Client Session.
+        /// </summary>
         [DataContract(Name = "getOrCreateRequest_request")]
         public class GetOrCreateRequest
         {
@@ -401,9 +489,15 @@ namespace Seam.Api
                 UserIdentityIds = userIdentityIds;
             }
 
+            /// <summary>
+            /// IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session (or that are already associated with the existing client session).
+            /// </summary>
             [DataMember(Name = "connect_webview_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ConnectWebviewIds { get; set; }
 
+            /// <summary>
+            /// IDs of the [connected accounts](https://docs.seam.co/api/connected_accounts) that you want to associate with the client session (or that are already associated with the existing client session).
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -411,15 +505,28 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Date and time at which the client session should expire in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. If the client session already exists, this will update the expiration before returning it.
+            /// </summary>
             [DataMember(Name = "expires_at", IsRequired = false, EmitDefaultValue = false)]
             public string? ExpiresAt { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user that you want to associate with the client session (or that is already associated with the existing client session).
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
+            /// <summary>
+            /// ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session (or that are already associated with the existing client session).
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+            /// </summary>
+            [Obsolete("Use `user_identity_id`.")]
             [DataMember(Name = "user_identity_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UserIdentityIds { get; set; }
 
@@ -454,6 +561,9 @@ namespace Seam.Api
                 ClientSession = clientSession;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "client_session", IsRequired = false, EmitDefaultValue = false)]
             public ClientSession ClientSession { get; set; }
 
@@ -477,6 +587,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.
+        /// </summary>
         public ClientSession GetOrCreate(GetOrCreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -486,6 +599,9 @@ namespace Seam.Api
                 .Data.ClientSession;
         }
 
+        /// <summary>
+        /// Returns a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.
+        /// </summary>
         public ClientSession GetOrCreate(
             List<string>? connectWebviewIds = default,
             List<string>? connectedAccountIds = default,
@@ -507,6 +623,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.
+        /// </summary>
         public async Task<ClientSession> GetOrCreateAsync(GetOrCreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -521,6 +640,9 @@ namespace Seam.Api
                 .ClientSession;
         }
 
+        /// <summary>
+        /// Returns a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.
+        /// </summary>
         public async Task<ClientSession> GetOrCreateAsync(
             List<string>? connectWebviewIds = default,
             List<string>? connectedAccountIds = default,
@@ -544,6 +666,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Grant Access to a Client Session.
+        /// </summary>
         [DataContract(Name = "grantAccessRequest_request")]
         public class GrantAccessRequest
         {
@@ -567,12 +692,21 @@ namespace Seam.Api
                 UserIdentityIds = userIdentityIds;
             }
 
+            /// <summary>
+            /// ID of the client session to which you want to grant access to resources.
+            /// </summary>
             [DataMember(Name = "client_session_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ClientSessionId { get; set; }
 
+            /// <summary>
+            /// IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session.
+            /// </summary>
             [DataMember(Name = "connect_webview_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ConnectWebviewIds { get; set; }
 
+            /// <summary>
+            /// IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that you want to associate with the client session.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -580,12 +714,22 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user that you want to associate with the client session.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
+            /// <summary>
+            /// ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.
+            /// </summary>
+            [Obsolete("Use `user_identity_id`.")]
             [DataMember(Name = "user_identity_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UserIdentityIds { get; set; }
 
@@ -609,6 +753,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.
+        /// </summary>
         public void GrantAccess(GrantAccessRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -616,6 +763,9 @@ namespace Seam.Api
             _seam.Post<object>("/client_sessions/grant_access", requestOptions);
         }
 
+        /// <summary>
+        /// Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.
+        /// </summary>
         public void GrantAccess(
             string? clientSessionId = default,
             List<string>? connectWebviewIds = default,
@@ -637,6 +787,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.
+        /// </summary>
         public async Task GrantAccessAsync(GrantAccessRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -644,6 +797,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/client_sessions/grant_access", requestOptions);
         }
 
+        /// <summary>
+        /// Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.
+        /// </summary>
         public async Task GrantAccessAsync(
             string? clientSessionId = default,
             List<string>? connectWebviewIds = default,
@@ -665,6 +821,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Client Sessions.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -686,18 +845,33 @@ namespace Seam.Api
                 WithoutUserIdentifierKey = withoutUserIdentifierKey;
             }
 
+            /// <summary>
+            /// ID of the client session that you want to retrieve.
+            /// </summary>
             [DataMember(Name = "client_session_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ClientSessionId { get; set; }
 
+            /// <summary>
+            /// ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) for which you want to retrieve client sessions.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user by which you want to filter client sessions.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
+            /// <summary>
+            /// ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to retrieve client sessions.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Indicates whether to retrieve only client sessions without associated user identifier keys.
+            /// </summary>
             [DataMember(
                 Name = "without_user_identifier_key",
                 IsRequired = false,
@@ -736,6 +910,9 @@ namespace Seam.Api
                 ClientSessions = clientSessions;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "client_sessions", IsRequired = false, EmitDefaultValue = false)]
             public List<ClientSession> ClientSessions { get; set; }
 
@@ -759,6 +936,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public List<ClientSession> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -768,6 +948,9 @@ namespace Seam.Api
                 .Data.ClientSessions;
         }
 
+        /// <summary>
+        /// Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public List<ClientSession> List(
             string? clientSessionId = default,
             string? connectWebviewId = default,
@@ -787,6 +970,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task<List<ClientSession>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -796,6 +982,9 @@ namespace Seam.Api
                 .ClientSessions;
         }
 
+        /// <summary>
+        /// Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         public async Task<List<ClientSession>> ListAsync(
             string? clientSessionId = default,
             string? connectWebviewId = default,
@@ -817,6 +1006,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Revoke a Client Session.
+        /// </summary>
         [DataContract(Name = "revokeRequest_request")]
         public class RevokeRequest
         {
@@ -828,6 +1020,9 @@ namespace Seam.Api
                 ClientSessionId = clientSessionId;
             }
 
+            /// <summary>
+            /// ID of the client session that you want to revoke.
+            /// </summary>
             [DataMember(Name = "client_session_id", IsRequired = true, EmitDefaultValue = false)]
             public string ClientSessionId { get; set; }
 
@@ -851,6 +1046,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Revokes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        ///
+        /// Note that [deleting a client session](https://docs.seam.co/api/client_sessions/delete) is a separate action.
+        /// </summary>
         public void Revoke(RevokeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -858,11 +1058,21 @@ namespace Seam.Api
             _seam.Post<object>("/client_sessions/revoke", requestOptions);
         }
 
+        /// <summary>
+        /// Revokes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        ///
+        /// Note that [deleting a client session](https://docs.seam.co/api/client_sessions/delete) is a separate action.
+        /// </summary>
         public void Revoke(string clientSessionId = default)
         {
             Revoke(new RevokeRequest(clientSessionId: clientSessionId));
         }
 
+        /// <summary>
+        /// Revokes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        ///
+        /// Note that [deleting a client session](https://docs.seam.co/api/client_sessions/delete) is a separate action.
+        /// </summary>
         public async Task RevokeAsync(RevokeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -870,6 +1080,11 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/client_sessions/revoke", requestOptions);
         }
 
+        /// <summary>
+        /// Revokes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        ///
+        /// Note that [deleting a client session](https://docs.seam.co/api/client_sessions/delete) is a separate action.
+        /// </summary>
         public async Task RevokeAsync(string clientSessionId = default)
         {
             await RevokeAsync(new RevokeRequest(clientSessionId: clientSessionId));

--- a/output/csharp/src/Seam/Api/ConnectWebviews.cs
+++ b/output/csharp/src/Seam/Api/ConnectWebviews.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Connect Webview.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -49,6 +52,9 @@ namespace Seam.Api
                 WaitForDeviceCreation = waitForDeviceCreation;
             }
 
+            /// <summary>
+            /// List of accepted device capabilities that restrict the types of devices that can be connected through the Connect Webview. If not provided, defaults will be determined based on the accepted providers.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum AcceptedCapabilitiesEnum
             {
@@ -71,6 +77,9 @@ namespace Seam.Api
                 Camera = 5,
             }
 
+            /// <summary>
+            /// Accepted device provider keys as an alternative to `provider_category`. Use this parameter to specify accepted providers explicitly. See [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews). To list all provider keys, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with no filters.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum AcceptedProvidersEnum
             {
@@ -276,6 +285,9 @@ namespace Seam.Api
                 Slack = 66,
             }
 
+            /// <summary>
+            /// Specifies the category of providers that you want to include. To list all providers within a category, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with the desired `provider_category` filter.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ProviderCategoryEnum
             {
@@ -310,6 +322,9 @@ namespace Seam.Api
                 InternalBeta = 9,
             }
 
+            /// <summary>
+            /// List of accepted device capabilities that restrict the types of devices that can be connected through the Connect Webview. If not provided, defaults will be determined based on the accepted providers.
+            /// </summary>
             [DataMember(
                 Name = "accepted_capabilities",
                 IsRequired = false,
@@ -317,9 +332,15 @@ namespace Seam.Api
             )]
             public List<CreateRequest.AcceptedCapabilitiesEnum>? AcceptedCapabilities { get; set; }
 
+            /// <summary>
+            /// Accepted device provider keys as an alternative to `provider_category`. Use this parameter to specify accepted providers explicitly. See [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews). To list all provider keys, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with no filters.
+            /// </summary>
             [DataMember(Name = "accepted_providers", IsRequired = false, EmitDefaultValue = false)]
             public List<CreateRequest.AcceptedProvidersEnum>? AcceptedProviders { get; set; }
 
+            /// <summary>
+            /// Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "automatically_manage_new_devices",
                 IsRequired = false,
@@ -327,9 +348,15 @@ namespace Seam.Api
             )]
             public bool? AutomaticallyManageNewDevices { get; set; }
 
+            /// <summary>
+            /// Custom metadata that you want to associate with the Connect Webview. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview) enables you to store custom information, like customer details or internal IDs from your application. The custom metadata is then transferred to any [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that were connected using the Connect Webview, making it easy to find and filter these resources in your [workspace](https://docs.seam.co/core-concepts/workspaces). You can also [filter Connect Webviews by custom metadata](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata).
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// Alternative URL that you want to redirect the user to on an error. If you do not set this parameter, the Connect Webview falls back to the `custom_redirect_url`.
+            /// </summary>
             [DataMember(
                 Name = "custom_redirect_failure_url",
                 IsRequired = false,
@@ -337,18 +364,33 @@ namespace Seam.Api
             )]
             public string? CustomRedirectFailureUrl { get; set; }
 
+            /// <summary>
+            /// URL that you want to redirect the user to after the provider login is complete.
+            /// </summary>
             [DataMember(Name = "custom_redirect_url", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomRedirectUrl { get; set; }
 
+            /// <summary>
+            /// Associate the Connect Webview, the connected account, and all resources under the connected account with a customer. If the connected account already exists, it will be associated with the customer. If the connected account already exists, but is already associated with a customer, the Connect Webview will show an error.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// List of provider keys to exclude from the Connect Webview. These providers will not be shown when the user tries to connect an account.
+            /// </summary>
             [DataMember(Name = "excluded_providers", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ExcludedProviders { get; set; }
 
+            /// <summary>
+            /// Specifies the category of providers that you want to include. To list all providers within a category, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with the desired `provider_category` filter.
+            /// </summary>
             [DataMember(Name = "provider_category", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequest.ProviderCategoryEnum? ProviderCategory { get; set; }
 
+            /// <summary>
+            /// Indicates whether Seam should finish syncing all devices in a newly-connected account before completing the associated Connect Webview. See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "wait_for_device_creation",
                 IsRequired = false,
@@ -387,6 +429,9 @@ namespace Seam.Api
                 ConnectWebview = connectWebview;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "connect_webview", IsRequired = false, EmitDefaultValue = false)]
             public ConnectWebview ConnectWebview { get; set; }
 
@@ -410,6 +455,15 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// To enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.
+        ///
+        /// You should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.
+        ///
+        /// See also: [Connect Webview Process](https://docs.seam.co/core-concepts/connect-webviews/connect-webview-process).
+        /// </summary>
         public ConnectWebview Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -419,6 +473,15 @@ namespace Seam.Api
                 .Data.ConnectWebview;
         }
 
+        /// <summary>
+        /// Creates a new [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// To enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.
+        ///
+        /// You should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.
+        ///
+        /// See also: [Connect Webview Process](https://docs.seam.co/core-concepts/connect-webviews/connect-webview-process).
+        /// </summary>
         public ConnectWebview Create(
             List<CreateRequest.AcceptedCapabilitiesEnum>? acceptedCapabilities = default,
             List<CreateRequest.AcceptedProvidersEnum>? acceptedProviders = default,
@@ -448,6 +511,15 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// To enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.
+        ///
+        /// You should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.
+        ///
+        /// See also: [Connect Webview Process](https://docs.seam.co/core-concepts/connect-webviews/connect-webview-process).
+        /// </summary>
         public async Task<ConnectWebview> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -459,6 +531,15 @@ namespace Seam.Api
                 .ConnectWebview;
         }
 
+        /// <summary>
+        /// Creates a new [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// To enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.
+        ///
+        /// You should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.
+        ///
+        /// See also: [Connect Webview Process](https://docs.seam.co/core-concepts/connect-webviews/connect-webview-process).
+        /// </summary>
         public async Task<ConnectWebview> CreateAsync(
             List<CreateRequest.AcceptedCapabilitiesEnum>? acceptedCapabilities = default,
             List<CreateRequest.AcceptedProvidersEnum>? acceptedProviders = default,
@@ -490,6 +571,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Connect Webview.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -501,6 +585,9 @@ namespace Seam.Api
                 ConnectWebviewId = connectWebviewId;
             }
 
+            /// <summary>
+            /// ID of the Connect Webview that you want to delete.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectWebviewId { get; set; }
 
@@ -524,6 +611,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -531,11 +623,21 @@ namespace Seam.Api
             _seam.Post<object>("/connect_webviews/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
+        /// </summary>
         public void Delete(string connectWebviewId = default)
         {
             Delete(new DeleteRequest(connectWebviewId: connectWebviewId));
         }
 
+        /// <summary>
+        /// Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -543,11 +645,19 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/connect_webviews/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// You do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.
+        /// </summary>
         public async Task DeleteAsync(string connectWebviewId = default)
         {
             await DeleteAsync(new DeleteRequest(connectWebviewId: connectWebviewId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Connect Webview.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -559,6 +669,9 @@ namespace Seam.Api
                 ConnectWebviewId = connectWebviewId;
             }
 
+            /// <summary>
+            /// ID of the Connect Webview that you want to get.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectWebviewId { get; set; }
 
@@ -593,6 +706,9 @@ namespace Seam.Api
                 ConnectWebview = connectWebview;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "connect_webview", IsRequired = false, EmitDefaultValue = false)]
             public ConnectWebview ConnectWebview { get; set; }
 
@@ -616,6 +732,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// Unless you&apos;re using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they&apos;ve connected.
+        /// </summary>
         public ConnectWebview Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -625,11 +746,21 @@ namespace Seam.Api
                 .Data.ConnectWebview;
         }
 
+        /// <summary>
+        /// Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// Unless you&apos;re using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they&apos;ve connected.
+        /// </summary>
         public ConnectWebview Get(string connectWebviewId = default)
         {
             return Get(new GetRequest(connectWebviewId: connectWebviewId));
         }
 
+        /// <summary>
+        /// Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// Unless you&apos;re using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they&apos;ve connected.
+        /// </summary>
         public async Task<ConnectWebview> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -639,11 +770,19 @@ namespace Seam.Api
                 .ConnectWebview;
         }
 
+        /// <summary>
+        /// Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// Unless you&apos;re using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they&apos;ve connected.
+        /// </summary>
         public async Task<ConnectWebview> GetAsync(string connectWebviewId = default)
         {
             return (await GetAsync(new GetRequest(connectWebviewId: connectWebviewId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Connect Webviews.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -667,21 +806,39 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Custom metadata pairs by which you want to [filter Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata). Returns Connect Webviews with `custom_metadata` that contains all of the provided key:value pairs.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list connect webviews.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned Connect Webviews to include all records that satisfy a partial match using `connect_webview_id`, `accepted_providers`, `custom_metadata`, or `customer_key`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user by which you want to filter Connect Webviews.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -716,6 +873,9 @@ namespace Seam.Api
                 ConnectWebviews = connectWebviews;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "connect_webviews", IsRequired = false, EmitDefaultValue = false)]
             public List<ConnectWebview> ConnectWebviews { get; set; }
 
@@ -739,6 +899,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).
+        /// </summary>
         public List<ConnectWebview> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -748,6 +911,9 @@ namespace Seam.Api
                 .Data.ConnectWebviews;
         }
 
+        /// <summary>
+        /// Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).
+        /// </summary>
         public List<ConnectWebview> List(
             object? customMetadataHas = default,
             string? customerKey = default,
@@ -769,6 +935,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).
+        /// </summary>
         public async Task<List<ConnectWebview>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -778,6 +947,9 @@ namespace Seam.Api
                 .ConnectWebviews;
         }
 
+        /// <summary>
+        /// Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).
+        /// </summary>
         public async Task<List<ConnectWebview>> ListAsync(
             object? customMetadataHas = default,
             string? customerKey = default,

--- a/output/csharp/src/Seam/Api/ConnectedAccounts.cs
+++ b/output/csharp/src/Seam/Api/ConnectedAccounts.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Connected Account.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 ConnectedAccountId = connectedAccountId;
             }
 
+            /// <summary>
+            /// ID of the connected account that you want to delete.
+            /// </summary>
             [DataMember(Name = "connected_account_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectedAccountId { get; set; }
 
@@ -52,6 +58,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        ///
+        /// Deleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.
+        ///
+        /// For example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -59,11 +72,25 @@ namespace Seam.Api
             _seam.Post<object>("/connected_accounts/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        ///
+        /// Deleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.
+        ///
+        /// For example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.
+        /// </summary>
         public void Delete(string connectedAccountId = default)
         {
             Delete(new DeleteRequest(connectedAccountId: connectedAccountId));
         }
 
+        /// <summary>
+        /// Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        ///
+        /// Deleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.
+        ///
+        /// For example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,11 +98,21 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/connected_accounts/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        ///
+        /// Deleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.
+        ///
+        /// For example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.
+        /// </summary>
         public async Task DeleteAsync(string connectedAccountId = default)
         {
             await DeleteAsync(new DeleteRequest(connectedAccountId: connectedAccountId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Connected Account.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -88,6 +125,9 @@ namespace Seam.Api
                 Email = email;
             }
 
+            /// <summary>
+            /// ID of the connected account that you want to get.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -95,6 +135,9 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Email address associated with the connected account that you want to get.
+            /// </summary>
             [DataMember(Name = "email", IsRequired = false, EmitDefaultValue = false)]
             public string? Email { get; set; }
 
@@ -129,6 +172,9 @@ namespace Seam.Api
                 ConnectedAccount = connectedAccount;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "connected_account", IsRequired = false, EmitDefaultValue = false)]
             public ConnectedAccount ConnectedAccount { get; set; }
 
@@ -152,6 +198,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public ConnectedAccount Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -161,11 +210,17 @@ namespace Seam.Api
                 .Data.ConnectedAccount;
         }
 
+        /// <summary>
+        /// Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public ConnectedAccount Get(string? connectedAccountId = default, string? email = default)
         {
             return Get(new GetRequest(connectedAccountId: connectedAccountId, email: email));
         }
 
+        /// <summary>
+        /// Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public async Task<ConnectedAccount> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -175,6 +230,9 @@ namespace Seam.Api
                 .ConnectedAccount;
         }
 
+        /// <summary>
+        /// Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public async Task<ConnectedAccount> GetAsync(
             string? connectedAccountId = default,
             string? email = default
@@ -185,6 +243,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Connected Accounts.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -210,24 +271,45 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Custom metadata pairs by which you want to filter connected accounts. Returns connected accounts with `custom_metadata` that contains all of the provided key:value pairs.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key by which you want to filter connected accounts.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public int? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned connected accounts to include all records that satisfy a partial match using `connected_account_id`, `account_type`, `customer_key`, `custom_metadata`, `user_identifier.username`, `user_identifier.email` or `user_identifier.phone`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space by which you want to filter connected accounts.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user by which you want to filter connected accounts.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -262,6 +344,9 @@ namespace Seam.Api
                 ConnectedAccounts = connectedAccounts;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "connected_accounts", IsRequired = false, EmitDefaultValue = false)]
             public List<ConnectedAccount> ConnectedAccounts { get; set; }
 
@@ -285,6 +370,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public List<ConnectedAccount> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -294,6 +382,9 @@ namespace Seam.Api
                 .Data.ConnectedAccounts;
         }
 
+        /// <summary>
+        /// Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public List<ConnectedAccount> List(
             object? customMetadataHas = default,
             string? customerKey = default,
@@ -317,6 +408,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public async Task<List<ConnectedAccount>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -326,6 +420,9 @@ namespace Seam.Api
                 .ConnectedAccounts;
         }
 
+        /// <summary>
+        /// Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public async Task<List<ConnectedAccount>> ListAsync(
             object? customMetadataHas = default,
             string? customerKey = default,
@@ -351,6 +448,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Sync a Connected Account.
+        /// </summary>
         [DataContract(Name = "syncRequest_request")]
         public class SyncRequest
         {
@@ -362,6 +462,9 @@ namespace Seam.Api
                 ConnectedAccountId = connectedAccountId;
             }
 
+            /// <summary>
+            /// ID of the connected account that you want to sync.
+            /// </summary>
             [DataMember(Name = "connected_account_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectedAccountId { get; set; }
 
@@ -385,6 +488,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Request a [connected account](https://docs.seam.co/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.
+        /// </summary>
         public void Sync(SyncRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -392,11 +498,17 @@ namespace Seam.Api
             _seam.Post<object>("/connected_accounts/sync", requestOptions);
         }
 
+        /// <summary>
+        /// Request a [connected account](https://docs.seam.co/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.
+        /// </summary>
         public void Sync(string connectedAccountId = default)
         {
             Sync(new SyncRequest(connectedAccountId: connectedAccountId));
         }
 
+        /// <summary>
+        /// Request a [connected account](https://docs.seam.co/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.
+        /// </summary>
         public async Task SyncAsync(SyncRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -404,11 +516,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/connected_accounts/sync", requestOptions);
         }
 
+        /// <summary>
+        /// Request a [connected account](https://docs.seam.co/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.
+        /// </summary>
         public async Task SyncAsync(string connectedAccountId = default)
         {
             await SyncAsync(new SyncRequest(connectedAccountId: connectedAccountId));
         }
 
+        /// <summary>
+        /// Request parameters for Update a Connected Account.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -432,6 +550,9 @@ namespace Seam.Api
                 DisplayName = displayName;
             }
 
+            /// <summary>
+            /// List of accepted device capabilities that restrict the types of devices that can be connected through this connected account. Valid values are `lock`, `thermostat`, `noise_sensor`, and `access_control`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum AcceptedCapabilitiesEnum
             {
@@ -454,6 +575,9 @@ namespace Seam.Api
                 Camera = 5,
             }
 
+            /// <summary>
+            /// List of accepted device capabilities that restrict the types of devices that can be connected through this connected account. Valid values are `lock`, `thermostat`, `noise_sensor`, and `access_control`.
+            /// </summary>
             [DataMember(
                 Name = "accepted_capabilities",
                 IsRequired = false,
@@ -461,6 +585,9 @@ namespace Seam.Api
             )]
             public List<UpdateRequest.AcceptedCapabilitiesEnum>? AcceptedCapabilities { get; set; }
 
+            /// <summary>
+            /// Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+            /// </summary>
             [DataMember(
                 Name = "automatically_manage_new_devices",
                 IsRequired = false,
@@ -468,15 +595,27 @@ namespace Seam.Api
             )]
             public bool? AutomaticallyManageNewDevices { get; set; }
 
+            /// <summary>
+            /// ID of the connected account that you want to update.
+            /// </summary>
             [DataMember(Name = "connected_account_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Custom metadata that you want to associate with the connected account. Entirely replaces the existing custom metadata object. If a new Connect Webview contains custom metadata and is used to reconnect a connected account, the custom metadata from the Connect Webview will entirely replace the entire custom metadata object on the connected account. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter connected accounts by the desired metadata](https://docs.seam.co/core-concepts/connected-accounts/filtering-connected-accounts-by-custom-metadata).
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// The customer key to associate with this connected account. If provided, the connected account and all resources under the connected account will be moved to this customer. May only be provided if the connected account is not already associated with a customer.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Human-readable name for the connected account, shown in the dashboard. For example, `Booking from Airbnb House 1`.
+            /// </summary>
             [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
             public string? DisplayName { get; set; }
 
@@ -500,6 +639,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -507,6 +649,9 @@ namespace Seam.Api
             _seam.Post<object>("/connected_accounts/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public void Update(
             List<UpdateRequest.AcceptedCapabilitiesEnum>? acceptedCapabilities = default,
             bool? automaticallyManageNewDevices = default,
@@ -528,6 +673,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -535,6 +683,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/connected_accounts/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).
+        /// </summary>
         public async Task UpdateAsync(
             List<UpdateRequest.AcceptedCapabilitiesEnum>? acceptedCapabilities = default,
             bool? automaticallyManageNewDevices = default,

--- a/output/csharp/src/Seam/Api/CredentialsAcs.cs
+++ b/output/csharp/src/Seam/Api/CredentialsAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Assign a Credential to an ACS User.
+        /// </summary>
         [DataContract(Name = "assignRequest_request")]
         public class AssignRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the credential that you want to assign to an access system user.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity to whom you want to assign a credential. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the credential belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -64,6 +76,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Assigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void Assign(AssignRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,6 +86,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/credentials/assign", requestOptions);
         }
 
+        /// <summary>
+        /// Assigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void Assign(
             string acsCredentialId = default,
             string? acsUserId = default,
@@ -86,6 +104,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Assigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task AssignAsync(AssignRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -93,6 +114,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/credentials/assign", requestOptions);
         }
 
+        /// <summary>
+        /// Assigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task AssignAsync(
             string acsCredentialId = default,
             string? acsUserId = default,
@@ -108,6 +132,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Create a Credential for an ACS User.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -145,6 +172,9 @@ namespace Seam.Api
                 VisionlineMetadata = visionlineMetadata;
             }
 
+            /// <summary>
+            /// Access method for the new credential. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum AccessMethodEnum
             {
@@ -164,15 +194,27 @@ namespace Seam.Api
                 CloudKey = 4,
             }
 
+            /// <summary>
+            /// Access method for the new credential. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+            /// </summary>
             [DataMember(Name = "access_method", IsRequired = true, EmitDefaultValue = false)]
             public CreateRequest.AccessMethodEnum AccessMethod { get; set; }
 
+            /// <summary>
+            /// ID of the access system to which the new credential belongs. You must provide either `acs_user_id` or the combination of `user_identity_id` and `acs_system_id`.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user to whom the new credential belongs. You must provide either `acs_user_id` or the combination of `user_identity_id` and `acs_system_id`.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// Set of IDs of the [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for which the new credential grants access.
+            /// </summary>
             [DataMember(
                 Name = "allowed_acs_entrance_ids",
                 IsRequired = false,
@@ -180,6 +222,9 @@ namespace Seam.Api
             )]
             public List<string>? AllowedAcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// Vostio-specific metadata for the new credential.
+            /// </summary>
             [DataMember(
                 Name = "assa_abloy_vostio_metadata",
                 IsRequired = false,
@@ -187,9 +232,15 @@ namespace Seam.Api
             )]
             public CreateRequestAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+            /// <summary>
+            /// Access (PIN) code for the new credential. There may be manufacturer-specific code restrictions. For details, see the applicable [device or system integration guide](https://docs.seam.co/device-and-system-integration-guides).
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// ACS system ID of the credential manager for the new credential.
+            /// </summary>
             [DataMember(
                 Name = "credential_manager_acs_system_id",
                 IsRequired = false,
@@ -197,9 +248,15 @@ namespace Seam.Api
             )]
             public string? CredentialManagerAcsSystemId { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new credential ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether the new credential is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+            /// </summary>
             [DataMember(
                 Name = "is_multi_phone_sync_credential",
                 IsRequired = false,
@@ -207,6 +264,9 @@ namespace Seam.Api
             )]
             public bool? IsMultiPhoneSyncCredential { get; set; }
 
+            /// <summary>
+            /// Salto Space-specific metadata for the new credential.
+            /// </summary>
             [DataMember(
                 Name = "salto_space_metadata",
                 IsRequired = false,
@@ -214,12 +274,21 @@ namespace Seam.Api
             )]
             public CreateRequestSaltoSpaceMetadata? SaltoSpaceMetadata { get; set; }
 
+            /// <summary>
+            /// Date and time at which the validity of the new credential starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// ID of the user identity to whom the new credential belongs. You must provide either `acs_user_id` or the combination of `user_identity_id` and `acs_system_id`. If the access system contains a user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the credential belongs to the access system user. If the access system does not have a corresponding user, one is created.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Visionline-specific metadata for the new credential.
+            /// </summary>
             [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestVisionlineMetadata? VisionlineMetadata { get; set; }
 
@@ -317,6 +386,9 @@ namespace Seam.Api
                 AssignNewKey = assignNewKey;
             }
 
+            /// <summary>
+            /// Indicates whether to assign a first, new card to a user. See also [Programming Salto Space Card-based Credentials](https://docs.seam.co/device-and-system-integration-guides/salto-proaccess-space-access-system/programming-salto-space-card-based-credentials).
+            /// </summary>
             [DataMember(Name = "assign_new_key", IsRequired = false, EmitDefaultValue = false)]
             public bool? AssignNewKey { get; set; }
 
@@ -437,6 +509,9 @@ namespace Seam.Api
                 AcsCredential = acsCredential;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_credential", IsRequired = false, EmitDefaultValue = false)]
             public AcsCredential AcsCredential { get; set; }
 
@@ -460,6 +535,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [credential](https://docs.seam.co/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.
+        /// </summary>
         public AcsCredential Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -469,6 +547,9 @@ namespace Seam.Api
                 .Data.AcsCredential;
         }
 
+        /// <summary>
+        /// Creates a new [credential](https://docs.seam.co/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.
+        /// </summary>
         public AcsCredential Create(
             CreateRequest.AccessMethodEnum accessMethod = default,
             string? acsSystemId = default,
@@ -504,6 +585,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [credential](https://docs.seam.co/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.
+        /// </summary>
         public async Task<AcsCredential> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -515,6 +599,9 @@ namespace Seam.Api
                 .AcsCredential;
         }
 
+        /// <summary>
+        /// Creates a new [credential](https://docs.seam.co/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.
+        /// </summary>
         public async Task<AcsCredential> CreateAsync(
             CreateRequest.AccessMethodEnum accessMethod = default,
             string? acsSystemId = default,
@@ -552,6 +639,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Credential.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -563,6 +653,9 @@ namespace Seam.Api
                 AcsCredentialId = acsCredentialId;
             }
 
+            /// <summary>
+            /// ID of the credential that you want to delete.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
@@ -586,6 +679,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -593,11 +689,17 @@ namespace Seam.Api
             _seam.Post<object>("/acs/credentials/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public void Delete(string acsCredentialId = default)
         {
             Delete(new DeleteRequest(acsCredentialId: acsCredentialId));
         }
 
+        /// <summary>
+        /// Deletes a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -605,11 +707,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/credentials/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task DeleteAsync(string acsCredentialId = default)
         {
             await DeleteAsync(new DeleteRequest(acsCredentialId: acsCredentialId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Credential.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -621,6 +729,9 @@ namespace Seam.Api
                 AcsCredentialId = acsCredentialId;
             }
 
+            /// <summary>
+            /// ID of the credential that you want to get.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
@@ -655,6 +766,9 @@ namespace Seam.Api
                 AcsCredential = acsCredential;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_credential", IsRequired = false, EmitDefaultValue = false)]
             public AcsCredential AcsCredential { get; set; }
 
@@ -678,6 +792,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public AcsCredential Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -687,11 +804,17 @@ namespace Seam.Api
                 .Data.AcsCredential;
         }
 
+        /// <summary>
+        /// Returns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public AcsCredential Get(string acsCredentialId = default)
         {
             return Get(new GetRequest(acsCredentialId: acsCredentialId));
         }
 
+        /// <summary>
+        /// Returns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task<AcsCredential> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -701,11 +824,17 @@ namespace Seam.Api
                 .AcsCredential;
         }
 
+        /// <summary>
+        /// Returns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task<AcsCredential> GetAsync(string acsCredentialId = default)
         {
             return (await GetAsync(new GetRequest(acsCredentialId: acsCredentialId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Credentials.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -733,18 +862,33 @@ namespace Seam.Api
                 Search = search;
             }
 
+            /// <summary>
+            /// ID of the access system user for which you want to retrieve all credentials.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the access system for which you want to retrieve all credentials.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all credentials.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Date and time, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, before which events to return were created.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Indicates whether you want to retrieve only multi-phone sync credentials or non-multi-phone sync credentials.
+            /// </summary>
             [DataMember(
                 Name = "is_multi_phone_sync_credential",
                 IsRequired = false,
@@ -752,12 +896,21 @@ namespace Seam.Api
             )]
             public bool? IsMultiPhoneSyncCredential { get; set; }
 
+            /// <summary>
+            /// Number of credentials to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned credentials to include all records that satisfy a partial match using `display_name`, `code`, `card_number`, `acs_user_id` or `acs_credential_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
@@ -792,6 +945,9 @@ namespace Seam.Api
                 AcsCredentials = acsCredentials;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_credentials", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsCredential> AcsCredentials { get; set; }
 
@@ -815,6 +971,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public List<AcsCredential> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -824,6 +983,9 @@ namespace Seam.Api
                 .Data.AcsCredentials;
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public List<AcsCredential> List(
             string? acsUserId = default,
             string? acsSystemId = default,
@@ -849,6 +1011,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task<List<AcsCredential>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -858,6 +1023,9 @@ namespace Seam.Api
                 .AcsCredentials;
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task<List<AcsCredential>> ListAsync(
             string? acsUserId = default,
             string? acsSystemId = default,
@@ -885,6 +1053,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Accessible Entrances.
+        /// </summary>
         [DataContract(Name = "listAccessibleEntrancesRequest_request")]
         public class ListAccessibleEntrancesRequest
         {
@@ -896,6 +1067,9 @@ namespace Seam.Api
                 AcsCredentialId = acsCredentialId;
             }
 
+            /// <summary>
+            /// ID of the credential for which you want to retrieve all entrances to which the credential grants access.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
@@ -930,6 +1104,9 @@ namespace Seam.Api
                 AcsEntrances = acsEntrances;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsEntrance> AcsEntrances { get; set; }
 
@@ -953,6 +1130,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(ListAccessibleEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -965,6 +1145,9 @@ namespace Seam.Api
                 .Data.AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(string acsCredentialId = default)
         {
             return ListAccessibleEntrances(
@@ -972,6 +1155,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             ListAccessibleEntrancesRequest request
         )
@@ -988,6 +1174,9 @@ namespace Seam.Api
                 .AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             string acsCredentialId = default
         )
@@ -999,6 +1188,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Unassign a Credential from an ACS User.
+        /// </summary>
         [DataContract(Name = "unassignRequest_request")]
         public class UnassignRequest
         {
@@ -1016,12 +1208,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the credential that you want to unassign from an access system user.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity from which you want to unassign a credential. You can only provide one of acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -1045,6 +1246,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Unassigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void Unassign(UnassignRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1052,6 +1256,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/credentials/unassign", requestOptions);
         }
 
+        /// <summary>
+        /// Unassigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void Unassign(
             string acsCredentialId = default,
             string? acsUserId = default,
@@ -1067,6 +1274,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Unassigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task UnassignAsync(UnassignRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1074,6 +1284,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/credentials/unassign", requestOptions);
         }
 
+        /// <summary>
+        /// Unassigns a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task UnassignAsync(
             string acsCredentialId = default,
             string? acsUserId = default,
@@ -1089,6 +1302,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update a Credential.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -1106,12 +1322,21 @@ namespace Seam.Api
                 EndsAt = endsAt;
             }
 
+            /// <summary>
+            /// ID of the credential that you want to update.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// Replacement access (PIN) code for the credential that you want to update.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// Replacement date and time at which the validity of the credential ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after the `starts_at` value that you set when creating the credential.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
@@ -1135,6 +1360,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1142,6 +1370,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/credentials/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public void Update(
             string acsCredentialId = default,
             string? code = default,
@@ -1151,6 +1382,9 @@ namespace Seam.Api
             Update(new UpdateRequest(acsCredentialId: acsCredentialId, code: code, endsAt: endsAt));
         }
 
+        /// <summary>
+        /// Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1158,6 +1392,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/credentials/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task UpdateAsync(
             string acsCredentialId = default,
             string? code = default,

--- a/output/csharp/src/Seam/Api/Customers.cs
+++ b/output/csharp/src/Seam/Api/Customers.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create Customer Portal.
+        /// </summary>
         [DataContract(Name = "createPortalRequest_request")]
         public class CreatePortalRequest
         {
@@ -48,6 +51,9 @@ namespace Seam.Api
                 CustomerData = customerData;
             }
 
+            /// <summary>
+            /// The locale to use for the portal.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum LocaleEnum
             {
@@ -85,6 +91,9 @@ namespace Seam.Api
                 RuRu = 10,
             }
 
+            /// <summary>
+            /// Navigation mode for the portal. &apos;restricted&apos; tells frontend to hide navigation UI, typically used for embedded deep links.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum NavigationModeEnum
             {
@@ -98,6 +107,9 @@ namespace Seam.Api
                 Restricted = 2,
             }
 
+            /// <summary>
+            /// Filter configuration for resources based on their custom_metadata. Each filter specifies a field, operation, and value to match against resource custom_metadata.
+            /// </summary>
             [DataMember(
                 Name = "customer_resources_filters",
                 IsRequired = false,
@@ -105,6 +117,9 @@ namespace Seam.Api
             )]
             public List<CreatePortalRequestCustomerResourcesFilters>? CustomerResourcesFilters { get; set; }
 
+            /// <summary>
+            /// The ID of the customization profile to use for the portal.
+            /// </summary>
             [DataMember(
                 Name = "customization_profile_id",
                 IsRequired = false,
@@ -112,6 +127,9 @@ namespace Seam.Api
             )]
             public string? CustomizationProfileId { get; set; }
 
+            /// <summary>
+            /// Whether to exclude the option to select a locale within the portal UI.
+            /// </summary>
             [DataMember(
                 Name = "exclude_locale_picker",
                 IsRequired = false,
@@ -122,15 +140,27 @@ namespace Seam.Api
             [DataMember(Name = "features", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeatures? Features { get; set; }
 
+            /// <summary>
+            /// Whether the portal is embedded in another application.
+            /// </summary>
             [DataMember(Name = "is_embedded", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsEmbedded { get; set; }
 
+            /// <summary>
+            /// Configuration for the landing page when the portal loads.
+            /// </summary>
             [DataMember(Name = "landing_page", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestLandingPage? LandingPage { get; set; }
 
+            /// <summary>
+            /// The locale to use for the portal.
+            /// </summary>
             [DataMember(Name = "locale", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequest.LocaleEnum? Locale { get; set; }
 
+            /// <summary>
+            /// Navigation mode for the portal. &apos;restricted&apos; tells frontend to hide navigation UI, typically used for embedded deep links.
+            /// </summary>
             [DataMember(Name = "navigation_mode", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequest.NavigationModeEnum? NavigationMode { get; set; }
 
@@ -174,6 +204,9 @@ namespace Seam.Api
                 Value = value;
             }
 
+            /// <summary>
+            /// The comparison operation. Currently only &apos;=&apos; is supported.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum OperationEnum
             {
@@ -184,12 +217,21 @@ namespace Seam.Api
                 empty = 1,
             }
 
+            /// <summary>
+            /// The custom_metadata field name to filter on.
+            /// </summary>
             [DataMember(Name = "field", IsRequired = false, EmitDefaultValue = false)]
             public string? Field { get; set; }
 
+            /// <summary>
+            /// The comparison operation. Currently only &apos;=&apos; is supported.
+            /// </summary>
             [DataMember(Name = "operation", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestCustomerResourcesFilters.OperationEnum? Operation { get; set; }
 
+            /// <summary>
+            /// The value to compare against.
+            /// </summary>
             [DataMember(Name = "value", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestCustomerResourcesFiltersValue? Value { get; set; }
 
@@ -260,18 +302,36 @@ namespace Seam.Api
                 Organize = organize;
             }
 
+            /// <summary>
+            /// Configuration for the configure feature.
+            /// </summary>
             [DataMember(Name = "configure", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeaturesConfigure? Configure { get; set; }
 
+            /// <summary>
+            /// Configuration for the connect accounts feature.
+            /// </summary>
             [DataMember(Name = "connect", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeaturesConnect? Connect { get; set; }
 
+            /// <summary>
+            /// Configuration for the manage feature.
+            /// </summary>
             [DataMember(Name = "manage", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeaturesManage? Manage { get; set; }
 
+            /// <summary>
+            /// Configuration for the manage devices feature.
+            /// ---
+            /// deprecated: Use `manage` instead.
+            /// ---
+            /// </summary>
             [DataMember(Name = "manage_devices", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeaturesManageDevices? ManageDevices { get; set; }
 
+            /// <summary>
+            /// Configuration for the organize feature.
+            /// </summary>
             [DataMember(Name = "organize", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeaturesOrganize? Organize { get; set; }
 
@@ -314,6 +374,9 @@ namespace Seam.Api
                 Exclude = exclude;
             }
 
+            /// <summary>
+            /// Indicates whether the customer can customize the access automation rules for their properties.
+            /// </summary>
             [DataMember(
                 Name = "allow_access_automation_rule_customization",
                 IsRequired = false,
@@ -321,6 +384,9 @@ namespace Seam.Api
             )]
             public bool? AllowAccessAutomationRuleCustomization { get; set; }
 
+            /// <summary>
+            /// Indicates whether the customer can customize the climate automation rules for their properties.
+            /// </summary>
             [DataMember(
                 Name = "allow_climate_automation_rule_customization",
                 IsRequired = false,
@@ -328,6 +394,9 @@ namespace Seam.Api
             )]
             public bool? AllowClimateAutomationRuleCustomization { get; set; }
 
+            /// <summary>
+            /// Indicates whether the customer can customize the Instant Key profile for their properties.
+            /// </summary>
             [DataMember(
                 Name = "allow_instant_key_customization",
                 IsRequired = false,
@@ -335,6 +404,9 @@ namespace Seam.Api
             )]
             public bool? AllowInstantKeyCustomization { get; set; }
 
+            /// <summary>
+            /// Whether to exclude this feature from the portal.
+            /// </summary>
             [DataMember(Name = "exclude", IsRequired = false, EmitDefaultValue = false)]
             public bool? Exclude { get; set; }
 
@@ -375,12 +447,21 @@ namespace Seam.Api
                 ExcludedProviders = excludedProviders;
             }
 
+            /// <summary>
+            /// List of provider keys to allow for the connect feature. These providers will be shown when the customer tries to connect an account.
+            /// </summary>
             [DataMember(Name = "accepted_providers", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcceptedProviders { get; set; }
 
+            /// <summary>
+            /// Whether to exclude this feature from the portal.
+            /// </summary>
             [DataMember(Name = "exclude", IsRequired = false, EmitDefaultValue = false)]
             public bool? Exclude { get; set; }
 
+            /// <summary>
+            /// List of provider keys to exclude from the connect feature. These providers will not be shown when the customer tries to connect an account.
+            /// </summary>
             [DataMember(Name = "excluded_providers", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ExcludedProviders { get; set; }
 
@@ -428,6 +509,9 @@ namespace Seam.Api
                 ExcludeStaffManagement = excludeStaffManagement;
             }
 
+            /// <summary>
+            /// Custom copy for the confirmation modal shown before unmanaged devices are added to a space and begin being managed (and billed). Only takes effect when the MANAGE_DEVICES_CONFIRMATION_MODAL feature flag is enabled for the workspace. Any omitted string falls back to a localized default.
+            /// </summary>
             [DataMember(
                 Name = "device_management_confirmation",
                 IsRequired = false,
@@ -435,12 +519,21 @@ namespace Seam.Api
             )]
             public CreatePortalRequestFeaturesManageDeviceManagementConfirmation? DeviceManagementConfirmation { get; set; }
 
+            /// <summary>
+            /// Configuration for event type filtering in the manage feature.
+            /// </summary>
             [DataMember(Name = "events", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestFeaturesManageEvents? Events { get; set; }
 
+            /// <summary>
+            /// Whether to exclude this feature from the portal.
+            /// </summary>
             [DataMember(Name = "exclude", IsRequired = false, EmitDefaultValue = false)]
             public bool? Exclude { get; set; }
 
+            /// <summary>
+            /// Indicates whether the customer can manage reservations for their properties.
+            /// </summary>
             [DataMember(
                 Name = "exclude_reservation_management",
                 IsRequired = false,
@@ -448,6 +541,9 @@ namespace Seam.Api
             )]
             public bool? ExcludeReservationManagement { get; set; }
 
+            /// <summary>
+            /// Indicates whether to exclude technical details from reservation views.
+            /// </summary>
             [DataMember(
                 Name = "exclude_reservation_technical_details",
                 IsRequired = false,
@@ -455,6 +551,9 @@ namespace Seam.Api
             )]
             public bool? ExcludeReservationTechnicalDetails { get; set; }
 
+            /// <summary>
+            /// Indicates whether the customer can manage staff for their properties.
+            /// </summary>
             [DataMember(
                 Name = "exclude_staff_management",
                 IsRequired = false,
@@ -501,12 +600,21 @@ namespace Seam.Api
                 Title = title;
             }
 
+            /// <summary>
+            /// Custom body text for the confirmation modal. May include the {count} token, which is replaced with the number of devices that will begin being managed.
+            /// </summary>
             [DataMember(Name = "body", IsRequired = false, EmitDefaultValue = false)]
             public string? Body { get; set; }
 
+            /// <summary>
+            /// Custom label for the cancel button.
+            /// </summary>
             [DataMember(Name = "cancel_button_label", IsRequired = false, EmitDefaultValue = false)]
             public string? CancelButtonLabel { get; set; }
 
+            /// <summary>
+            /// Custom label for the confirm button.
+            /// </summary>
             [DataMember(
                 Name = "confirm_button_label",
                 IsRequired = false,
@@ -514,6 +622,9 @@ namespace Seam.Api
             )]
             public string? ConfirmButtonLabel { get; set; }
 
+            /// <summary>
+            /// Custom title for the confirmation modal.
+            /// </summary>
             [DataMember(Name = "title", IsRequired = false, EmitDefaultValue = false)]
             public string? Title { get; set; }
 
@@ -552,9 +663,15 @@ namespace Seam.Api
                 DefaultEvents = defaultEvents;
             }
 
+            /// <summary>
+            /// List of event types to show in the events filter. When set, only these event types will be available. Leave empty to show all events.
+            /// </summary>
             [DataMember(Name = "allowed_events", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AllowedEvents { get; set; }
 
+            /// <summary>
+            /// List of event types that are pre-selected in the events filter when the user first loads the events tab.
+            /// </summary>
             [DataMember(Name = "default_events", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DefaultEvents { get; set; }
 
@@ -589,6 +706,9 @@ namespace Seam.Api
                 Exclude = exclude;
             }
 
+            /// <summary>
+            /// Whether to exclude this feature from the portal.
+            /// </summary>
             [DataMember(Name = "exclude", IsRequired = false, EmitDefaultValue = false)]
             public bool? Exclude { get; set; }
 
@@ -623,6 +743,9 @@ namespace Seam.Api
                 Exclude = exclude;
             }
 
+            /// <summary>
+            /// Whether to exclude this feature from the portal.
+            /// </summary>
             [DataMember(Name = "exclude", IsRequired = false, EmitDefaultValue = false)]
             public bool? Exclude { get; set; }
 
@@ -833,63 +956,123 @@ namespace Seam.Api
                 Users = users;
             }
 
+            /// <summary>
+            /// List of access grants.
+            /// </summary>
             [DataMember(Name = "access_grants", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataAccessGrants>? AccessGrants { get; set; }
 
+            /// <summary>
+            /// List of bookings.
+            /// </summary>
             [DataMember(Name = "bookings", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataBookings>? Bookings { get; set; }
 
+            /// <summary>
+            /// List of buildings.
+            /// </summary>
             [DataMember(Name = "buildings", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataBuildings>? Buildings { get; set; }
 
+            /// <summary>
+            /// List of shared common areas.
+            /// </summary>
             [DataMember(Name = "common_areas", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataCommonAreas>? CommonAreas { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the customer.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// List of gym or fitness facilities.
+            /// </summary>
             [DataMember(Name = "facilities", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataFacilities>? Facilities { get; set; }
 
+            /// <summary>
+            /// List of guests.
+            /// </summary>
             [DataMember(Name = "guests", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataGuests>? Guests { get; set; }
 
+            /// <summary>
+            /// List of property listings.
+            /// </summary>
             [DataMember(Name = "listings", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataListings>? Listings { get; set; }
 
+            /// <summary>
+            /// List of short-term rental properties.
+            /// </summary>
             [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataProperties>? Properties { get; set; }
 
+            /// <summary>
+            /// List of property listings.
+            /// </summary>
             [DataMember(Name = "property_listings", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataPropertyListings>? PropertyListings { get; set; }
 
+            /// <summary>
+            /// List of reservations.
+            /// </summary>
             [DataMember(Name = "reservations", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataReservations>? Reservations { get; set; }
 
+            /// <summary>
+            /// List of residents.
+            /// </summary>
             [DataMember(Name = "residents", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataResidents>? Residents { get; set; }
 
+            /// <summary>
+            /// List of hotel or hospitality rooms.
+            /// </summary>
             [DataMember(Name = "rooms", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataRooms>? Rooms { get; set; }
 
+            /// <summary>
+            /// List of general sites or areas.
+            /// </summary>
             [DataMember(Name = "sites", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataSites>? Sites { get; set; }
 
+            /// <summary>
+            /// List of general spaces or areas.
+            /// </summary>
             [DataMember(Name = "spaces", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataSpaces>? Spaces { get; set; }
 
+            /// <summary>
+            /// List of staff members.
+            /// </summary>
             [DataMember(Name = "staff_members", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataStaffMembers>? StaffMembers { get; set; }
 
+            /// <summary>
+            /// List of tenants.
+            /// </summary>
             [DataMember(Name = "tenants", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataTenants>? Tenants { get; set; }
 
+            /// <summary>
+            /// List of multi-family residential units.
+            /// </summary>
             [DataMember(Name = "units", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataUnits>? Units { get; set; }
 
+            /// <summary>
+            /// List of user identities.
+            /// </summary>
             [DataMember(Name = "user_identities", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataUserIdentities>? UserIdentities { get; set; }
 
+            /// <summary>
+            /// List of users.
+            /// </summary>
             [DataMember(Name = "users", IsRequired = false, EmitDefaultValue = false)]
             public List<CreatePortalRequestCustomerDataUsers>? Users { get; set; }
 
@@ -960,57 +1143,111 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Your unique identifier for the access grant.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// Building keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// Common area keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Ending date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Facility keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// Guest key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Listing keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your name for this access grant resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Preferred PIN code to use when creating access for this reservation.
+            /// </summary>
             [DataMember(Name = "preferred_code", IsRequired = false, EmitDefaultValue = false)]
             public string? PreferredCode { get; set; }
 
+            /// <summary>
+            /// Property keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// Resident key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
+            /// <summary>
+            /// Room keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// Space keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Starting date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Tenant key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
+            /// <summary>
+            /// Unit keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// User identity key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
+            /// <summary>
+            /// User key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -1081,57 +1318,111 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Your unique identifier for the booking.
+            /// </summary>
             [DataMember(Name = "booking_key", IsRequired = false, EmitDefaultValue = false)]
             public string? BookingKey { get; set; }
 
+            /// <summary>
+            /// Building keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// Common area keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Ending date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Facility keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// Guest key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Listing keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your name for this access grant resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Preferred PIN code to use when creating access for this reservation.
+            /// </summary>
             [DataMember(Name = "preferred_code", IsRequired = false, EmitDefaultValue = false)]
             public string? PreferredCode { get; set; }
 
+            /// <summary>
+            /// Property keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// Resident key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
+            /// <summary>
+            /// Room keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// Space keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Starting date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Tenant key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
+            /// <summary>
+            /// Unit keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// User identity key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
+            /// <summary>
+            /// User key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -1170,9 +1461,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Your unique identifier for the building.
+            /// </summary>
             [DataMember(Name = "building_key", IsRequired = false, EmitDefaultValue = false)]
             public string? BuildingKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -1213,12 +1510,21 @@ namespace Seam.Api
                 ParentSiteKey = parentSiteKey;
             }
 
+            /// <summary>
+            /// Your unique identifier for the common area.
+            /// </summary>
             [DataMember(Name = "common_area_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CommonAreaKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
@@ -1257,9 +1563,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Your unique identifier for the facility.
+            /// </summary>
             [DataMember(Name = "facility_key", IsRequired = false, EmitDefaultValue = false)]
             public string? FacilityKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -1302,15 +1614,27 @@ namespace Seam.Api
                 PhoneNumber = phoneNumber;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the guest.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
@@ -1349,9 +1673,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Your unique identifier for the listing.
+            /// </summary>
             [DataMember(Name = "listing_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ListingKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -1390,9 +1720,15 @@ namespace Seam.Api
                 PropertyKey = propertyKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the property.
+            /// </summary>
             [DataMember(Name = "property_key", IsRequired = false, EmitDefaultValue = false)]
             public string? PropertyKey { get; set; }
 
@@ -1433,12 +1769,21 @@ namespace Seam.Api
                 PropertyListingKey = propertyListingKey;
             }
 
+            /// <summary>
+            /// Set key:value pairs. Accepts string or Boolean values. Adding custom metadata to a property listing enables you to store custom information, like customer details or internal IDs from your application.
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the property listing.
+            /// </summary>
             [DataMember(
                 Name = "property_listing_key",
                 IsRequired = false,
@@ -1515,60 +1860,117 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Building keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// Common area keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Set key:value pairs for filtering reservations by custom criteria.
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// Ending date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Facility keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// Guest key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Listing keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your name for this access grant resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Preferred PIN code to use when creating access for this reservation.
+            /// </summary>
             [DataMember(Name = "preferred_code", IsRequired = false, EmitDefaultValue = false)]
             public string? PreferredCode { get; set; }
 
+            /// <summary>
+            /// Property keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the reservation.
+            /// </summary>
             [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ReservationKey { get; set; }
 
+            /// <summary>
+            /// Resident key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
+            /// <summary>
+            /// Room keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// Space keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Starting date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Tenant key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
+            /// <summary>
+            /// Unit keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// User identity key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
+            /// <summary>
+            /// User key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -1611,15 +2013,27 @@ namespace Seam.Api
                 ResidentKey = residentKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the resident.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
@@ -1660,12 +2074,21 @@ namespace Seam.Api
                 RoomKey = roomKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the room.
+            /// </summary>
             [DataMember(Name = "room_key", IsRequired = false, EmitDefaultValue = false)]
             public string? RoomKey { get; set; }
 
@@ -1704,9 +2127,15 @@ namespace Seam.Api
                 SiteKey = siteKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SiteKey { get; set; }
 
@@ -1753,21 +2182,39 @@ namespace Seam.Api
                 SpaceKey = spaceKey;
             }
 
+            /// <summary>
+            /// Reservation/stay-related defaults for the space (time zone, default check-in/out times, address).
+            /// </summary>
             [DataMember(Name = "customer_data", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestCustomerDataSpacesCustomerData? CustomerData { get; set; }
 
+            /// <summary>
+            /// Default duration of this space in minutes, when the space represents a fixed-length bookable slot (e.g. an appointment type). Used to interpret reservations booked against this space.
+            /// </summary>
             [DataMember(Name = "duration_minutes", IsRequired = false, EmitDefaultValue = false)]
             public int? DurationMinutes { get; set; }
 
+            /// <summary>
+            /// Geographic coordinates (latitude and longitude) of the space.
+            /// </summary>
             [DataMember(Name = "geolocation", IsRequired = false, EmitDefaultValue = false)]
             public CreatePortalRequestCustomerDataSpacesGeolocation? Geolocation { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the space.
+            /// </summary>
             [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceKey { get; set; }
 
@@ -1810,9 +2257,15 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// Postal address for the space.
+            /// </summary>
             [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
             public string? Address { get; set; }
 
+            /// <summary>
+            /// Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkin_time",
                 IsRequired = false,
@@ -1820,6 +2273,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckinTime { get; set; }
 
+            /// <summary>
+            /// Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkout_time",
                 IsRequired = false,
@@ -1827,6 +2283,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckoutTime { get; set; }
 
+            /// <summary>
+            /// IANA time zone for the space, e.g. America/Los_Angeles.
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public string? TimeZone { get; set; }
 
@@ -1865,9 +2324,15 @@ namespace Seam.Api
                 Longitude = longitude;
             }
 
+            /// <summary>
+            /// Latitude of the space, in decimal degrees.
+            /// </summary>
             [DataMember(Name = "latitude", IsRequired = false, EmitDefaultValue = false)]
             public float? Latitude { get; set; }
 
+            /// <summary>
+            /// Longitude of the space, in decimal degrees.
+            /// </summary>
             [DataMember(Name = "longitude", IsRequired = false, EmitDefaultValue = false)]
             public float? Longitude { get; set; }
 
@@ -1930,30 +2395,57 @@ namespace Seam.Api
                 UnitKeys = unitKeys;
             }
 
+            /// <summary>
+            /// List of unique identifiers for the buildings the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the common areas the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the facilities the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the listings the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the properties the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the property listings the staff member is associated with.
+            /// </summary>
             [DataMember(
                 Name = "property_listing_keys",
                 IsRequired = false,
@@ -1961,18 +2453,33 @@ namespace Seam.Api
             )]
             public List<string>? PropertyListingKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the rooms the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the sites the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "site_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SiteKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the spaces the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the staff.
+            /// </summary>
             [DataMember(Name = "staff_member_key", IsRequired = false, EmitDefaultValue = false)]
             public string? StaffMemberKey { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the units the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
@@ -2015,15 +2522,27 @@ namespace Seam.Api
                 TenantKey = tenantKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the tenant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
@@ -2064,12 +2583,21 @@ namespace Seam.Api
                 UnitKey = unitKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the unit.
+            /// </summary>
             [DataMember(Name = "unit_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UnitKey { get; set; }
 
@@ -2112,15 +2640,27 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the user identity.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -2163,15 +2703,27 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the user.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -2206,6 +2758,9 @@ namespace Seam.Api
                 CustomerPortal = customerPortal;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "customer_portal", IsRequired = false, EmitDefaultValue = false)]
             public CustomerPortal CustomerPortal { get; set; }
 
@@ -2229,6 +2784,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new customer portal magic link with configurable features.
+        /// </summary>
         public CustomerPortal CreatePortal(CreatePortalRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2238,6 +2796,9 @@ namespace Seam.Api
                 .Data.CustomerPortal;
         }
 
+        /// <summary>
+        /// Creates a new customer portal magic link with configurable features.
+        /// </summary>
         public CustomerPortal CreatePortal(
             List<CreatePortalRequestCustomerResourcesFilters>? customerResourcesFilters = default,
             string? customizationProfileId = default,
@@ -2265,6 +2826,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new customer portal magic link with configurable features.
+        /// </summary>
         public async Task<CustomerPortal> CreatePortalAsync(CreatePortalRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2279,6 +2843,9 @@ namespace Seam.Api
                 .CustomerPortal;
         }
 
+        /// <summary>
+        /// Creates a new customer portal magic link with configurable features.
+        /// </summary>
         public async Task<CustomerPortal> CreatePortalAsync(
             List<CreatePortalRequestCustomerResourcesFilters>? customerResourcesFilters = default,
             string? customizationProfileId = default,
@@ -2308,6 +2875,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete Customer Data.
+        /// </summary>
         [DataContract(Name = "deleteDataRequest_request")]
         public class DeleteDataRequest
         {
@@ -2357,33 +2927,63 @@ namespace Seam.Api
                 UserKeys = userKeys;
             }
 
+            /// <summary>
+            /// List of access grant keys to delete.
+            /// </summary>
             [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessGrantKeys { get; set; }
 
+            /// <summary>
+            /// List of booking keys to delete.
+            /// </summary>
             [DataMember(Name = "booking_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BookingKeys { get; set; }
 
+            /// <summary>
+            /// List of building keys to delete.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// List of common area keys to delete.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// List of customer keys to delete all data for.
+            /// </summary>
             [DataMember(Name = "customer_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CustomerKeys { get; set; }
 
+            /// <summary>
+            /// List of facility keys to delete.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// List of guest keys to delete.
+            /// </summary>
             [DataMember(Name = "guest_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? GuestKeys { get; set; }
 
+            /// <summary>
+            /// List of listing keys to delete.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// List of property keys to delete.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// List of property listing keys to delete.
+            /// </summary>
             [DataMember(
                 Name = "property_listing_keys",
                 IsRequired = false,
@@ -2391,30 +2991,57 @@ namespace Seam.Api
             )]
             public List<string>? PropertyListingKeys { get; set; }
 
+            /// <summary>
+            /// List of reservation keys to delete.
+            /// </summary>
             [DataMember(Name = "reservation_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ReservationKeys { get; set; }
 
+            /// <summary>
+            /// List of resident keys to delete.
+            /// </summary>
             [DataMember(Name = "resident_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ResidentKeys { get; set; }
 
+            /// <summary>
+            /// List of room keys to delete.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// List of space keys to delete.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// List of staff member keys to delete.
+            /// </summary>
             [DataMember(Name = "staff_member_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? StaffMemberKeys { get; set; }
 
+            /// <summary>
+            /// List of tenant keys to delete.
+            /// </summary>
             [DataMember(Name = "tenant_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? TenantKeys { get; set; }
 
+            /// <summary>
+            /// List of unit keys to delete.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// List of user identity keys to delete.
+            /// </summary>
             [DataMember(Name = "user_identity_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UserIdentityKeys { get; set; }
 
+            /// <summary>
+            /// List of user keys to delete.
+            /// </summary>
             [DataMember(Name = "user_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UserKeys { get; set; }
 
@@ -2438,6 +3065,10 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes customer data including resources like spaces, properties, rooms, users, etc.
+        /// This will delete the partner resources and any related Seam resources (user identities, access grants, spaces).
+        /// </summary>
         public void DeleteData(DeleteDataRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2445,6 +3076,10 @@ namespace Seam.Api
             _seam.Post<object>("/customers/delete_data", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes customer data including resources like spaces, properties, rooms, users, etc.
+        /// This will delete the partner resources and any related Seam resources (user identities, access grants, spaces).
+        /// </summary>
         public void DeleteData(
             List<string>? accessGrantKeys = default,
             List<string>? bookingKeys = default,
@@ -2492,6 +3127,10 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Deletes customer data including resources like spaces, properties, rooms, users, etc.
+        /// This will delete the partner resources and any related Seam resources (user identities, access grants, spaces).
+        /// </summary>
         public async Task DeleteDataAsync(DeleteDataRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2499,6 +3138,10 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/customers/delete_data", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes customer data including resources like spaces, properties, rooms, users, etc.
+        /// This will delete the partner resources and any related Seam resources (user identities, access grants, spaces).
+        /// </summary>
         public async Task DeleteDataAsync(
             List<string>? accessGrantKeys = default,
             List<string>? bookingKeys = default,
@@ -2546,6 +3189,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Push Customer Data.
+        /// </summary>
         [DataContract(Name = "pushDataRequest_request")]
         public class PushDataRequest
         {
@@ -2597,63 +3243,123 @@ namespace Seam.Api
                 Users = users;
             }
 
+            /// <summary>
+            /// List of access grants.
+            /// </summary>
             [DataMember(Name = "access_grants", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestAccessGrants>? AccessGrants { get; set; }
 
+            /// <summary>
+            /// List of bookings.
+            /// </summary>
             [DataMember(Name = "bookings", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestBookings>? Bookings { get; set; }
 
+            /// <summary>
+            /// List of buildings.
+            /// </summary>
             [DataMember(Name = "buildings", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestBuildings>? Buildings { get; set; }
 
+            /// <summary>
+            /// List of shared common areas.
+            /// </summary>
             [DataMember(Name = "common_areas", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestCommonAreas>? CommonAreas { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the customer.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = true, EmitDefaultValue = false)]
             public string CustomerKey { get; set; }
 
+            /// <summary>
+            /// List of gym or fitness facilities.
+            /// </summary>
             [DataMember(Name = "facilities", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestFacilities>? Facilities { get; set; }
 
+            /// <summary>
+            /// List of guests.
+            /// </summary>
             [DataMember(Name = "guests", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestGuests>? Guests { get; set; }
 
+            /// <summary>
+            /// List of property listings.
+            /// </summary>
             [DataMember(Name = "listings", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestListings>? Listings { get; set; }
 
+            /// <summary>
+            /// List of short-term rental properties.
+            /// </summary>
             [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestProperties>? Properties { get; set; }
 
+            /// <summary>
+            /// List of property listings.
+            /// </summary>
             [DataMember(Name = "property_listings", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestPropertyListings>? PropertyListings { get; set; }
 
+            /// <summary>
+            /// List of reservations.
+            /// </summary>
             [DataMember(Name = "reservations", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestReservations>? Reservations { get; set; }
 
+            /// <summary>
+            /// List of residents.
+            /// </summary>
             [DataMember(Name = "residents", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestResidents>? Residents { get; set; }
 
+            /// <summary>
+            /// List of hotel or hospitality rooms.
+            /// </summary>
             [DataMember(Name = "rooms", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestRooms>? Rooms { get; set; }
 
+            /// <summary>
+            /// List of general sites or areas.
+            /// </summary>
             [DataMember(Name = "sites", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestSites>? Sites { get; set; }
 
+            /// <summary>
+            /// List of general spaces or areas.
+            /// </summary>
             [DataMember(Name = "spaces", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestSpaces>? Spaces { get; set; }
 
+            /// <summary>
+            /// List of staff members.
+            /// </summary>
             [DataMember(Name = "staff_members", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestStaffMembers>? StaffMembers { get; set; }
 
+            /// <summary>
+            /// List of tenants.
+            /// </summary>
             [DataMember(Name = "tenants", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestTenants>? Tenants { get; set; }
 
+            /// <summary>
+            /// List of multi-family residential units.
+            /// </summary>
             [DataMember(Name = "units", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestUnits>? Units { get; set; }
 
+            /// <summary>
+            /// List of user identities.
+            /// </summary>
             [DataMember(Name = "user_identities", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestUserIdentities>? UserIdentities { get; set; }
 
+            /// <summary>
+            /// List of users.
+            /// </summary>
             [DataMember(Name = "users", IsRequired = false, EmitDefaultValue = false)]
             public List<PushDataRequestUsers>? Users { get; set; }
 
@@ -2724,57 +3430,111 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Your unique identifier for the access grant.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// Building keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// Common area keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Ending date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Facility keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// Guest key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Listing keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your name for this access grant resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Preferred PIN code to use when creating access for this reservation.
+            /// </summary>
             [DataMember(Name = "preferred_code", IsRequired = false, EmitDefaultValue = false)]
             public string? PreferredCode { get; set; }
 
+            /// <summary>
+            /// Property keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// Resident key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
+            /// <summary>
+            /// Room keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// Space keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Starting date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Tenant key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
+            /// <summary>
+            /// Unit keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// User identity key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
+            /// <summary>
+            /// User key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -2845,57 +3605,111 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Your unique identifier for the booking.
+            /// </summary>
             [DataMember(Name = "booking_key", IsRequired = false, EmitDefaultValue = false)]
             public string? BookingKey { get; set; }
 
+            /// <summary>
+            /// Building keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// Common area keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Ending date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Facility keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// Guest key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Listing keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your name for this access grant resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Preferred PIN code to use when creating access for this reservation.
+            /// </summary>
             [DataMember(Name = "preferred_code", IsRequired = false, EmitDefaultValue = false)]
             public string? PreferredCode { get; set; }
 
+            /// <summary>
+            /// Property keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// Resident key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
+            /// <summary>
+            /// Room keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// Space keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Starting date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Tenant key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
+            /// <summary>
+            /// Unit keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// User identity key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
+            /// <summary>
+            /// User key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -2931,9 +3745,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Your unique identifier for the building.
+            /// </summary>
             [DataMember(Name = "building_key", IsRequired = false, EmitDefaultValue = false)]
             public string? BuildingKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -2974,12 +3794,21 @@ namespace Seam.Api
                 ParentSiteKey = parentSiteKey;
             }
 
+            /// <summary>
+            /// Your unique identifier for the common area.
+            /// </summary>
             [DataMember(Name = "common_area_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CommonAreaKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
@@ -3015,9 +3844,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Your unique identifier for the facility.
+            /// </summary>
             [DataMember(Name = "facility_key", IsRequired = false, EmitDefaultValue = false)]
             public string? FacilityKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -3060,15 +3895,27 @@ namespace Seam.Api
                 PhoneNumber = phoneNumber;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the guest.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
@@ -3104,9 +3951,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Your unique identifier for the listing.
+            /// </summary>
             [DataMember(Name = "listing_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ListingKey { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -3142,9 +3995,15 @@ namespace Seam.Api
                 PropertyKey = propertyKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the property.
+            /// </summary>
             [DataMember(Name = "property_key", IsRequired = false, EmitDefaultValue = false)]
             public string? PropertyKey { get; set; }
 
@@ -3185,12 +4044,21 @@ namespace Seam.Api
                 PropertyListingKey = propertyListingKey;
             }
 
+            /// <summary>
+            /// Set key:value pairs. Accepts string or Boolean values. Adding custom metadata to a property listing enables you to store custom information, like customer details or internal IDs from your application.
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the property listing.
+            /// </summary>
             [DataMember(
                 Name = "property_listing_key",
                 IsRequired = false,
@@ -3267,60 +4135,117 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Building keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// Common area keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Set key:value pairs for filtering reservations by custom criteria.
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// Ending date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Facility keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// Guest key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "guest_key", IsRequired = false, EmitDefaultValue = false)]
             public string? GuestKey { get; set; }
 
+            /// <summary>
+            /// Listing keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your name for this access grant resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Preferred PIN code to use when creating access for this reservation.
+            /// </summary>
             [DataMember(Name = "preferred_code", IsRequired = false, EmitDefaultValue = false)]
             public string? PreferredCode { get; set; }
 
+            /// <summary>
+            /// Property keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the reservation.
+            /// </summary>
             [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ReservationKey { get; set; }
 
+            /// <summary>
+            /// Resident key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
+            /// <summary>
+            /// Room keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// Space keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Starting date and time for the access grant.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// Tenant key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
+            /// <summary>
+            /// Unit keys associated with the access grant.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
+            /// <summary>
+            /// User identity key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
+            /// <summary>
+            /// User key associated with the access grant.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -3363,15 +4288,27 @@ namespace Seam.Api
                 ResidentKey = residentKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the resident.
+            /// </summary>
             [DataMember(Name = "resident_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ResidentKey { get; set; }
 
@@ -3412,12 +4349,21 @@ namespace Seam.Api
                 RoomKey = roomKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the room.
+            /// </summary>
             [DataMember(Name = "room_key", IsRequired = false, EmitDefaultValue = false)]
             public string? RoomKey { get; set; }
 
@@ -3453,9 +4399,15 @@ namespace Seam.Api
                 SiteKey = siteKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SiteKey { get; set; }
 
@@ -3502,21 +4454,39 @@ namespace Seam.Api
                 SpaceKey = spaceKey;
             }
 
+            /// <summary>
+            /// Reservation/stay-related defaults for the space (time zone, default check-in/out times, address).
+            /// </summary>
             [DataMember(Name = "customer_data", IsRequired = false, EmitDefaultValue = false)]
             public PushDataRequestSpacesCustomerData? CustomerData { get; set; }
 
+            /// <summary>
+            /// Default duration of this space in minutes, when the space represents a fixed-length bookable slot (e.g. an appointment type). Used to interpret reservations booked against this space.
+            /// </summary>
             [DataMember(Name = "duration_minutes", IsRequired = false, EmitDefaultValue = false)]
             public int? DurationMinutes { get; set; }
 
+            /// <summary>
+            /// Geographic coordinates (latitude and longitude) of the space.
+            /// </summary>
             [DataMember(Name = "geolocation", IsRequired = false, EmitDefaultValue = false)]
             public PushDataRequestSpacesGeolocation? Geolocation { get; set; }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the space.
+            /// </summary>
             [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceKey { get; set; }
 
@@ -3559,9 +4529,15 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// Postal address for the space.
+            /// </summary>
             [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
             public string? Address { get; set; }
 
+            /// <summary>
+            /// Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkin_time",
                 IsRequired = false,
@@ -3569,6 +4545,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckinTime { get; set; }
 
+            /// <summary>
+            /// Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkout_time",
                 IsRequired = false,
@@ -3576,6 +4555,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckoutTime { get; set; }
 
+            /// <summary>
+            /// IANA time zone for the space, e.g. America/Los_Angeles.
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public string? TimeZone { get; set; }
 
@@ -3614,9 +4596,15 @@ namespace Seam.Api
                 Longitude = longitude;
             }
 
+            /// <summary>
+            /// Latitude of the space, in decimal degrees.
+            /// </summary>
             [DataMember(Name = "latitude", IsRequired = false, EmitDefaultValue = false)]
             public float? Latitude { get; set; }
 
+            /// <summary>
+            /// Longitude of the space, in decimal degrees.
+            /// </summary>
             [DataMember(Name = "longitude", IsRequired = false, EmitDefaultValue = false)]
             public float? Longitude { get; set; }
 
@@ -3679,30 +4667,57 @@ namespace Seam.Api
                 UnitKeys = unitKeys;
             }
 
+            /// <summary>
+            /// List of unique identifiers for the buildings the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "building_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? BuildingKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the common areas the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "common_area_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? CommonAreaKeys { get; set; }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the facilities the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "facility_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? FacilityKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the listings the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "listing_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? ListingKeys { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the properties the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "property_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? PropertyKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the property listings the staff member is associated with.
+            /// </summary>
             [DataMember(
                 Name = "property_listing_keys",
                 IsRequired = false,
@@ -3710,18 +4725,33 @@ namespace Seam.Api
             )]
             public List<string>? PropertyListingKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the rooms the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "room_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? RoomKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the sites the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "site_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SiteKeys { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the spaces the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the staff.
+            /// </summary>
             [DataMember(Name = "staff_member_key", IsRequired = false, EmitDefaultValue = false)]
             public string? StaffMemberKey { get; set; }
 
+            /// <summary>
+            /// List of unique identifiers for the units the staff member is associated with.
+            /// </summary>
             [DataMember(Name = "unit_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UnitKeys { get; set; }
 
@@ -3764,15 +4794,27 @@ namespace Seam.Api
                 TenantKey = tenantKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the tenant.
+            /// </summary>
             [DataMember(Name = "tenant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? TenantKey { get; set; }
 
@@ -3813,12 +4855,21 @@ namespace Seam.Api
                 UnitKey = unitKey;
             }
 
+            /// <summary>
+            /// Your display name for this location resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the site.
+            /// </summary>
             [DataMember(Name = "parent_site_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ParentSiteKey { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the unit.
+            /// </summary>
             [DataMember(Name = "unit_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UnitKey { get; set; }
 
@@ -3861,15 +4912,27 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the user identity.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -3912,15 +4975,27 @@ namespace Seam.Api
                 UserKey = userKey;
             }
 
+            /// <summary>
+            /// Email address associated with the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Your display name for this user identity resource.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Phone number associated with the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Your unique identifier for the user.
+            /// </summary>
             [DataMember(Name = "user_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserKey { get; set; }
 
@@ -3944,6 +5019,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Pushes customer data including resources like spaces, properties, rooms, users, etc.
+        /// </summary>
         public void PushData(PushDataRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -3951,6 +5029,9 @@ namespace Seam.Api
             _seam.Post<object>("/customers/push_data", requestOptions);
         }
 
+        /// <summary>
+        /// Pushes customer data including resources like spaces, properties, rooms, users, etc.
+        /// </summary>
         public void PushData(
             List<PushDataRequestAccessGrants>? accessGrants = default,
             List<PushDataRequestBookings>? bookings = default,
@@ -4000,6 +5081,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Pushes customer data including resources like spaces, properties, rooms, users, etc.
+        /// </summary>
         public async Task PushDataAsync(PushDataRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -4007,6 +5091,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/customers/push_data", requestOptions);
         }
 
+        /// <summary>
+        /// Pushes customer data including resources like spaces, properties, rooms, users, etc.
+        /// </summary>
         public async Task PushDataAsync(
             List<PushDataRequestAccessGrants>? accessGrants = default,
             List<PushDataRequestBookings>? bookings = default,

--- a/output/csharp/src/Seam/Api/DailyProgramsThermostats.cs
+++ b/output/csharp/src/Seam/Api/DailyProgramsThermostats.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Thermostat Daily Program.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 Periods = periods;
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to create a daily program.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Name of the thermostat daily program.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = true, EmitDefaultValue = false)]
             public string Name { get; set; }
 
+            /// <summary>
+            /// Array of thermostat daily program periods.
+            /// </summary>
             [DataMember(Name = "periods", IsRequired = true, EmitDefaultValue = false)]
             public List<CreateRequestPeriods> Periods { get; set; }
 
@@ -79,9 +91,15 @@ namespace Seam.Api
                 StartsAtTime = startsAtTime;
             }
 
+            /// <summary>
+            /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at_time", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAtTime { get; set; }
 
@@ -116,6 +134,9 @@ namespace Seam.Api
                 ThermostatDailyProgram = thermostatDailyProgram;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(
                 Name = "thermostat_daily_program",
                 IsRequired = false,
@@ -143,6 +164,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new thermostat daily program. A daily program consists of a set of periods, where each period includes a start time and the key of a configured climate preset. Once you have defined a daily program, you can assign it to one or more days within a weekly program.
+        /// </summary>
         public ThermostatDailyProgram Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -152,6 +176,9 @@ namespace Seam.Api
                 .Data.ThermostatDailyProgram;
         }
 
+        /// <summary>
+        /// Creates a new thermostat daily program. A daily program consists of a set of periods, where each period includes a start time and the key of a configured climate preset. Once you have defined a daily program, you can assign it to one or more days within a weekly program.
+        /// </summary>
         public ThermostatDailyProgram Create(
             string deviceId = default,
             string name = default,
@@ -161,6 +188,9 @@ namespace Seam.Api
             return Create(new CreateRequest(deviceId: deviceId, name: name, periods: periods));
         }
 
+        /// <summary>
+        /// Creates a new thermostat daily program. A daily program consists of a set of periods, where each period includes a start time and the key of a configured climate preset. Once you have defined a daily program, you can assign it to one or more days within a weekly program.
+        /// </summary>
         public async Task<ThermostatDailyProgram> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -175,6 +205,9 @@ namespace Seam.Api
                 .ThermostatDailyProgram;
         }
 
+        /// <summary>
+        /// Creates a new thermostat daily program. A daily program consists of a set of periods, where each period includes a start time and the key of a configured climate preset. Once you have defined a daily program, you can assign it to one or more days within a weekly program.
+        /// </summary>
         public async Task<ThermostatDailyProgram> CreateAsync(
             string deviceId = default,
             string name = default,
@@ -188,6 +221,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Thermostat Daily Program.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -199,6 +235,9 @@ namespace Seam.Api
                 ThermostatDailyProgramId = thermostatDailyProgramId;
             }
 
+            /// <summary>
+            /// ID of the thermostat daily program that you want to delete.
+            /// </summary>
             [DataMember(
                 Name = "thermostat_daily_program_id",
                 IsRequired = true,
@@ -226,6 +265,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a thermostat daily program.
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -233,11 +275,17 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/daily_programs/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a thermostat daily program.
+        /// </summary>
         public void Delete(string thermostatDailyProgramId = default)
         {
             Delete(new DeleteRequest(thermostatDailyProgramId: thermostatDailyProgramId));
         }
 
+        /// <summary>
+        /// Deletes a thermostat daily program.
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -245,6 +293,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/daily_programs/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a thermostat daily program.
+        /// </summary>
         public async Task DeleteAsync(string thermostatDailyProgramId = default)
         {
             await DeleteAsync(
@@ -252,6 +303,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update a Thermostat Daily Program.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -269,12 +323,21 @@ namespace Seam.Api
                 ThermostatDailyProgramId = thermostatDailyProgramId;
             }
 
+            /// <summary>
+            /// Name of the thermostat daily program that you want to update.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = true, EmitDefaultValue = false)]
             public string Name { get; set; }
 
+            /// <summary>
+            /// Array of thermostat daily program periods. The periods that you specify overwrite any existing periods for the daily program.
+            /// </summary>
             [DataMember(Name = "periods", IsRequired = true, EmitDefaultValue = false)]
             public List<UpdateRequestPeriods> Periods { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program that you want to update.
+            /// </summary>
             [DataMember(
                 Name = "thermostat_daily_program_id",
                 IsRequired = true,
@@ -317,9 +380,15 @@ namespace Seam.Api
                 StartsAtTime = startsAtTime;
             }
 
+            /// <summary>
+            /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at_time", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAtTime { get; set; }
 
@@ -354,6 +423,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -377,6 +449,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified thermostat daily program. The periods that you specify overwrite any existing periods for the daily program.
+        /// </summary>
         public ActionAttempt Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -386,6 +461,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Updates a specified thermostat daily program. The periods that you specify overwrite any existing periods for the daily program.
+        /// </summary>
         public ActionAttempt Update(
             string name = default,
             List<UpdateRequestPeriods> periods = default,
@@ -401,6 +479,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified thermostat daily program. The periods that you specify overwrite any existing periods for the daily program.
+        /// </summary>
         public async Task<ActionAttempt> UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -415,6 +496,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Updates a specified thermostat daily program. The periods that you specify overwrite any existing periods for the daily program.
+        /// </summary>
         public async Task<ActionAttempt> UpdateAsync(
             string name = default,
             List<UpdateRequestPeriods> periods = default,

--- a/output/csharp/src/Seam/Api/Devices.cs
+++ b/output/csharp/src/Seam/Api/Devices.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get a Device.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -30,9 +33,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// ID of the device that you want to get.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Name of the device that you want to get.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -67,6 +76,9 @@ namespace Seam.Api
                 Device = device;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "device", IsRequired = false, EmitDefaultValue = false)]
             public Device Device { get; set; }
 
@@ -90,6 +102,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public Device Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -97,11 +114,21 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/devices/get", requestOptions).Data.Device;
         }
 
+        /// <summary>
+        /// Returns a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public Device Get(string? deviceId = default, string? name = default)
         {
             return Get(new GetRequest(deviceId: deviceId, name: name));
         }
 
+        /// <summary>
+        /// Returns a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public async Task<Device> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -109,11 +136,19 @@ namespace Seam.Api
             return (await _seam.PostAsync<GetResponse>("/devices/get", requestOptions)).Data.Device;
         }
 
+        /// <summary>
+        /// Returns a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public async Task<Device> GetAsync(string? deviceId = default, string? name = default)
         {
             return (await GetAsync(new GetRequest(deviceId: deviceId, name: name)));
         }
 
+        /// <summary>
+        /// Request parameters for List Devices.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -157,6 +192,9 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Device type for which you want to list devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypeEnum
             {
@@ -287,6 +325,9 @@ namespace Seam.Api
                 RingCamera = 41,
             }
 
+            /// <summary>
+            /// Array of device types for which you want to list devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypesEnum
             {
@@ -417,6 +458,9 @@ namespace Seam.Api
                 RingCamera = 41,
             }
 
+            /// <summary>
+            /// Manufacturer for which you want to list devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ManufacturerEnum
             {
@@ -574,9 +618,15 @@ namespace Seam.Api
                 Slack = 50,
             }
 
+            /// <summary>
+            /// ID of the Connect Webview for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -584,6 +634,9 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Array of IDs of the connected accounts for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -591,39 +644,73 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Array of device IDs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Device type for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.DeviceTypeEnum? DeviceType { get; set; }
 
+            /// <summary>
+            /// Array of device types for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_types", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequest.DeviceTypesEnum>? DeviceTypes { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of devices to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Manufacturer for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.ManufacturerEnum? Manufacturer { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(
                 Name = "unstable_location_id",
                 IsRequired = false,
@@ -631,6 +718,9 @@ namespace Seam.Api
             )]
             public string? UnstableLocationId { get; set; }
 
+            /// <summary>
+            /// Your own internal user ID for the user for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -665,6 +755,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
             public List<Device> Devices { get; set; }
 
@@ -688,6 +781,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).
+        /// </summary>
         public List<Device> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -695,6 +791,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/devices/list", requestOptions).Data.Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).
+        /// </summary>
         public List<Device> List(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -736,6 +835,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).
+        /// </summary>
         public async Task<List<Device>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -745,6 +847,9 @@ namespace Seam.Api
                 .Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).
+        /// </summary>
         public async Task<List<Device>> ListAsync(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -788,6 +893,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Device Providers.
+        /// </summary>
         [DataContract(Name = "listDeviceProvidersRequest_request")]
         public class ListDeviceProvidersRequest
         {
@@ -801,6 +909,9 @@ namespace Seam.Api
                 ProviderCategory = providerCategory;
             }
 
+            /// <summary>
+            /// Category for which you want to list providers.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ProviderCategoryEnum
             {
@@ -832,6 +943,9 @@ namespace Seam.Api
                 Connectors = 8,
             }
 
+            /// <summary>
+            /// Category for which you want to list providers.
+            /// </summary>
             [DataMember(Name = "provider_category", IsRequired = false, EmitDefaultValue = false)]
             public ListDeviceProvidersRequest.ProviderCategoryEnum? ProviderCategory { get; set; }
 
@@ -866,6 +980,9 @@ namespace Seam.Api
                 DeviceProviders = deviceProviders;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "device_providers", IsRequired = false, EmitDefaultValue = false)]
             public List<DeviceProvider> DeviceProviders { get; set; }
 
@@ -889,6 +1006,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all device providers.
+        ///
+        /// The information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.
+        ///
+        /// When you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+        /// </summary>
         public List<DeviceProvider> ListDeviceProviders(ListDeviceProvidersRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -898,6 +1022,13 @@ namespace Seam.Api
                 .Data.DeviceProviders;
         }
 
+        /// <summary>
+        /// Returns a list of all device providers.
+        ///
+        /// The information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.
+        ///
+        /// When you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+        /// </summary>
         public List<DeviceProvider> ListDeviceProviders(
             ListDeviceProvidersRequest.ProviderCategoryEnum? providerCategory = default
         )
@@ -907,6 +1038,13 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all device providers.
+        ///
+        /// The information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.
+        ///
+        /// When you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+        /// </summary>
         public async Task<List<DeviceProvider>> ListDeviceProvidersAsync(
             ListDeviceProvidersRequest request
         )
@@ -923,6 +1061,13 @@ namespace Seam.Api
                 .DeviceProviders;
         }
 
+        /// <summary>
+        /// Returns a list of all device providers.
+        ///
+        /// The information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.
+        ///
+        /// When you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+        /// </summary>
         public async Task<List<DeviceProvider>> ListDeviceProvidersAsync(
             ListDeviceProvidersRequest.ProviderCategoryEnum? providerCategory = default
         )
@@ -934,6 +1079,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Report Provider Metadata.
+        /// </summary>
         [DataContract(Name = "reportProviderMetadataRequest_request")]
         public class ReportProviderMetadataRequest
         {
@@ -947,6 +1095,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// Array of devices with provider metadata to update
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = true, EmitDefaultValue = false)]
             public List<ReportProviderMetadataRequestDevices> Devices { get; set; }
 
@@ -989,15 +1140,27 @@ namespace Seam.Api
                 UltraloqMetadata = ultraloqMetadata;
             }
 
+            /// <summary>
+            /// ID of the device to update
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Omnitec-specific metadata to update
+            /// </summary>
             [DataMember(Name = "omnitec_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ReportProviderMetadataRequestDevicesOmnitecMetadata? OmnitecMetadata { get; set; }
 
+            /// <summary>
+            /// Schlage-specific metadata to update
+            /// </summary>
             [DataMember(Name = "schlage_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ReportProviderMetadataRequestDevicesSchlageMetadata? SchlageMetadata { get; set; }
 
+            /// <summary>
+            /// Ultraloq-specific metadata to update
+            /// </summary>
             [DataMember(Name = "ultraloq_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ReportProviderMetadataRequestDevicesUltraloqMetadata? UltraloqMetadata { get; set; }
 
@@ -1034,6 +1197,9 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// IANA timezone for the Omnitec device
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum TimeZoneEnum
             {
@@ -2328,6 +2494,9 @@ namespace Seam.Api
                 PacificWallis = 429,
             }
 
+            /// <summary>
+            /// IANA timezone for the Omnitec device
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public ReportProviderMetadataRequestDevicesOmnitecMetadata.TimeZoneEnum? TimeZone { get; set; }
 
@@ -2364,6 +2533,9 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// IANA timezone for the Schlage device
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum TimeZoneEnum
             {
@@ -3658,6 +3830,9 @@ namespace Seam.Api
                 PacificWallis = 429,
             }
 
+            /// <summary>
+            /// IANA timezone for the Schlage device
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public ReportProviderMetadataRequestDevicesSchlageMetadata.TimeZoneEnum? TimeZone { get; set; }
 
@@ -3695,6 +3870,9 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// IANA timezone for the Ultraloq device
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum TimeZoneEnum
             {
@@ -4989,6 +5167,9 @@ namespace Seam.Api
                 PacificWallis = 429,
             }
 
+            /// <summary>
+            /// IANA timezone for the Ultraloq device
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public ReportProviderMetadataRequestDevicesUltraloqMetadata.TimeZoneEnum? TimeZone { get; set; }
 
@@ -5012,6 +5193,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates provider-specific metadata for devices.
+        /// </summary>
         public void ReportProviderMetadata(ReportProviderMetadataRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -5019,6 +5203,9 @@ namespace Seam.Api
             _seam.Post<object>("/devices/report_provider_metadata", requestOptions);
         }
 
+        /// <summary>
+        /// Updates provider-specific metadata for devices.
+        /// </summary>
         public void ReportProviderMetadata(
             List<ReportProviderMetadataRequestDevices> devices = default
         )
@@ -5026,6 +5213,9 @@ namespace Seam.Api
             ReportProviderMetadata(new ReportProviderMetadataRequest(devices: devices));
         }
 
+        /// <summary>
+        /// Updates provider-specific metadata for devices.
+        /// </summary>
         public async Task ReportProviderMetadataAsync(ReportProviderMetadataRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -5033,6 +5223,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/report_provider_metadata", requestOptions);
         }
 
+        /// <summary>
+        /// Updates provider-specific metadata for devices.
+        /// </summary>
         public async Task ReportProviderMetadataAsync(
             List<ReportProviderMetadataRequestDevices> devices = default
         )
@@ -5040,6 +5233,9 @@ namespace Seam.Api
             await ReportProviderMetadataAsync(new ReportProviderMetadataRequest(devices: devices));
         }
 
+        /// <summary>
+        /// Request parameters for Update a Device.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -5063,6 +5259,9 @@ namespace Seam.Api
                 Properties = properties;
             }
 
+            /// <summary>
+            /// Indicates whether the device&apos;s [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is enabled. Set to `false` to disable the pool: Seam stops refilling it and removes any backup codes that have not yet been pulled into active use.
+            /// </summary>
             [DataMember(
                 Name = "backup_access_code_pool_enabled",
                 IsRequired = false,
@@ -5070,15 +5269,27 @@ namespace Seam.Api
             )]
             public bool? BackupAccessCodePoolEnabled { get; set; }
 
+            /// <summary>
+            /// Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter devices by the desired metadata](https://docs.seam.co/core-concepts/devices/filtering-devices-by-custom-metadata).
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// ID of the device that you want to update.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Indicates whether the device is managed. To unmanage a device, set `is_managed` to `false`.
+            /// </summary>
             [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsManaged { get; set; }
 
+            /// <summary>
+            /// Name for the device.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -5116,6 +5327,9 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Name for the device.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -5139,6 +5353,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device&apos;s name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -5146,6 +5365,11 @@ namespace Seam.Api
             _seam.Post<object>("/devices/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device&apos;s name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        /// </summary>
         public void Update(
             bool? backupAccessCodePoolEnabled = default,
             object? customMetadata = default,
@@ -5167,6 +5391,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device&apos;s name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -5174,6 +5403,11 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [device](https://docs.seam.co/core-concepts/devices).
+        ///
+        /// You can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device&apos;s name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        /// </summary>
         public async Task UpdateAsync(
             bool? backupAccessCodePoolEnabled = default,
             object? customMetadata = default,

--- a/output/csharp/src/Seam/Api/EncodersAcs.cs
+++ b/output/csharp/src/Seam/Api/EncodersAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Encode a Credential.
+        /// </summary>
         [DataContract(Name = "encodeCredentialRequest_request")]
         public class EncodeCredentialRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 AcsEncoderId = acsEncoderId;
             }
 
+            /// <summary>
+            /// ID of the `access_method` to encode onto a card.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessMethodId { get; set; }
 
+            /// <summary>
+            /// ID of the `acs_credential` to encode onto a card.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// ID of the `acs_encoder` to use to encode the `acs_credential`.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
@@ -75,6 +87,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -98,6 +113,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Encodes an existing [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`
+        /// </summary>
         public ActionAttempt EncodeCredential(EncodeCredentialRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -107,6 +125,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Encodes an existing [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`
+        /// </summary>
         public ActionAttempt EncodeCredential(
             string? accessMethodId = default,
             string? acsCredentialId = default,
@@ -122,6 +143,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Encodes an existing [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`
+        /// </summary>
         public async Task<ActionAttempt> EncodeCredentialAsync(EncodeCredentialRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -136,6 +160,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Encodes an existing [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`
+        /// </summary>
         public async Task<ActionAttempt> EncodeCredentialAsync(
             string? accessMethodId = default,
             string? acsCredentialId = default,
@@ -153,6 +180,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get an Encoder.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -164,6 +194,9 @@ namespace Seam.Api
                 AcsEncoderId = acsEncoderId;
             }
 
+            /// <summary>
+            /// ID of the encoder that you want to get.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
@@ -198,6 +231,9 @@ namespace Seam.Api
                 AcsEncoder = acsEncoder;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_encoder", IsRequired = false, EmitDefaultValue = false)]
             public AcsEncoder AcsEncoder { get; set; }
 
@@ -221,6 +257,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public AcsEncoder Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -228,11 +267,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/acs/encoders/get", requestOptions).Data.AcsEncoder;
         }
 
+        /// <summary>
+        /// Returns a specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public AcsEncoder Get(string acsEncoderId = default)
         {
             return Get(new GetRequest(acsEncoderId: acsEncoderId));
         }
 
+        /// <summary>
+        /// Returns a specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<AcsEncoder> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -242,11 +287,17 @@ namespace Seam.Api
                 .AcsEncoder;
         }
 
+        /// <summary>
+        /// Returns a specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<AcsEncoder> GetAsync(string acsEncoderId = default)
         {
             return (await GetAsync(new GetRequest(acsEncoderId: acsEncoderId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Encoders.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -268,18 +319,33 @@ namespace Seam.Api
                 PageCursor = pageCursor;
             }
 
+            /// <summary>
+            /// ID of the access system for which you want to retrieve all encoders.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// IDs of the access systems for which you want to retrieve all encoders.
+            /// </summary>
             [DataMember(Name = "acs_system_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsSystemIds { get; set; }
 
+            /// <summary>
+            /// IDs of the encoders that you want to retrieve.
+            /// </summary>
             [DataMember(Name = "acs_encoder_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsEncoderIds { get; set; }
 
+            /// <summary>
+            /// Number of encoders to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
@@ -314,6 +380,9 @@ namespace Seam.Api
                 AcsEncoders = acsEncoders;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_encoders", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsEncoder> AcsEncoders { get; set; }
 
@@ -337,6 +406,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [encoders](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public List<AcsEncoder> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -344,6 +416,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/acs/encoders/list", requestOptions).Data.AcsEncoders;
         }
 
+        /// <summary>
+        /// Returns a list of all [encoders](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public List<AcsEncoder> List(
             string? acsSystemId = default,
             List<string>? acsSystemIds = default,
@@ -363,6 +438,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [encoders](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<List<AcsEncoder>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -372,6 +450,9 @@ namespace Seam.Api
                 .AcsEncoders;
         }
 
+        /// <summary>
+        /// Returns a list of all [encoders](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<List<AcsEncoder>> ListAsync(
             string? acsSystemId = default,
             List<string>? acsSystemIds = default,
@@ -393,6 +474,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Scan a Credential.
+        /// </summary>
         [DataContract(Name = "scanCredentialRequest_request")]
         public class ScanCredentialRequest
         {
@@ -408,9 +492,15 @@ namespace Seam.Api
                 SaltoKsMetadata = saltoKsMetadata;
             }
 
+            /// <summary>
+            /// ID of the encoder to use for the scan.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
+            /// <summary>
+            /// Salto KS-specific metadata for the scan action.
+            /// </summary>
             [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ScanCredentialRequestSaltoKsMetadata? SaltoKsMetadata { get; set; }
 
@@ -445,6 +535,9 @@ namespace Seam.Api
                 DetectNewTags = detectNewTags;
             }
 
+            /// <summary>
+            /// When true, activates tag registration mode on the encoder to detect new, unregistered tags. When false, only detects existing tags already registered in the system. Defaults to false.
+            /// </summary>
             [DataMember(Name = "detect_new_tags", IsRequired = false, EmitDefaultValue = false)]
             public bool? DetectNewTags { get; set; }
 
@@ -479,6 +572,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -502,6 +598,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Scans an encoded [acs_credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public ActionAttempt ScanCredential(ScanCredentialRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -511,6 +610,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Scans an encoded [acs_credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public ActionAttempt ScanCredential(
             string acsEncoderId = default,
             ScanCredentialRequestSaltoKsMetadata? saltoKsMetadata = default
@@ -524,6 +626,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Scans an encoded [acs_credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<ActionAttempt> ScanCredentialAsync(ScanCredentialRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -538,6 +643,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Scans an encoded [acs_credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         public async Task<ActionAttempt> ScanCredentialAsync(
             string acsEncoderId = default,
             ScanCredentialRequestSaltoKsMetadata? saltoKsMetadata = default
@@ -553,6 +661,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Scan to Assign a Credential.
+        /// </summary>
         [DataContract(Name = "scanToAssignCredentialRequest_request")]
         public class ScanToAssignCredentialRequest
         {
@@ -572,15 +683,27 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the `acs_encoder` to use to scan the credential.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
+            /// <summary>
+            /// ID of the `acs_user` to assign the scanned credential to.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// Salto KS-specific metadata for the scan action.
+            /// </summary>
             [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ScanToAssignCredentialRequestSaltoKsMetadata? SaltoKsMetadata { get; set; }
 
+            /// <summary>
+            /// ID of the `user_identity` to assign the scanned credential to. If the ACS system contains an ACS user linked to this user identity, it is used. Otherwise, one is created.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -615,6 +738,9 @@ namespace Seam.Api
                 DetectNewTags = detectNewTags;
             }
 
+            /// <summary>
+            /// When true, activates tag registration mode on the encoder to detect new, unregistered tags. When false, only detects existing tags already registered in the system. Defaults to false.
+            /// </summary>
             [DataMember(Name = "detect_new_tags", IsRequired = false, EmitDefaultValue = false)]
             public bool? DetectNewTags { get; set; }
 
@@ -649,6 +775,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -672,6 +801,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Scans a physical card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.
+        /// </summary>
         public ActionAttempt ScanToAssignCredential(ScanToAssignCredentialRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -684,6 +816,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Scans a physical card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.
+        /// </summary>
         public ActionAttempt ScanToAssignCredential(
             string acsEncoderId = default,
             string? acsUserId = default,
@@ -701,6 +836,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Scans a physical card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.
+        /// </summary>
         public async Task<ActionAttempt> ScanToAssignCredentialAsync(
             ScanToAssignCredentialRequest request
         )
@@ -717,6 +855,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Scans a physical card placed on the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.
+        /// </summary>
         public async Task<ActionAttempt> ScanToAssignCredentialAsync(
             string acsEncoderId = default,
             string? acsUserId = default,

--- a/output/csharp/src/Seam/Api/EntrancesAcs.cs
+++ b/output/csharp/src/Seam/Api/EntrancesAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Entrance.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 AcsEntranceId = acsEntranceId;
             }
 
+            /// <summary>
+            /// ID of the entrance that you want to get.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEntranceId { get; set; }
 
@@ -63,6 +69,9 @@ namespace Seam.Api
                 AcsEntrance = acsEntrance;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_entrance", IsRequired = false, EmitDefaultValue = false)]
             public AcsEntrance AcsEntrance { get; set; }
 
@@ -86,6 +95,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public AcsEntrance Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -93,11 +105,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/acs/entrances/get", requestOptions).Data.AcsEntrance;
         }
 
+        /// <summary>
+        /// Returns a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public AcsEntrance Get(string acsEntranceId = default)
         {
             return Get(new GetRequest(acsEntranceId: acsEntranceId));
         }
 
+        /// <summary>
+        /// Returns a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task<AcsEntrance> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -107,11 +125,17 @@ namespace Seam.Api
                 .AcsEntrance;
         }
 
+        /// <summary>
+        /// Returns a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task<AcsEntrance> GetAsync(string acsEntranceId = default)
         {
             return (await GetAsync(new GetRequest(acsEntranceId: acsEntranceId)));
         }
 
+        /// <summary>
+        /// Request parameters for Grant an ACS User Access to an Entrance.
+        /// </summary>
         [DataContract(Name = "grantAccessRequest_request")]
         public class GrantAccessRequest
         {
@@ -129,12 +153,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the entrance to which you want to grant an access system user access.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity to whom you want to grant access to an entrance. You can only provide one of acs_user_id or user_identity_id. If the ACS system contains an ACS user with the same `email_address` or `phone_number` as the user identity that you specify, they are linked, and the access group membership belongs to the ACS user. If the ACS system does not have a corresponding ACS user, one is created.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -158,6 +191,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Grants a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public void GrantAccess(GrantAccessRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -165,6 +201,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/entrances/grant_access", requestOptions);
         }
 
+        /// <summary>
+        /// Grants a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public void GrantAccess(
             string acsEntranceId = default,
             string? acsUserId = default,
@@ -180,6 +219,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Grants a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task GrantAccessAsync(GrantAccessRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -187,6 +229,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/entrances/grant_access", requestOptions);
         }
 
+        /// <summary>
+        /// Grants a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task GrantAccessAsync(
             string acsEntranceId = default,
             string? acsUserId = default,
@@ -202,6 +247,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Entrances.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -233,15 +281,27 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// ID of the credential for which you want to retrieve all entrances.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// IDs of the entrances for which you want to retrieve all entrances.
+            /// </summary>
             [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// ID of the access system for which you want to retrieve all entrances.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to retrieve all entrances.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -249,21 +309,37 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list entrances.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public int? Limit { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(Name = "location_id", IsRequired = false, EmitDefaultValue = false)]
             public string? LocationId { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned entrances to include all records that satisfy a partial match using `display_name`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list entrances.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
@@ -298,6 +374,9 @@ namespace Seam.Api
                 AcsEntrances = acsEntrances;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsEntrance> AcsEntrances { get; set; }
 
@@ -321,6 +400,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access system entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public List<AcsEntrance> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -330,6 +412,9 @@ namespace Seam.Api
                 .Data.AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public List<AcsEntrance> List(
             string? acsCredentialId = default,
             List<string>? acsEntranceIds = default,
@@ -359,6 +444,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [access system entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -368,6 +456,9 @@ namespace Seam.Api
                 .AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAsync(
             string? acsCredentialId = default,
             List<string>? acsEntranceIds = default,
@@ -399,6 +490,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Credentials with Access to an Entrance.
+        /// </summary>
         [DataContract(Name = "listCredentialsWithAccessRequest_request")]
         public class ListCredentialsWithAccessRequest
         {
@@ -414,6 +508,9 @@ namespace Seam.Api
                 IncludeIf = includeIf;
             }
 
+            /// <summary>
+            /// Conditions that credentials must meet to be included in the returned list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum IncludeIfEnum
             {
@@ -424,9 +521,15 @@ namespace Seam.Api
                 VisionlineMetadataIsValid = 1,
             }
 
+            /// <summary>
+            /// ID of the entrance for which you want to list all credentials that grant access.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// Conditions that credentials must meet to be included in the returned list.
+            /// </summary>
             [DataMember(Name = "include_if", IsRequired = false, EmitDefaultValue = false)]
             public List<ListCredentialsWithAccessRequest.IncludeIfEnum>? IncludeIf { get; set; }
 
@@ -461,6 +564,9 @@ namespace Seam.Api
                 AcsCredentials = acsCredentials;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_credentials", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsCredential> AcsCredentials { get; set; }
 
@@ -484,6 +590,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public List<AcsCredential> ListCredentialsWithAccess(
             ListCredentialsWithAccessRequest request
         )
@@ -498,6 +607,9 @@ namespace Seam.Api
                 .Data.AcsCredentials;
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public List<AcsCredential> ListCredentialsWithAccess(
             string acsEntranceId = default,
             List<ListCredentialsWithAccessRequest.IncludeIfEnum>? includeIf = default
@@ -511,6 +623,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task<List<AcsCredential>> ListCredentialsWithAccessAsync(
             ListCredentialsWithAccessRequest request
         )
@@ -527,6 +642,9 @@ namespace Seam.Api
                 .AcsCredentials;
         }
 
+        /// <summary>
+        /// Returns a list of all [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         public async Task<List<AcsCredential>> ListCredentialsWithAccessAsync(
             string acsEntranceId = default,
             List<ListCredentialsWithAccessRequest.IncludeIfEnum>? includeIf = default
@@ -542,6 +660,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Unlock an Entrance.
+        /// </summary>
         [DataContract(Name = "unlockRequest_request")]
         public class UnlockRequest
         {
@@ -554,9 +675,15 @@ namespace Seam.Api
                 AcsEntranceId = acsEntranceId;
             }
 
+            /// <summary>
+            /// ID of the cloud_key credential to use for the unlock operation.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// ID of the entrance to unlock.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEntranceId { get; set; }
 
@@ -591,6 +718,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -614,6 +744,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public ActionAttempt Unlock(UnlockRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -623,6 +756,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public ActionAttempt Unlock(
             string acsCredentialId = default,
             string acsEntranceId = default
@@ -633,6 +769,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public async Task<ActionAttempt> UnlockAsync(UnlockRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -642,6 +781,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Remotely unlocks a specified [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.
+        /// </summary>
         public async Task<ActionAttempt> UnlockAsync(
             string acsCredentialId = default,
             string acsEntranceId = default

--- a/output/csharp/src/Seam/Api/Events.cs
+++ b/output/csharp/src/Seam/Api/Events.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Event.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 EventType = eventType;
             }
 
+            /// <summary>
+            /// Unique identifier for the device that triggered the event that you want to get.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Unique identifier for the event that you want to get.
+            /// </summary>
             [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
             public string? EventId { get; set; }
 
+            /// <summary>
+            /// Type of the event that you want to get.
+            /// </summary>
             [DataMember(Name = "event_type", IsRequired = false, EmitDefaultValue = false)]
             public string? EventType { get; set; }
 
@@ -75,6 +87,9 @@ namespace Seam.Api
                 Event = event_;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "event", IsRequired = false, EmitDefaultValue = false)]
             public Event Event { get; set; }
 
@@ -98,6 +113,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.
+        /// </summary>
         public Event Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -105,6 +123,9 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/events/get", requestOptions).Data.Event;
         }
 
+        /// <summary>
+        /// Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.
+        /// </summary>
         public Event Get(
             string? deviceId = default,
             string? eventId = default,
@@ -114,6 +135,9 @@ namespace Seam.Api
             return Get(new GetRequest(deviceId: deviceId, eventId: eventId, eventType: eventType));
         }
 
+        /// <summary>
+        /// Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.
+        /// </summary>
         public async Task<Event> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -121,6 +145,9 @@ namespace Seam.Api
             return (await _seam.PostAsync<GetResponse>("/events/get", requestOptions)).Data.Event;
         }
 
+        /// <summary>
+        /// Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.
+        /// </summary>
         public async Task<Event> GetAsync(
             string? deviceId = default,
             string? eventId = default,
@@ -134,6 +161,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Events.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -201,6 +231,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// Type of the events that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum EventTypeEnum
             {
@@ -535,6 +568,9 @@ namespace Seam.Api
                 SpaceDeleted = 109,
             }
 
+            /// <summary>
+            /// Types of the events that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum EventTypesEnum
             {
@@ -869,51 +905,99 @@ namespace Seam.Api
                 SpaceDeleted = 109,
             }
 
+            /// <summary>
+            /// ID of the access code for which you want to list events.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessCodeId { get; set; }
 
+            /// <summary>
+            /// IDs of the access codes for which you want to list events.
+            /// </summary>
             [DataMember(Name = "access_code_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessCodeIds { get; set; }
 
+            /// <summary>
+            /// ID of the access grant for which you want to list events.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantId { get; set; }
 
+            /// <summary>
+            /// IDs of the access grants for which you want to list events.
+            /// </summary>
             [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessGrantIds { get; set; }
 
+            /// <summary>
+            /// ID of the access method for which you want to list events.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessMethodId { get; set; }
 
+            /// <summary>
+            /// IDs of the access methods for which you want to list events.
+            /// </summary>
             [DataMember(Name = "access_method_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AccessMethodIds { get; set; }
 
+            /// <summary>
+            /// ID of the ACS access group for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsAccessGroupId { get; set; }
 
+            /// <summary>
+            /// ID of the ACS credential for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// ID of the ACS encoder for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEncoderId { get; set; }
 
+            /// <summary>
+            /// ID of the ACS entrance for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// ID of the access system for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// IDs of the access systems for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_system_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsSystemIds { get; set; }
 
+            /// <summary>
+            /// ID of the ACS user for which you want to list events.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// Lower and upper timestamps to define an exclusive interval containing the events that you want to list. You must include `since` or `between`.
+            /// </summary>
             [DataMember(Name = "between", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequestBetween>? Between { get; set; }
 
+            /// <summary>
+            /// ID of the Connect Webview for which you want to list events.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to list events.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -921,39 +1005,75 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list events.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to list events.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// IDs of the devices for which you want to list events.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// IDs of the events that you want to list.
+            /// </summary>
             [DataMember(Name = "event_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? EventIds { get; set; }
 
+            /// <summary>
+            /// Type of the events that you want to list.
+            /// </summary>
             [DataMember(Name = "event_type", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.EventTypeEnum? EventType { get; set; }
 
+            /// <summary>
+            /// Types of the events that you want to list.
+            /// </summary>
             [DataMember(Name = "event_types", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequest.EventTypesEnum>? EventTypes { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of events to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Timestamp to indicate the beginning generation time for the events that you want to list. You must include `since` or `between`.
+            /// </summary>
             [DataMember(Name = "since", IsRequired = false, EmitDefaultValue = false)]
             public string? Since { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list events.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            /// <summary>
+            /// IDs of the spaces for which you want to list events.
+            /// </summary>
             [DataMember(Name = "space_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceIds { get; set; }
 
+            /// <summary>
+            /// Offset for the events that you want to list.
+            /// </summary>
             [DataMember(Name = "unstable_offset", IsRequired = false, EmitDefaultValue = false)]
             public float? UnstableOffset { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for which you want to list events.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -1014,6 +1134,9 @@ namespace Seam.Api
                 Events = events;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "events", IsRequired = false, EmitDefaultValue = false)]
             public List<Event> Events { get; set; }
 
@@ -1037,6 +1160,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.
+        /// </summary>
         public List<Event> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1044,6 +1170,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/events/list", requestOptions).Data.Events;
         }
 
+        /// <summary>
+        /// Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.
+        /// </summary>
         public List<Event> List(
             string? accessCodeId = default,
             List<string>? accessCodeIds = default,
@@ -1109,6 +1238,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.
+        /// </summary>
         public async Task<List<Event>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1118,6 +1250,9 @@ namespace Seam.Api
                 .Events;
         }
 
+        /// <summary>
+        /// Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.
+        /// </summary>
         public async Task<List<Event>> ListAsync(
             string? accessCodeId = default,
             List<string>? accessCodeIds = default,

--- a/output/csharp/src/Seam/Api/InstantKeys.cs
+++ b/output/csharp/src/Seam/Api/InstantKeys.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Delete an Instant Key.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 InstantKeyId = instantKeyId;
             }
 
+            /// <summary>
+            /// ID of the Instant Key that you want to delete.
+            /// </summary>
             [DataMember(Name = "instant_key_id", IsRequired = true, EmitDefaultValue = false)]
             public string InstantKeyId { get; set; }
 
@@ -52,6 +58,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -59,11 +68,17 @@ namespace Seam.Api
             _seam.Post<object>("/instant_keys/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public void Delete(string instantKeyId = default)
         {
             Delete(new DeleteRequest(instantKeyId: instantKeyId));
         }
 
+        /// <summary>
+        /// Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,11 +86,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/instant_keys/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public async Task DeleteAsync(string instantKeyId = default)
         {
             await DeleteAsync(new DeleteRequest(instantKeyId: instantKeyId));
         }
 
+        /// <summary>
+        /// Request parameters for Get an Instant Key.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -88,9 +109,15 @@ namespace Seam.Api
                 InstantKeyUrl = instantKeyUrl;
             }
 
+            /// <summary>
+            /// ID of the instant key to get.
+            /// </summary>
             [DataMember(Name = "instant_key_id", IsRequired = false, EmitDefaultValue = false)]
             public string? InstantKeyId { get; set; }
 
+            /// <summary>
+            /// URL of the instant key to get.
+            /// </summary>
             [DataMember(Name = "instant_key_url", IsRequired = false, EmitDefaultValue = false)]
             public string? InstantKeyUrl { get; set; }
 
@@ -125,6 +152,9 @@ namespace Seam.Api
                 InstantKey = instantKey;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "instant_key", IsRequired = false, EmitDefaultValue = false)]
             public InstantKey InstantKey { get; set; }
 
@@ -148,6 +178,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public InstantKey Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -155,11 +188,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/instant_keys/get", requestOptions).Data.InstantKey;
         }
 
+        /// <summary>
+        /// Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public InstantKey Get(string? instantKeyId = default, string? instantKeyUrl = default)
         {
             return Get(new GetRequest(instantKeyId: instantKeyId, instantKeyUrl: instantKeyUrl));
         }
 
+        /// <summary>
+        /// Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public async Task<InstantKey> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -169,6 +208,9 @@ namespace Seam.Api
                 .InstantKey;
         }
 
+        /// <summary>
+        /// Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public async Task<InstantKey> GetAsync(
             string? instantKeyId = default,
             string? instantKeyUrl = default
@@ -181,6 +223,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Instant Keys.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -192,6 +237,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the user identity by which you want to filter the list of Instant Keys.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -226,6 +274,9 @@ namespace Seam.Api
                 InstantKeys = instantKeys;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "instant_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<InstantKey> InstantKeys { get; set; }
 
@@ -249,6 +300,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public List<InstantKey> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -256,11 +310,17 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/instant_keys/list", requestOptions).Data.InstantKeys;
         }
 
+        /// <summary>
+        /// Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public List<InstantKey> List(string? userIdentityId = default)
         {
             return List(new ListRequest(userIdentityId: userIdentityId));
         }
 
+        /// <summary>
+        /// Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public async Task<List<InstantKey>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -270,6 +330,9 @@ namespace Seam.Api
                 .InstantKeys;
         }
 
+        /// <summary>
+        /// Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).
+        /// </summary>
         public async Task<List<InstantKey>> ListAsync(string? userIdentityId = default)
         {
             return (await ListAsync(new ListRequest(userIdentityId: userIdentityId)));

--- a/output/csharp/src/Seam/Api/Locks.cs
+++ b/output/csharp/src/Seam/Api/Locks.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Configure Auto-Lock.
+        /// </summary>
         [DataContract(Name = "configureAutoLockRequest_request")]
         public class ConfigureAutoLockRequest
         {
@@ -35,6 +38,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Delay in seconds before the lock automatically locks. Required when enabling auto-lock. Must be between 1 and 60.
+            /// </summary>
             [DataMember(
                 Name = "auto_lock_delay_seconds",
                 IsRequired = false,
@@ -42,9 +48,15 @@ namespace Seam.Api
             )]
             public float? AutoLockDelaySeconds { get; set; }
 
+            /// <summary>
+            /// Whether to enable or disable auto-lock.
+            /// </summary>
             [DataMember(Name = "auto_lock_enabled", IsRequired = true, EmitDefaultValue = false)]
             public bool AutoLockEnabled { get; set; }
 
+            /// <summary>
+            /// ID of the lock for which you want to configure the auto-lock.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -79,6 +91,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -102,6 +117,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Configures the auto-lock setting for a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public ActionAttempt ConfigureAutoLock(ConfigureAutoLockRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,6 +129,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Configures the auto-lock setting for a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public ActionAttempt ConfigureAutoLock(
             float? autoLockDelaySeconds = default,
             bool autoLockEnabled = default,
@@ -126,6 +147,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Configures the auto-lock setting for a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public async Task<ActionAttempt> ConfigureAutoLockAsync(ConfigureAutoLockRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -140,6 +164,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Configures the auto-lock setting for a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public async Task<ActionAttempt> ConfigureAutoLockAsync(
             float? autoLockDelaySeconds = default,
             bool autoLockEnabled = default,
@@ -157,6 +184,10 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get a Lock.
+        /// </summary>
+        [Obsolete("Use `/devices/get` instead.")]
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -169,9 +200,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// ID of the lock that you want to get.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Name of the lock that you want to get.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -206,6 +243,9 @@ namespace Seam.Api
                 Device = device;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "device", IsRequired = false, EmitDefaultValue = false)]
             public Device Device { get; set; }
 
@@ -229,6 +269,10 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
+        [Obsolete("Use `/devices/get` instead.")]
         public Device Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -236,11 +280,19 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/locks/get", requestOptions).Data.Device;
         }
 
+        /// <summary>
+        /// Returns a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
+        [Obsolete("Use `/devices/get` instead.")]
         public Device Get(string? deviceId = default, string? name = default)
         {
             return Get(new GetRequest(deviceId: deviceId, name: name));
         }
 
+        /// <summary>
+        /// Returns a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
+        [Obsolete("Use `/devices/get` instead.")]
         public async Task<Device> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -248,11 +300,18 @@ namespace Seam.Api
             return (await _seam.PostAsync<GetResponse>("/locks/get", requestOptions)).Data.Device;
         }
 
+        /// <summary>
+        /// Returns a specified [lock](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
+        [Obsolete("Use `/devices/get` instead.")]
         public async Task<Device> GetAsync(string? deviceId = default, string? name = default)
         {
             return (await GetAsync(new GetRequest(deviceId: deviceId, name: name)));
         }
 
+        /// <summary>
+        /// Request parameters for List Locks.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -296,6 +355,9 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Device type of the locks that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypeEnum
             {
@@ -390,6 +452,9 @@ namespace Seam.Api
                 KisiLock = 29,
             }
 
+            /// <summary>
+            /// Device types of the locks that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypesEnum
             {
@@ -484,6 +549,9 @@ namespace Seam.Api
                 KisiLock = 29,
             }
 
+            /// <summary>
+            /// Manufacturer of the locks that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ManufacturerEnum
             {
@@ -584,9 +652,15 @@ namespace Seam.Api
                 Kisi = 31,
             }
 
+            /// <summary>
+            /// ID of the Connect Webview for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -594,6 +668,9 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Array of IDs of the connected accounts for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -601,39 +678,73 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Array of device IDs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Device type of the locks that you want to list.
+            /// </summary>
             [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.DeviceTypeEnum? DeviceType { get; set; }
 
+            /// <summary>
+            /// Device types of the locks that you want to list.
+            /// </summary>
             [DataMember(Name = "device_types", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequest.DeviceTypesEnum>? DeviceTypes { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of devices to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Manufacturer of the locks that you want to list.
+            /// </summary>
             [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.ManufacturerEnum? Manufacturer { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(
                 Name = "unstable_location_id",
                 IsRequired = false,
@@ -641,6 +752,9 @@ namespace Seam.Api
             )]
             public string? UnstableLocationId { get; set; }
 
+            /// <summary>
+            /// Your own internal user ID for the user for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -675,6 +789,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
             public List<Device> Devices { get; set; }
 
@@ -698,6 +815,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [locks](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public List<Device> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -705,6 +825,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/locks/list", requestOptions).Data.Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [locks](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public List<Device> List(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -746,6 +869,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [locks](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public async Task<List<Device>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -755,6 +881,9 @@ namespace Seam.Api
                 .Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [locks](https://docs.seam.co/low-level-apis/smart-locks).
+        /// </summary>
         public async Task<List<Device>> ListAsync(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -798,6 +927,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Lock a Lock.
+        /// </summary>
         [DataContract(Name = "lockDoorRequest_request")]
         public class LockDoorRequest
         {
@@ -809,6 +941,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the lock that you want to lock.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -843,6 +978,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -866,6 +1004,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Locks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public ActionAttempt LockDoor(LockDoorRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -875,11 +1016,17 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Locks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public ActionAttempt LockDoor(string deviceId = default)
         {
             return LockDoor(new LockDoorRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Locks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public async Task<ActionAttempt> LockDoorAsync(LockDoorRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -889,11 +1036,17 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Locks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public async Task<ActionAttempt> LockDoorAsync(string deviceId = default)
         {
             return (await LockDoorAsync(new LockDoorRequest(deviceId: deviceId)));
         }
 
+        /// <summary>
+        /// Request parameters for Unlock a Lock.
+        /// </summary>
         [DataContract(Name = "unlockDoorRequest_request")]
         public class UnlockDoorRequest
         {
@@ -905,6 +1058,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the lock that you want to unlock.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -939,6 +1095,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -962,6 +1121,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Unlocks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public ActionAttempt UnlockDoor(UnlockDoorRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -971,11 +1133,17 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Unlocks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public ActionAttempt UnlockDoor(string deviceId = default)
         {
             return UnlockDoor(new UnlockDoorRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Unlocks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public async Task<ActionAttempt> UnlockDoorAsync(UnlockDoorRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -985,6 +1153,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Unlocks a [lock](https://docs.seam.co/low-level-apis/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/low-level-apis/smart-locks/lock-and-unlock).
+        /// </summary>
         public async Task<ActionAttempt> UnlockDoorAsync(string deviceId = default)
         {
             return (await UnlockDoorAsync(new UnlockDoorRequest(deviceId: deviceId)));

--- a/output/csharp/src/Seam/Api/NoiseSensors.cs
+++ b/output/csharp/src/Seam/Api/NoiseSensors.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for List Noise Sensors.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -61,6 +64,9 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Device type of the noise sensors that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypeEnum
             {
@@ -74,6 +80,9 @@ namespace Seam.Api
                 MinutSensor = 2,
             }
 
+            /// <summary>
+            /// Device types of the noise sensors that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypesEnum
             {
@@ -87,6 +96,9 @@ namespace Seam.Api
                 MinutSensor = 2,
             }
 
+            /// <summary>
+            /// Manufacturers of the noise sensors that you want to list.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ManufacturerEnum
             {
@@ -100,9 +112,15 @@ namespace Seam.Api
                 Noiseaware = 2,
             }
 
+            /// <summary>
+            /// ID of the Connect Webview for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -110,6 +128,9 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Array of IDs of the connected accounts for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -117,39 +138,73 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Array of device IDs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Device type of the noise sensors that you want to list.
+            /// </summary>
             [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.DeviceTypeEnum? DeviceType { get; set; }
 
+            /// <summary>
+            /// Device types of the noise sensors that you want to list.
+            /// </summary>
             [DataMember(Name = "device_types", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequest.DeviceTypesEnum>? DeviceTypes { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of devices to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Manufacturers of the noise sensors that you want to list.
+            /// </summary>
             [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.ManufacturerEnum? Manufacturer { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(
                 Name = "unstable_location_id",
                 IsRequired = false,
@@ -157,6 +212,9 @@ namespace Seam.Api
             )]
             public string? UnstableLocationId { get; set; }
 
+            /// <summary>
+            /// Your own internal user ID for the user for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -191,6 +249,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
             public List<Device> Devices { get; set; }
 
@@ -214,6 +275,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public List<Device> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -221,6 +285,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/noise_sensors/list", requestOptions).Data.Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public List<Device> List(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -262,6 +329,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task<List<Device>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -271,6 +341,9 @@ namespace Seam.Api
                 .Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task<List<Device>> ListAsync(
             string? connectWebviewId = default,
             string? connectedAccountId = default,

--- a/output/csharp/src/Seam/Api/NoiseThresholdsNoiseSensors.cs
+++ b/output/csharp/src/Seam/Api/NoiseThresholdsNoiseSensors.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Noise Threshold.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -41,15 +44,27 @@ namespace Seam.Api
                 StartsDailyAt = startsDailyAt;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to create a noise threshold.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Time at which the new noise threshold should become inactive daily.
+            /// </summary>
             [DataMember(Name = "ends_daily_at", IsRequired = true, EmitDefaultValue = false)]
             public string EndsDailyAt { get; set; }
 
+            /// <summary>
+            /// Name of the new noise threshold.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Noise level in decibels for the new noise threshold.
+            /// </summary>
             [DataMember(
                 Name = "noise_threshold_decibels",
                 IsRequired = false,
@@ -57,9 +72,15 @@ namespace Seam.Api
             )]
             public float? NoiseThresholdDecibels { get; set; }
 
+            /// <summary>
+            /// Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).
+            /// </summary>
             [DataMember(Name = "noise_threshold_nrs", IsRequired = false, EmitDefaultValue = false)]
             public float? NoiseThresholdNrs { get; set; }
 
+            /// <summary>
+            /// Time at which the new noise threshold should become active daily.
+            /// </summary>
             [DataMember(Name = "starts_daily_at", IsRequired = true, EmitDefaultValue = false)]
             public string StartsDailyAt { get; set; }
 
@@ -94,6 +115,9 @@ namespace Seam.Api
                 NoiseThreshold = noiseThreshold;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "noise_threshold", IsRequired = false, EmitDefaultValue = false)]
             public NoiseThreshold NoiseThreshold { get; set; }
 
@@ -117,6 +141,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+        /// </summary>
         public NoiseThreshold Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -126,6 +153,9 @@ namespace Seam.Api
                 .Data.NoiseThreshold;
         }
 
+        /// <summary>
+        /// Creates a new [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+        /// </summary>
         public NoiseThreshold Create(
             string deviceId = default,
             string endsDailyAt = default,
@@ -147,6 +177,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+        /// </summary>
         public async Task<NoiseThreshold> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -161,6 +194,9 @@ namespace Seam.Api
                 .NoiseThreshold;
         }
 
+        /// <summary>
+        /// Creates a new [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+        /// </summary>
         public async Task<NoiseThreshold> CreateAsync(
             string deviceId = default,
             string endsDailyAt = default,
@@ -184,6 +220,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Noise Threshold.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -196,9 +235,15 @@ namespace Seam.Api
                 NoiseThresholdId = noiseThresholdId;
             }
 
+            /// <summary>
+            /// ID of the device that contains the noise threshold that you want to delete.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// ID of the noise threshold that you want to delete.
+            /// </summary>
             [DataMember(Name = "noise_threshold_id", IsRequired = true, EmitDefaultValue = false)]
             public string NoiseThresholdId { get; set; }
 
@@ -222,6 +267,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -229,11 +277,17 @@ namespace Seam.Api
             _seam.Post<object>("/noise_sensors/noise_thresholds/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public void Delete(string deviceId = default, string noiseThresholdId = default)
         {
             Delete(new DeleteRequest(deviceId: deviceId, noiseThresholdId: noiseThresholdId));
         }
 
+        /// <summary>
+        /// Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -241,6 +295,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/noise_sensors/noise_thresholds/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task DeleteAsync(string deviceId = default, string noiseThresholdId = default)
         {
             await DeleteAsync(
@@ -248,6 +305,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get a Noise Threshold.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -259,6 +319,9 @@ namespace Seam.Api
                 NoiseThresholdId = noiseThresholdId;
             }
 
+            /// <summary>
+            /// ID of the noise threshold that you want to get.
+            /// </summary>
             [DataMember(Name = "noise_threshold_id", IsRequired = true, EmitDefaultValue = false)]
             public string NoiseThresholdId { get; set; }
 
@@ -293,6 +356,9 @@ namespace Seam.Api
                 NoiseThreshold = noiseThreshold;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "noise_threshold", IsRequired = false, EmitDefaultValue = false)]
             public NoiseThreshold NoiseThreshold { get; set; }
 
@@ -316,6 +382,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public NoiseThreshold Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -325,11 +394,17 @@ namespace Seam.Api
                 .Data.NoiseThreshold;
         }
 
+        /// <summary>
+        /// Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public NoiseThreshold Get(string noiseThresholdId = default)
         {
             return Get(new GetRequest(noiseThresholdId: noiseThresholdId));
         }
 
+        /// <summary>
+        /// Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task<NoiseThreshold> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -344,11 +419,17 @@ namespace Seam.Api
                 .NoiseThreshold;
         }
 
+        /// <summary>
+        /// Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task<NoiseThreshold> GetAsync(string noiseThresholdId = default)
         {
             return (await GetAsync(new GetRequest(noiseThresholdId: noiseThresholdId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Noise Thresholds.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -360,6 +441,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to list noise thresholds.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -394,6 +478,9 @@ namespace Seam.Api
                 NoiseThresholds = noiseThresholds;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "noise_thresholds", IsRequired = false, EmitDefaultValue = false)]
             public List<NoiseThreshold> NoiseThresholds { get; set; }
 
@@ -417,6 +504,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public List<NoiseThreshold> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -426,11 +516,17 @@ namespace Seam.Api
                 .Data.NoiseThresholds;
         }
 
+        /// <summary>
+        /// Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public List<NoiseThreshold> List(string deviceId = default)
         {
             return List(new ListRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task<List<NoiseThreshold>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -445,11 +541,17 @@ namespace Seam.Api
                 .NoiseThresholds;
         }
 
+        /// <summary>
+        /// Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task<List<NoiseThreshold>> ListAsync(string deviceId = default)
         {
             return (await ListAsync(new ListRequest(deviceId: deviceId)));
         }
 
+        /// <summary>
+        /// Request parameters for Update a Noise Threshold.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -475,15 +577,27 @@ namespace Seam.Api
                 StartsDailyAt = startsDailyAt;
             }
 
+            /// <summary>
+            /// ID of the device that contains the noise threshold that you want to update.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Time at which the noise threshold should become inactive daily.
+            /// </summary>
             [DataMember(Name = "ends_daily_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsDailyAt { get; set; }
 
+            /// <summary>
+            /// Name of the noise threshold that you want to update.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Noise level in decibels for the noise threshold.
+            /// </summary>
             [DataMember(
                 Name = "noise_threshold_decibels",
                 IsRequired = false,
@@ -491,12 +605,21 @@ namespace Seam.Api
             )]
             public float? NoiseThresholdDecibels { get; set; }
 
+            /// <summary>
+            /// ID of the noise threshold that you want to update.
+            /// </summary>
             [DataMember(Name = "noise_threshold_id", IsRequired = true, EmitDefaultValue = false)]
             public string NoiseThresholdId { get; set; }
 
+            /// <summary>
+            /// Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).
+            /// </summary>
             [DataMember(Name = "noise_threshold_nrs", IsRequired = false, EmitDefaultValue = false)]
             public float? NoiseThresholdNrs { get; set; }
 
+            /// <summary>
+            /// Time at which the noise threshold should become active daily.
+            /// </summary>
             [DataMember(Name = "starts_daily_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsDailyAt { get; set; }
 
@@ -520,6 +643,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -527,6 +653,9 @@ namespace Seam.Api
             _seam.Post<object>("/noise_sensors/noise_thresholds/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public void Update(
             string deviceId = default,
             string? endsDailyAt = default,
@@ -550,6 +679,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -557,6 +689,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/noise_sensors/noise_thresholds/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).
+        /// </summary>
         public async Task UpdateAsync(
             string deviceId = default,
             string? endsDailyAt = default,

--- a/output/csharp/src/Seam/Api/Phones.cs
+++ b/output/csharp/src/Seam/Api/Phones.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Deactivate a Phone.
+        /// </summary>
         [DataContract(Name = "deactivateRequest_request")]
         public class DeactivateRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Device ID of the phone that you want to deactivate.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -52,6 +58,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).
+        /// </summary>
         public void Deactivate(DeactivateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -59,11 +68,17 @@ namespace Seam.Api
             _seam.Post<object>("/phones/deactivate", requestOptions);
         }
 
+        /// <summary>
+        /// Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).
+        /// </summary>
         public void Deactivate(string deviceId = default)
         {
             Deactivate(new DeactivateRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).
+        /// </summary>
         public async Task DeactivateAsync(DeactivateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,11 +86,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/phones/deactivate", requestOptions);
         }
 
+        /// <summary>
+        /// Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).
+        /// </summary>
         public async Task DeactivateAsync(string deviceId = default)
         {
             await DeactivateAsync(new DeactivateRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Phone.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -87,6 +108,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Device ID of the phone that you want to get.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -121,6 +145,9 @@ namespace Seam.Api
                 Phone = phone;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "phone", IsRequired = false, EmitDefaultValue = false)]
             public Phone Phone { get; set; }
 
@@ -144,6 +171,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).
+        /// </summary>
         public Phone Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -151,11 +181,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/phones/get", requestOptions).Data.Phone;
         }
 
+        /// <summary>
+        /// Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).
+        /// </summary>
         public Phone Get(string deviceId = default)
         {
             return Get(new GetRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).
+        /// </summary>
         public async Task<Phone> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -163,11 +199,17 @@ namespace Seam.Api
             return (await _seam.PostAsync<GetResponse>("/phones/get", requestOptions)).Data.Phone;
         }
 
+        /// <summary>
+        /// Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).
+        /// </summary>
         public async Task<Phone> GetAsync(string deviceId = default)
         {
             return (await GetAsync(new GetRequest(deviceId: deviceId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Phones.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -183,9 +225,15 @@ namespace Seam.Api
                 OwnerUserIdentityId = ownerUserIdentityId;
             }
 
+            /// <summary>
+            /// ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) by which you want to filter the list of returned phones.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that represents the owner by which you want to filter the list of returned phones.
+            /// </summary>
             [DataMember(
                 Name = "owner_user_identity_id",
                 IsRequired = false,
@@ -224,6 +272,9 @@ namespace Seam.Api
                 Phones = phones;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "phones", IsRequired = false, EmitDefaultValue = false)]
             public List<Phone> Phones { get; set; }
 
@@ -247,6 +298,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.
+        /// </summary>
         public List<Phone> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -254,6 +308,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/phones/list", requestOptions).Data.Phones;
         }
 
+        /// <summary>
+        /// Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.
+        /// </summary>
         public List<Phone> List(
             string? acsCredentialId = default,
             string? ownerUserIdentityId = default
@@ -267,6 +324,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.
+        /// </summary>
         public async Task<List<Phone>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -276,6 +336,9 @@ namespace Seam.Api
                 .Phones;
         }
 
+        /// <summary>
+        /// Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.
+        /// </summary>
         public async Task<List<Phone>> ListAsync(
             string? acsCredentialId = default,
             string? ownerUserIdentityId = default

--- a/output/csharp/src/Seam/Api/SchedulesThermostats.cs
+++ b/output/csharp/src/Seam/Api/SchedulesThermostats.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Thermostat Schedule.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -43,18 +46,33 @@ namespace Seam.Api
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the new thermostat schedule.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = true, EmitDefaultValue = false)]
             public string ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to create a schedule.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Date and time at which the new thermostat schedule ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = true, EmitDefaultValue = false)]
             public string EndsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether a person at the thermostat or using the API can change the thermostat&apos;s settings while the new schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+            /// </summary>
             [DataMember(Name = "is_override_allowed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsOverrideAllowed { get; set; }
 
+            /// <summary>
+            /// Number of minutes for which a person at the thermostat or using the API can change the thermostat&apos;s settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+            /// </summary>
             [DataMember(
                 Name = "max_override_period_minutes",
                 IsRequired = false,
@@ -62,9 +80,15 @@ namespace Seam.Api
             )]
             public int? MaxOverridePeriodMinutes { get; set; }
 
+            /// <summary>
+            /// Name of the thermostat schedule.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Date and time at which the new thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = true, EmitDefaultValue = false)]
             public string StartsAt { get; set; }
 
@@ -99,6 +123,9 @@ namespace Seam.Api
                 ThermostatSchedule = thermostatSchedule;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "thermostat_schedule", IsRequired = false, EmitDefaultValue = false)]
             public ThermostatSchedule ThermostatSchedule { get; set; }
 
@@ -122,6 +149,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ThermostatSchedule Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -131,6 +161,9 @@ namespace Seam.Api
                 .Data.ThermostatSchedule;
         }
 
+        /// <summary>
+        /// Creates a new [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ThermostatSchedule Create(
             string climatePresetKey = default,
             string deviceId = default,
@@ -154,6 +187,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ThermostatSchedule> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -168,6 +204,9 @@ namespace Seam.Api
                 .ThermostatSchedule;
         }
 
+        /// <summary>
+        /// Creates a new [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ThermostatSchedule> CreateAsync(
             string climatePresetKey = default,
             string deviceId = default,
@@ -193,6 +232,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Thermostat Schedule.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -204,6 +246,9 @@ namespace Seam.Api
                 ThermostatScheduleId = thermostatScheduleId;
             }
 
+            /// <summary>
+            /// ID of the thermostat schedule that you want to delete.
+            /// </summary>
             [DataMember(
                 Name = "thermostat_schedule_id",
                 IsRequired = true,
@@ -231,6 +276,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -238,11 +286,17 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/schedules/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void Delete(string thermostatScheduleId = default)
         {
             Delete(new DeleteRequest(thermostatScheduleId: thermostatScheduleId));
         }
 
+        /// <summary>
+        /// Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -250,11 +304,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/schedules/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task DeleteAsync(string thermostatScheduleId = default)
         {
             await DeleteAsync(new DeleteRequest(thermostatScheduleId: thermostatScheduleId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Thermostat Schedule.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -266,6 +326,9 @@ namespace Seam.Api
                 ThermostatScheduleId = thermostatScheduleId;
             }
 
+            /// <summary>
+            /// ID of the thermostat schedule that you want to get.
+            /// </summary>
             [DataMember(
                 Name = "thermostat_schedule_id",
                 IsRequired = true,
@@ -304,6 +367,9 @@ namespace Seam.Api
                 ThermostatSchedule = thermostatSchedule;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "thermostat_schedule", IsRequired = false, EmitDefaultValue = false)]
             public ThermostatSchedule ThermostatSchedule { get; set; }
 
@@ -327,6 +393,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public ThermostatSchedule Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -336,11 +405,17 @@ namespace Seam.Api
                 .Data.ThermostatSchedule;
         }
 
+        /// <summary>
+        /// Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public ThermostatSchedule Get(string thermostatScheduleId = default)
         {
             return Get(new GetRequest(thermostatScheduleId: thermostatScheduleId));
         }
 
+        /// <summary>
+        /// Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public async Task<ThermostatSchedule> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -352,11 +427,17 @@ namespace Seam.Api
                 .ThermostatSchedule;
         }
 
+        /// <summary>
+        /// Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public async Task<ThermostatSchedule> GetAsync(string thermostatScheduleId = default)
         {
             return (await GetAsync(new GetRequest(thermostatScheduleId: thermostatScheduleId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Thermostat Schedules.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -369,9 +450,15 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to list schedules.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// User identifier key by which to filter the list of returned thermostat schedules.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -406,6 +493,9 @@ namespace Seam.Api
                 ThermostatSchedules = thermostatSchedules;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(
                 Name = "thermostat_schedules",
                 IsRequired = false,
@@ -433,6 +523,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public List<ThermostatSchedule> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -442,6 +535,9 @@ namespace Seam.Api
                 .Data.ThermostatSchedules;
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public List<ThermostatSchedule> List(
             string deviceId = default,
             string? userIdentifierKey = default
@@ -450,6 +546,9 @@ namespace Seam.Api
             return List(new ListRequest(deviceId: deviceId, userIdentifierKey: userIdentifierKey));
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<List<ThermostatSchedule>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -461,6 +560,9 @@ namespace Seam.Api
                 .ThermostatSchedules;
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<List<ThermostatSchedule>> ListAsync(
             string deviceId = default,
             string? userIdentifierKey = default
@@ -473,6 +575,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update a Thermostat Schedule.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -498,15 +603,27 @@ namespace Seam.Api
                 ThermostatScheduleId = thermostatScheduleId;
             }
 
+            /// <summary>
+            /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the thermostat schedule.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// Date and time at which the thermostat schedule ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether a person at the thermostat or using the API can change the thermostat&apos;s settings while the schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+            /// </summary>
             [DataMember(Name = "is_override_allowed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsOverrideAllowed { get; set; }
 
+            /// <summary>
+            /// Number of minutes for which a person at the thermostat or using the API can change the thermostat&apos;s settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+            /// </summary>
             [DataMember(
                 Name = "max_override_period_minutes",
                 IsRequired = false,
@@ -514,12 +631,21 @@ namespace Seam.Api
             )]
             public int? MaxOverridePeriodMinutes { get; set; }
 
+            /// <summary>
+            /// Name of the thermostat schedule.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// Date and time at which the thermostat schedule starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat schedule that you want to update.
+            /// </summary>
             [DataMember(
                 Name = "thermostat_schedule_id",
                 IsRequired = true,
@@ -547,6 +673,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -554,6 +683,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/schedules/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public void Update(
             string? climatePresetKey = default,
             string? endsAt = default,
@@ -577,6 +709,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -584,6 +719,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/schedules/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         public async Task UpdateAsync(
             string? climatePresetKey = default,
             string? endsAt = default,

--- a/output/csharp/src/Seam/Api/SimulateAccessCodes.cs
+++ b/output/csharp/src/Seam/Api/SimulateAccessCodes.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Creating an Unmanaged Access Code.
+        /// </summary>
         [DataContract(Name = "createUnmanagedAccessCodeRequest_request")]
         public class CreateUnmanagedAccessCodeRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// Code of the simulated unmanaged access code.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = true, EmitDefaultValue = false)]
             public string Code { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to simulate the creation of an unmanaged access code.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Name of the simulated unmanaged access code.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = true, EmitDefaultValue = false)]
             public string Name { get; set; }
 
@@ -75,6 +87,9 @@ namespace Seam.Api
                 AccessCode = accessCode;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_code", IsRequired = false, EmitDefaultValue = false)]
             public UnmanagedAccessCode AccessCode { get; set; }
 
@@ -98,6 +113,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates the creation of an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public UnmanagedAccessCode CreateUnmanagedAccessCode(
             CreateUnmanagedAccessCodeRequest request
         )
@@ -112,6 +130,9 @@ namespace Seam.Api
                 .Data.AccessCode;
         }
 
+        /// <summary>
+        /// Simulates the creation of an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public UnmanagedAccessCode CreateUnmanagedAccessCode(
             string code = default,
             string deviceId = default,
@@ -123,6 +144,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates the creation of an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task<UnmanagedAccessCode> CreateUnmanagedAccessCodeAsync(
             CreateUnmanagedAccessCodeRequest request
         )
@@ -139,6 +163,9 @@ namespace Seam.Api
                 .AccessCode;
         }
 
+        /// <summary>
+        /// Simulates the creation of an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task<UnmanagedAccessCode> CreateUnmanagedAccessCodeAsync(
             string code = default,
             string deviceId = default,

--- a/output/csharp/src/Seam/Api/SimulateConnectedAccounts.cs
+++ b/output/csharp/src/Seam/Api/SimulateConnectedAccounts.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Connected Account Disconnection.
+        /// </summary>
         [DataContract(Name = "disconnectRequest_request")]
         public class DisconnectRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 ConnectedAccountId = connectedAccountId;
             }
 
+            /// <summary>
+            /// ID of the connected account you want to simulate as disconnected.
+            /// </summary>
             [DataMember(Name = "connected_account_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectedAccountId { get; set; }
 
@@ -52,6 +58,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void Disconnect(DisconnectRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -59,11 +68,17 @@ namespace Seam.Api
             _seam.Post<object>("/connected_accounts/simulate/disconnect", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void Disconnect(string connectedAccountId = default)
         {
             Disconnect(new DisconnectRequest(connectedAccountId: connectedAccountId));
         }
 
+        /// <summary>
+        /// Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task DisconnectAsync(DisconnectRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -74,6 +89,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task DisconnectAsync(string connectedAccountId = default)
         {
             await DisconnectAsync(new DisconnectRequest(connectedAccountId: connectedAccountId));

--- a/output/csharp/src/Seam/Api/SimulateDevices.cs
+++ b/output/csharp/src/Seam/Api/SimulateDevices.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Device Connection.
+        /// </summary>
         [DataContract(Name = "connectRequest_request")]
         public class ConnectRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device that you want to simulate connecting to Seam.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -52,6 +58,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public void Connect(ConnectRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -59,11 +68,17 @@ namespace Seam.Api
             _seam.Post<object>("/devices/simulate/connect", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public void Connect(string deviceId = default)
         {
             Connect(new ConnectRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public async Task ConnectAsync(ConnectRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,11 +86,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/simulate/connect", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public async Task ConnectAsync(string deviceId = default)
         {
             await ConnectAsync(new ConnectRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Hub Connection.
+        /// </summary>
         [DataContract(Name = "connectToHubRequest_request")]
         public class ConnectToHubRequest
         {
@@ -87,6 +108,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device whose hub you want to reconnect.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -110,6 +134,12 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates bringing the Wi‑Fi hub (bridge) back online for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August and TTLock locks.
+        /// This will clear the `hub_disconnected` error on the device.
+        /// </summary>
         public void ConnectToHub(ConnectToHubRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -117,11 +147,23 @@ namespace Seam.Api
             _seam.Post<object>("/devices/simulate/connect_to_hub", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates bringing the Wi‑Fi hub (bridge) back online for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August and TTLock locks.
+        /// This will clear the `hub_disconnected` error on the device.
+        /// </summary>
         public void ConnectToHub(string deviceId = default)
         {
             ConnectToHub(new ConnectToHubRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates bringing the Wi‑Fi hub (bridge) back online for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August and TTLock locks.
+        /// This will clear the `hub_disconnected` error on the device.
+        /// </summary>
         public async Task ConnectToHubAsync(ConnectToHubRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -129,11 +171,20 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/simulate/connect_to_hub", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates bringing the Wi‑Fi hub (bridge) back online for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August and TTLock locks.
+        /// This will clear the `hub_disconnected` error on the device.
+        /// </summary>
         public async Task ConnectToHubAsync(string deviceId = default)
         {
             await ConnectToHubAsync(new ConnectToHubRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Device Disconnection.
+        /// </summary>
         [DataContract(Name = "disconnectRequest_request")]
         public class DisconnectRequest
         {
@@ -145,6 +196,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device that you want to simulate disconnecting from Seam.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -168,6 +222,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public void Disconnect(DisconnectRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -175,11 +232,17 @@ namespace Seam.Api
             _seam.Post<object>("/devices/simulate/disconnect", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public void Disconnect(string deviceId = default)
         {
             Disconnect(new DisconnectRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public async Task DisconnectAsync(DisconnectRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -187,11 +250,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/simulate/disconnect", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public async Task DisconnectAsync(string deviceId = default)
         {
             await DisconnectAsync(new DisconnectRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Hub Disconnection.
+        /// </summary>
         [DataContract(Name = "disconnectFromHubRequest_request")]
         public class DisconnectFromHubRequest
         {
@@ -203,6 +272,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device whose hub you want to disconnect.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -226,6 +298,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates taking the Wi‑Fi hub (bridge) offline for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August, TTLock, and IglooHome devices.
+        /// This will set the `hub_disconnected` error on the device, or mark the
+        /// IglooHome bridge offline in sandbox.
+        /// </summary>
         public void DisconnectFromHub(DisconnectFromHubRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -233,11 +312,25 @@ namespace Seam.Api
             _seam.Post<object>("/devices/simulate/disconnect_from_hub", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates taking the Wi‑Fi hub (bridge) offline for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August, TTLock, and IglooHome devices.
+        /// This will set the `hub_disconnected` error on the device, or mark the
+        /// IglooHome bridge offline in sandbox.
+        /// </summary>
         public void DisconnectFromHub(string deviceId = default)
         {
             DisconnectFromHub(new DisconnectFromHubRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates taking the Wi‑Fi hub (bridge) offline for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August, TTLock, and IglooHome devices.
+        /// This will set the `hub_disconnected` error on the device, or mark the
+        /// IglooHome bridge offline in sandbox.
+        /// </summary>
         public async Task DisconnectFromHubAsync(DisconnectFromHubRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -245,11 +338,21 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/simulate/disconnect_from_hub", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates taking the Wi‑Fi hub (bridge) offline for a device.
+        /// Only applicable for sandbox workspaces and currently
+        /// implemented for August, TTLock, and IglooHome devices.
+        /// This will set the `hub_disconnected` error on the device, or mark the
+        /// IglooHome bridge offline in sandbox.
+        /// </summary>
         public async Task DisconnectFromHubAsync(string deviceId = default)
         {
             await DisconnectFromHubAsync(new DisconnectFromHubRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Paid Subscription.
+        /// </summary>
         [DataContract(Name = "paidSubscriptionRequest_request")]
         public class PaidSubscriptionRequest
         {
@@ -288,6 +391,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Toggle the simulated Nuki Smart Hosting subscription for a device (sandbox only).
+        /// Send `is_expired: true` to simulate an expired subscription, or `false` to simulate an active subscription.
+        /// The actual device error is created/cleared by the poller after this state change.
+        /// </summary>
         public void PaidSubscription(PaidSubscriptionRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -295,11 +403,21 @@ namespace Seam.Api
             _seam.Post<object>("/devices/simulate/paid_subscription", requestOptions);
         }
 
+        /// <summary>
+        /// Toggle the simulated Nuki Smart Hosting subscription for a device (sandbox only).
+        /// Send `is_expired: true` to simulate an expired subscription, or `false` to simulate an active subscription.
+        /// The actual device error is created/cleared by the poller after this state change.
+        /// </summary>
         public void PaidSubscription(string deviceId = default, bool isExpired = default)
         {
             PaidSubscription(new PaidSubscriptionRequest(deviceId: deviceId, isExpired: isExpired));
         }
 
+        /// <summary>
+        /// Toggle the simulated Nuki Smart Hosting subscription for a device (sandbox only).
+        /// Send `is_expired: true` to simulate an expired subscription, or `false` to simulate an active subscription.
+        /// The actual device error is created/cleared by the poller after this state change.
+        /// </summary>
         public async Task PaidSubscriptionAsync(PaidSubscriptionRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -307,6 +425,11 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/simulate/paid_subscription", requestOptions);
         }
 
+        /// <summary>
+        /// Toggle the simulated Nuki Smart Hosting subscription for a device (sandbox only).
+        /// Send `is_expired: true` to simulate an expired subscription, or `false` to simulate an active subscription.
+        /// The actual device error is created/cleared by the poller after this state change.
+        /// </summary>
         public async Task PaidSubscriptionAsync(string deviceId = default, bool isExpired = default)
         {
             await PaidSubscriptionAsync(
@@ -314,6 +437,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Device Removal.
+        /// </summary>
         [DataContract(Name = "removeRequest_request")]
         public class RemoveRequest
         {
@@ -325,6 +451,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device that you want to simulate removing from Seam.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -348,6 +477,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public void Remove(RemoveRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -355,11 +487,17 @@ namespace Seam.Api
             _seam.Post<object>("/devices/simulate/remove", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public void Remove(string deviceId = default)
         {
             Remove(new RemoveRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public async Task RemoveAsync(RemoveRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -367,6 +505,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/simulate/remove", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).
+        /// </summary>
         public async Task RemoveAsync(string deviceId = default)
         {
             await RemoveAsync(new RemoveRequest(deviceId: deviceId));

--- a/output/csharp/src/Seam/Api/SimulateEncodersAcs.cs
+++ b/output/csharp/src/Seam/Api/SimulateEncodersAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Simulate that the Next Credential Encoding Will Fail.
+        /// </summary>
         [DataContract(Name = "nextCredentialEncodeWillFailRequest_request")]
         public class NextCredentialEncodeWillFailRequest
         {
@@ -35,6 +38,9 @@ namespace Seam.Api
                 AcsCredentialId = acsCredentialId;
             }
 
+            /// <summary>
+            /// Code of the error to simulate.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ErrorCodeEnum
             {
@@ -54,12 +60,21 @@ namespace Seam.Api
                 ActionAttemptExpired = 4,
             }
 
+            /// <summary>
+            /// ID of the `acs_encoder` that will be used in the next request to encode the `acs_credential`.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
+            /// <summary>
+            /// Code of the error to simulate.
+            /// </summary>
             [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
             public NextCredentialEncodeWillFailRequest.ErrorCodeEnum? ErrorCode { get; set; }
 
+            /// <summary>
+            /// ID of the `acs_credential` that will fail to be encoded onto a card in the next request.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
@@ -83,6 +98,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialEncodeWillFail(NextCredentialEncodeWillFailRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -93,6 +111,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialEncodeWillFail(
             string acsEncoderId = default,
             NextCredentialEncodeWillFailRequest.ErrorCodeEnum? errorCode = default,
@@ -108,6 +129,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialEncodeWillFailAsync(
             NextCredentialEncodeWillFailRequest request
         )
@@ -120,6 +144,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialEncodeWillFailAsync(
             string acsEncoderId = default,
             NextCredentialEncodeWillFailRequest.ErrorCodeEnum? errorCode = default,
@@ -135,6 +162,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Simulate that the Next Credential Encoding Will Succeed.
+        /// </summary>
         [DataContract(Name = "nextCredentialEncodeWillSucceedRequest_request")]
         public class NextCredentialEncodeWillSucceedRequest
         {
@@ -150,6 +180,9 @@ namespace Seam.Api
                 Scenario = scenario;
             }
 
+            /// <summary>
+            /// Scenario to simulate.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ScenarioEnum
             {
@@ -160,9 +193,15 @@ namespace Seam.Api
                 CredentialIsIssued = 1,
             }
 
+            /// <summary>
+            /// ID of the `acs_encoder` that will be used in the next request to encode the `acs_credential`.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
+            /// <summary>
+            /// Scenario to simulate.
+            /// </summary>
             [DataMember(Name = "scenario", IsRequired = false, EmitDefaultValue = false)]
             public NextCredentialEncodeWillSucceedRequest.ScenarioEnum? Scenario { get; set; }
 
@@ -186,6 +225,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialEncodeWillSucceed(NextCredentialEncodeWillSucceedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -196,6 +238,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialEncodeWillSucceed(
             string acsEncoderId = default,
             NextCredentialEncodeWillSucceedRequest.ScenarioEnum? scenario = default
@@ -209,6 +254,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialEncodeWillSucceedAsync(
             NextCredentialEncodeWillSucceedRequest request
         )
@@ -221,6 +269,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to encode a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialEncodeWillSucceedAsync(
             string acsEncoderId = default,
             NextCredentialEncodeWillSucceedRequest.ScenarioEnum? scenario = default
@@ -234,6 +285,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Simulate that the Next Credential Scan Will Fail.
+        /// </summary>
         [DataContract(Name = "nextCredentialScanWillFailRequest_request")]
         public class NextCredentialScanWillFailRequest
         {
@@ -267,6 +321,9 @@ namespace Seam.Api
                 ActionAttemptExpired = 3,
             }
 
+            /// <summary>
+            /// ID of the `acs_encoder` that will fail to scan the `acs_credential` in the next request.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
@@ -300,6 +357,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialScanWillFail(NextCredentialScanWillFailRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -310,6 +370,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialScanWillFail(
             string acsEncoderId = default,
             NextCredentialScanWillFailRequest.ErrorCodeEnum? errorCode = default,
@@ -325,6 +388,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialScanWillFailAsync(NextCredentialScanWillFailRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -335,6 +401,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialScanWillFailAsync(
             string acsEncoderId = default,
             NextCredentialScanWillFailRequest.ErrorCodeEnum? errorCode = default,
@@ -350,6 +419,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Simulate that the Next Credential Scan Will Succeed.
+        /// </summary>
         [DataContract(Name = "nextCredentialScanWillSucceedRequest_request")]
         public class NextCredentialScanWillSucceedRequest
         {
@@ -367,6 +439,9 @@ namespace Seam.Api
                 Scenario = scenario;
             }
 
+            /// <summary>
+            /// Scenario to simulate.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ScenarioEnum
             {
@@ -386,6 +461,9 @@ namespace Seam.Api
                 CredentialOnEncoderIsEmpty = 4,
             }
 
+            /// <summary>
+            /// ID of the Seam `acs_credential` that matches the `acs_credential` on the encoder in this simulation.
+            /// </summary>
             [DataMember(
                 Name = "acs_credential_id_on_seam",
                 IsRequired = false,
@@ -393,9 +471,15 @@ namespace Seam.Api
             )]
             public string? AcsCredentialIdOnSeam { get; set; }
 
+            /// <summary>
+            /// ID of the `acs_encoder` that will be used in the next request to scan the `acs_credential`.
+            /// </summary>
             [DataMember(Name = "acs_encoder_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsEncoderId { get; set; }
 
+            /// <summary>
+            /// Scenario to simulate.
+            /// </summary>
             [DataMember(Name = "scenario", IsRequired = false, EmitDefaultValue = false)]
             public NextCredentialScanWillSucceedRequest.ScenarioEnum? Scenario { get; set; }
 
@@ -419,6 +503,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialScanWillSucceed(NextCredentialScanWillSucceedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -429,6 +516,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void NextCredentialScanWillSucceed(
             string? acsCredentialIdOnSeam = default,
             string acsEncoderId = default,
@@ -444,6 +534,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialScanWillSucceedAsync(
             NextCredentialScanWillSucceedRequest request
         )
@@ -456,6 +549,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates that the next attempt to scan a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task NextCredentialScanWillSucceedAsync(
             string? acsCredentialIdOnSeam = default,
             string acsEncoderId = default,

--- a/output/csharp/src/Seam/Api/SimulateLocks.cs
+++ b/output/csharp/src/Seam/Api/SimulateLocks.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Simulate a Keypad Code Entry.
+        /// </summary>
         [DataContract(Name = "keypadCodeEntryRequest_request")]
         public class KeypadCodeEntryRequest
         {
@@ -30,9 +33,15 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Code that you want to simulate entering on a keypad.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = true, EmitDefaultValue = false)]
             public string Code { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to simulate a keypad code entry.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -67,6 +76,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -90,6 +102,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public ActionAttempt KeypadCodeEntry(KeypadCodeEntryRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -99,11 +114,17 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public ActionAttempt KeypadCodeEntry(string code = default, string deviceId = default)
         {
             return KeypadCodeEntry(new KeypadCodeEntryRequest(code: code, deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task<ActionAttempt> KeypadCodeEntryAsync(KeypadCodeEntryRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -118,6 +139,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task<ActionAttempt> KeypadCodeEntryAsync(
             string code = default,
             string deviceId = default
@@ -130,6 +154,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Simulate a Manual Lock Action Using a Keypad.
+        /// </summary>
         [DataContract(Name = "manualLockViaKeypadRequest_request")]
         public class ManualLockViaKeypadRequest
         {
@@ -141,6 +168,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to simulate a manual lock action using a keypad.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -175,6 +205,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -198,6 +231,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public ActionAttempt ManualLockViaKeypad(ManualLockViaKeypadRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -210,11 +246,17 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public ActionAttempt ManualLockViaKeypad(string deviceId = default)
         {
             return ManualLockViaKeypad(new ManualLockViaKeypadRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task<ActionAttempt> ManualLockViaKeypadAsync(
             ManualLockViaKeypadRequest request
         )
@@ -231,6 +273,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task<ActionAttempt> ManualLockViaKeypadAsync(string deviceId = default)
         {
             return (

--- a/output/csharp/src/Seam/Api/SimulateNoiseSensors.cs
+++ b/output/csharp/src/Seam/Api/SimulateNoiseSensors.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Simulate Triggering a Noise Threshold.
+        /// </summary>
         [DataContract(Name = "triggerNoiseThresholdRequest_request")]
         public class TriggerNoiseThresholdRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to simulate the triggering of a noise threshold.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -52,6 +58,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates the triggering of a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void TriggerNoiseThreshold(TriggerNoiseThresholdRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -59,11 +68,17 @@ namespace Seam.Api
             _seam.Post<object>("/noise_sensors/simulate/trigger_noise_threshold", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates the triggering of a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public void TriggerNoiseThreshold(string deviceId = default)
         {
             TriggerNoiseThreshold(new TriggerNoiseThresholdRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Simulates the triggering of a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task TriggerNoiseThresholdAsync(TriggerNoiseThresholdRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -74,6 +89,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates the triggering of a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         public async Task TriggerNoiseThresholdAsync(string deviceId = default)
         {
             await TriggerNoiseThresholdAsync(new TriggerNoiseThresholdRequest(deviceId: deviceId));

--- a/output/csharp/src/Seam/Api/SimulatePhones.cs
+++ b/output/csharp/src/Seam/Api/SimulatePhones.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Sandbox Phone.
+        /// </summary>
         [DataContract(Name = "createSandboxPhoneRequest_request")]
         public class CreateSandboxPhoneRequest
         {
@@ -37,9 +40,15 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ASSA ABLOY metadata that you want to associate with the simulated phone.
+            /// </summary>
             [DataMember(Name = "assa_abloy_metadata", IsRequired = false, EmitDefaultValue = false)]
             public CreateSandboxPhoneRequestAssaAbloyMetadata? AssaAbloyMetadata { get; set; }
 
+            /// <summary>
+            /// ID of the custom SDK installation that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(
                 Name = "custom_sdk_installation_id",
                 IsRequired = false,
@@ -47,9 +56,15 @@ namespace Seam.Api
             )]
             public string? CustomSdkInstallationId { get; set; }
 
+            /// <summary>
+            /// Metadata that you want to associate with the simulated phone.
+            /// </summary>
             [DataMember(Name = "phone_metadata", IsRequired = false, EmitDefaultValue = false)]
             public CreateSandboxPhoneRequestPhoneMetadata? PhoneMetadata { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to associate with the simulated phone.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -96,21 +111,39 @@ namespace Seam.Api
                 SeosTsmEndpointId = seosTsmEndpointId;
             }
 
+            /// <summary>
+            /// Application version that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(Name = "application_version", IsRequired = false, EmitDefaultValue = false)]
             public string? ApplicationVersion { get; set; }
 
+            /// <summary>
+            /// Indicates whether the simulated phone should have Bluetooth low energy (BLE) capability.
+            /// </summary>
             [DataMember(Name = "ble_capability", IsRequired = false, EmitDefaultValue = false)]
             public bool? BleCapability { get; set; }
 
+            /// <summary>
+            /// Indicates whether the simulated phone should have host card emulation (HCE) capability.
+            /// </summary>
             [DataMember(Name = "hce_capability", IsRequired = false, EmitDefaultValue = false)]
             public bool? HceCapability { get; set; }
 
+            /// <summary>
+            /// Indicates whether the simulated phone should have near-field communication (NFC) capability.
+            /// </summary>
             [DataMember(Name = "nfc_capability", IsRequired = false, EmitDefaultValue = false)]
             public bool? NfcCapability { get; set; }
 
+            /// <summary>
+            /// SEOS applet version that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(Name = "seos_applet_version", IsRequired = false, EmitDefaultValue = false)]
             public string? SeosAppletVersion { get; set; }
 
+            /// <summary>
+            /// ID of the SEOS trusted service manager (TSM) endpoint that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(
                 Name = "seos_tsm_endpoint_id",
                 IsRequired = false,
@@ -158,6 +191,9 @@ namespace Seam.Api
                 OsVersion = osVersion;
             }
 
+            /// <summary>
+            /// Mobile operating system that you want to use for the simulated phone.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum OperatingSystemEnum
             {
@@ -171,15 +207,27 @@ namespace Seam.Api
                 Ios = 2,
             }
 
+            /// <summary>
+            /// Manufacturer that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(Name = "device_manufacturer", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceManufacturer { get; set; }
 
+            /// <summary>
+            /// Device model that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(Name = "device_model", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceModel { get; set; }
 
+            /// <summary>
+            /// Mobile operating system that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(Name = "operating_system", IsRequired = false, EmitDefaultValue = false)]
             public CreateSandboxPhoneRequestPhoneMetadata.OperatingSystemEnum? OperatingSystem { get; set; }
 
+            /// <summary>
+            /// Mobile operating system version that you want to use for the simulated phone.
+            /// </summary>
             [DataMember(Name = "os_version", IsRequired = false, EmitDefaultValue = false)]
             public string? OsVersion { get; set; }
 
@@ -214,6 +262,9 @@ namespace Seam.Api
                 Phone = phone;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "phone", IsRequired = false, EmitDefaultValue = false)]
             public Phone Phone { get; set; }
 
@@ -237,6 +288,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).
+        /// </summary>
         public Phone CreateSandboxPhone(CreateSandboxPhoneRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -249,6 +303,9 @@ namespace Seam.Api
                 .Data.Phone;
         }
 
+        /// <summary>
+        /// Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).
+        /// </summary>
         public Phone CreateSandboxPhone(
             CreateSandboxPhoneRequestAssaAbloyMetadata? assaAbloyMetadata = default,
             string? customSdkInstallationId = default,
@@ -266,6 +323,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).
+        /// </summary>
         public async Task<Phone> CreateSandboxPhoneAsync(CreateSandboxPhoneRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -280,6 +340,9 @@ namespace Seam.Api
                 .Phone;
         }
 
+        /// <summary>
+        /// Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).
+        /// </summary>
         public async Task<Phone> CreateSandboxPhoneAsync(
             CreateSandboxPhoneRequestAssaAbloyMetadata? assaAbloyMetadata = default,
             string? customSdkInstallationId = default,

--- a/output/csharp/src/Seam/Api/SimulateThermostats.cs
+++ b/output/csharp/src/Seam/Api/SimulateThermostats.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for HVAC Mode Adjusted.
+        /// </summary>
         [DataContract(Name = "hvacModeAdjustedRequest_request")]
         public class HvacModeAdjustedRequest
         {
@@ -41,6 +44,9 @@ namespace Seam.Api
                 HeatingSetPointFahrenheit = heatingSetPointFahrenheit;
             }
 
+            /// <summary>
+            /// HVAC mode that you want to simulate.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum HvacModeEnum
             {
@@ -60,12 +66,21 @@ namespace Seam.Api
                 HeatCool = 4,
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to simulate having adjusted the HVAC mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// HVAC mode that you want to simulate.
+            /// </summary>
             [DataMember(Name = "hvac_mode", IsRequired = true, EmitDefaultValue = false)]
             public HvacModeAdjustedRequest.HvacModeEnum HvacMode { get; set; }
 
+            /// <summary>
+            /// Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `cooling_set_point_celsius` or `cooling_set_point_fahrenheit`.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_celsius",
                 IsRequired = false,
@@ -73,6 +88,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `cooling_set_point_fahrenheit` or `cooling_set_point_celsius`.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_fahrenheit",
                 IsRequired = false,
@@ -80,6 +98,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `heating_set_point_celsius` or `heating_set_point_fahrenheit`.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_celsius",
                 IsRequired = false,
@@ -87,6 +108,9 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `heating_set_point_fahrenheit` or `heating_set_point_celsius`.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_fahrenheit",
                 IsRequired = false,
@@ -114,6 +138,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates having adjusted the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public void HvacModeAdjusted(HvacModeAdjustedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -121,6 +148,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/simulate/hvac_mode_adjusted", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates having adjusted the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public void HvacModeAdjusted(
             string deviceId = default,
             HvacModeAdjustedRequest.HvacModeEnum hvacMode = default,
@@ -142,6 +172,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates having adjusted the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public async Task HvacModeAdjustedAsync(HvacModeAdjustedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -152,6 +185,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates having adjusted the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public async Task HvacModeAdjustedAsync(
             string deviceId = default,
             HvacModeAdjustedRequest.HvacModeEnum hvacMode = default,
@@ -173,6 +209,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Temperature Reached.
+        /// </summary>
         [DataContract(Name = "temperatureReachedRequest_request")]
         public class TemperatureReachedRequest
         {
@@ -190,12 +229,21 @@ namespace Seam.Api
                 TemperatureFahrenheit = temperatureFahrenheit;
             }
 
+            /// <summary>
+            /// ID of the thermostat device that you want to simulate reaching a specified temperature.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Temperature in °C that you want simulate the thermostat reaching. You must set `temperature_celsius` or `temperature_fahrenheit`.
+            /// </summary>
             [DataMember(Name = "temperature_celsius", IsRequired = false, EmitDefaultValue = false)]
             public float? TemperatureCelsius { get; set; }
 
+            /// <summary>
+            /// Temperature in °F that you want simulate the thermostat reaching. You must set `temperature_fahrenheit` or `temperature_celsius`.
+            /// </summary>
             [DataMember(
                 Name = "temperature_fahrenheit",
                 IsRequired = false,
@@ -223,6 +271,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Simulates a [thermostat](https://docs.seam.co/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public void TemperatureReached(TemperatureReachedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -230,6 +281,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/simulate/temperature_reached", requestOptions);
         }
 
+        /// <summary>
+        /// Simulates a [thermostat](https://docs.seam.co/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public void TemperatureReached(
             string deviceId = default,
             float? temperatureCelsius = default,
@@ -245,6 +299,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates a [thermostat](https://docs.seam.co/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public async Task TemperatureReachedAsync(TemperatureReachedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -255,6 +312,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Simulates a [thermostat](https://docs.seam.co/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).
+        /// </summary>
         public async Task TemperatureReachedAsync(
             string deviceId = default,
             float? temperatureCelsius = default,

--- a/output/csharp/src/Seam/Api/Spaces.cs
+++ b/output/csharp/src/Seam/Api/Spaces.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Add Entrances to a Space.
+        /// </summary>
         [DataContract(Name = "addAcsEntrancesRequest_request")]
         public class AddAcsEntrancesRequest
         {
@@ -33,9 +36,15 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// IDs of the entrances that you want to add to the space.
+            /// </summary>
             [DataMember(Name = "acs_entrance_ids", IsRequired = true, EmitDefaultValue = false)]
             public List<string> AcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// ID of the space to which you want to add entrances.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -59,6 +68,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) to a specific space.
+        /// </summary>
         public void AddAcsEntrances(AddAcsEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -66,6 +78,9 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/add_acs_entrances", requestOptions);
         }
 
+        /// <summary>
+        /// Adds [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) to a specific space.
+        /// </summary>
         public void AddAcsEntrances(List<string> acsEntranceIds = default, string spaceId = default)
         {
             AddAcsEntrances(
@@ -73,6 +88,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Adds [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) to a specific space.
+        /// </summary>
         public async Task AddAcsEntrancesAsync(AddAcsEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -80,6 +98,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/add_acs_entrances", requestOptions);
         }
 
+        /// <summary>
+        /// Adds [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) to a specific space.
+        /// </summary>
         public async Task AddAcsEntrancesAsync(
             List<string> acsEntranceIds = default,
             string spaceId = default
@@ -90,6 +111,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Add a Connected Account to a Space.
+        /// </summary>
         [DataContract(Name = "addConnectedAccountRequest_request")]
         public class AddConnectedAccountRequest
         {
@@ -105,9 +129,15 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// ID of the connected account that you want to add to the space.
+            /// </summary>
             [DataMember(Name = "connected_account_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// ID of the space to which you want to add the connected account.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -131,6 +161,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.
+        /// </summary>
         public void AddConnectedAccount(AddConnectedAccountRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -138,6 +171,9 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/add_connected_account", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.
+        /// </summary>
         public void AddConnectedAccount(
             string connectedAccountId = default,
             string spaceId = default
@@ -151,6 +187,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.
+        /// </summary>
         public async Task AddConnectedAccountAsync(AddConnectedAccountRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -158,6 +197,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/add_connected_account", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.
+        /// </summary>
         public async Task AddConnectedAccountAsync(
             string connectedAccountId = default,
             string spaceId = default
@@ -171,6 +213,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Add Devices to a Space.
+        /// </summary>
         [DataContract(Name = "addDevicesRequest_request")]
         public class AddDevicesRequest
         {
@@ -183,9 +228,15 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// IDs of the devices that you want to add to the space.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = true, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
+            /// <summary>
+            /// ID of the space to which you want to add devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -209,6 +260,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds devices to a specific space.
+        /// </summary>
         public void AddDevices(AddDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -216,11 +270,17 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/add_devices", requestOptions);
         }
 
+        /// <summary>
+        /// Adds devices to a specific space.
+        /// </summary>
         public void AddDevices(List<string> deviceIds = default, string spaceId = default)
         {
             AddDevices(new AddDevicesRequest(deviceIds: deviceIds, spaceId: spaceId));
         }
 
+        /// <summary>
+        /// Adds devices to a specific space.
+        /// </summary>
         public async Task AddDevicesAsync(AddDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -228,6 +288,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/add_devices", requestOptions);
         }
 
+        /// <summary>
+        /// Adds devices to a specific space.
+        /// </summary>
         public async Task AddDevicesAsync(
             List<string> deviceIds = default,
             string spaceId = default
@@ -236,6 +299,9 @@ namespace Seam.Api
             await AddDevicesAsync(new AddDevicesRequest(deviceIds: deviceIds, spaceId: spaceId));
         }
 
+        /// <summary>
+        /// Request parameters for Create a Space.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -261,9 +327,15 @@ namespace Seam.Api
                 SpaceKey = spaceKey;
             }
 
+            /// <summary>
+            /// IDs of the entrances that you want to add to the new space.
+            /// </summary>
             [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// IDs of connected accounts to associate with the new space. Persisted on seam.location_third_party_account so the UI can show which provider account(s) a space came from.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -271,18 +343,33 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Reservation/stay-related defaults for the space.
+            /// </summary>
             [DataMember(Name = "customer_data", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestCustomerData? CustomerData { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to create the space.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// IDs of the devices that you want to add to the new space.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Name of the space that you want to create.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = true, EmitDefaultValue = false)]
             public string Name { get; set; }
 
+            /// <summary>
+            /// Unique key for the space within the workspace.
+            /// </summary>
             [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceKey { get; set; }
 
@@ -325,9 +412,15 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// Postal address for the space.
+            /// </summary>
             [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
             public string? Address { get; set; }
 
+            /// <summary>
+            /// Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkin_time",
                 IsRequired = false,
@@ -335,6 +428,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckinTime { get; set; }
 
+            /// <summary>
+            /// Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkout_time",
                 IsRequired = false,
@@ -342,6 +438,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckoutTime { get; set; }
 
+            /// <summary>
+            /// IANA time zone for the space, e.g. America/Los_Angeles.
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public string? TimeZone { get; set; }
 
@@ -376,6 +475,9 @@ namespace Seam.Api
                 Space = space;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "space", IsRequired = false, EmitDefaultValue = false)]
             public Space Space { get; set; }
 
@@ -399,6 +501,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new space.
+        /// </summary>
         public Space Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -406,6 +511,9 @@ namespace Seam.Api
             return _seam.Post<CreateResponse>("/spaces/create", requestOptions).Data.Space;
         }
 
+        /// <summary>
+        /// Creates a new space.
+        /// </summary>
         public Space Create(
             List<string>? acsEntranceIds = default,
             List<string>? connectedAccountIds = default,
@@ -429,6 +537,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new space.
+        /// </summary>
         public async Task<Space> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -438,6 +549,9 @@ namespace Seam.Api
                 .Space;
         }
 
+        /// <summary>
+        /// Creates a new space.
+        /// </summary>
         public async Task<Space> CreateAsync(
             List<string>? acsEntranceIds = default,
             List<string>? connectedAccountIds = default,
@@ -463,6 +577,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Space.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -474,6 +591,9 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// ID of the space that you want to delete.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -497,6 +617,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a space.
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -504,11 +627,17 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a space.
+        /// </summary>
         public void Delete(string spaceId = default)
         {
             Delete(new DeleteRequest(spaceId: spaceId));
         }
 
+        /// <summary>
+        /// Deletes a space.
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -516,11 +645,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a space.
+        /// </summary>
         public async Task DeleteAsync(string spaceId = default)
         {
             await DeleteAsync(new DeleteRequest(spaceId: spaceId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Space.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -533,9 +668,15 @@ namespace Seam.Api
                 SpaceKey = spaceKey;
             }
 
+            /// <summary>
+            /// ID of the space that you want to get.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            /// <summary>
+            /// Unique key of the space that you want to get.
+            /// </summary>
             [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceKey { get; set; }
 
@@ -570,6 +711,9 @@ namespace Seam.Api
                 Space = space;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "space", IsRequired = false, EmitDefaultValue = false)]
             public Space Space { get; set; }
 
@@ -593,6 +737,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets a space.
+        /// </summary>
         public Space Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -600,11 +747,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/spaces/get", requestOptions).Data.Space;
         }
 
+        /// <summary>
+        /// Gets a space.
+        /// </summary>
         public Space Get(string? spaceId = default, string? spaceKey = default)
         {
             return Get(new GetRequest(spaceId: spaceId, spaceKey: spaceKey));
         }
 
+        /// <summary>
+        /// Gets a space.
+        /// </summary>
         public async Task<Space> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -612,11 +765,17 @@ namespace Seam.Api
             return (await _seam.PostAsync<GetResponse>("/spaces/get", requestOptions)).Data.Space;
         }
 
+        /// <summary>
+        /// Gets a space.
+        /// </summary>
         public async Task<Space> GetAsync(string? spaceId = default, string? spaceKey = default)
         {
             return (await GetAsync(new GetRequest(spaceId: spaceId, spaceKey: spaceKey)));
         }
 
+        /// <summary>
+        /// Request parameters for Get related Space resources.
+        /// </summary>
         [DataContract(Name = "getRelatedRequest_request")]
         public class GetRelatedRequest
         {
@@ -692,9 +851,15 @@ namespace Seam.Api
             [DataMember(Name = "include", IsRequired = false, EmitDefaultValue = false)]
             public List<GetRelatedRequest.IncludeEnum>? Include { get; set; }
 
+            /// <summary>
+            /// IDs of the spaces that you want to get along with their related resources.
+            /// </summary>
             [DataMember(Name = "space_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceIds { get; set; }
 
+            /// <summary>
+            /// Keys of the spaces that you want to get along with their related resources.
+            /// </summary>
             [DataMember(Name = "space_keys", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? SpaceKeys { get; set; }
 
@@ -729,6 +894,9 @@ namespace Seam.Api
                 Batch = batch;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "batch", IsRequired = false, EmitDefaultValue = false)]
             public Batch Batch { get; set; }
 
@@ -752,6 +920,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Spaces.
+        /// </summary>
         public Batch GetRelated(GetRelatedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -759,6 +930,9 @@ namespace Seam.Api
             return _seam.Post<GetRelatedResponse>("/spaces/get_related", requestOptions).Data.Batch;
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Spaces.
+        /// </summary>
         public Batch GetRelated(
             List<GetRelatedRequest.ExcludeEnum>? exclude = default,
             List<GetRelatedRequest.IncludeEnum>? include = default,
@@ -776,6 +950,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Spaces.
+        /// </summary>
         public async Task<Batch> GetRelatedAsync(GetRelatedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -787,6 +964,9 @@ namespace Seam.Api
                 .Batch;
         }
 
+        /// <summary>
+        /// Gets all related resources for one or more Spaces.
+        /// </summary>
         public async Task<Batch> GetRelatedAsync(
             List<GetRelatedRequest.ExcludeEnum>? exclude = default,
             List<GetRelatedRequest.IncludeEnum>? include = default,
@@ -806,6 +986,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Spaces.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -827,18 +1010,33 @@ namespace Seam.Api
                 SpaceKey = spaceKey;
             }
 
+            /// <summary>
+            /// Customer key for which you want to list spaces.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned spaces to include all records that satisfy a partial match using `name`, `space_key`, or `customer_key`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// Filter spaces by space_key.
+            /// </summary>
             [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceKey { get; set; }
 
@@ -873,6 +1071,9 @@ namespace Seam.Api
                 Spaces = spaces;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "spaces", IsRequired = false, EmitDefaultValue = false)]
             public List<Space> Spaces { get; set; }
 
@@ -896,6 +1097,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all spaces.
+        /// </summary>
         public List<Space> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -903,6 +1107,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/spaces/list", requestOptions).Data.Spaces;
         }
 
+        /// <summary>
+        /// Returns a list of all spaces.
+        /// </summary>
         public List<Space> List(
             string? customerKey = default,
             float? limit = default,
@@ -922,6 +1129,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all spaces.
+        /// </summary>
         public async Task<List<Space>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -931,6 +1141,9 @@ namespace Seam.Api
                 .Spaces;
         }
 
+        /// <summary>
+        /// Returns a list of all spaces.
+        /// </summary>
         public async Task<List<Space>> ListAsync(
             string? customerKey = default,
             float? limit = default,
@@ -952,6 +1165,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Remove Entrances from a Space.
+        /// </summary>
         [DataContract(Name = "removeAcsEntrancesRequest_request")]
         public class RemoveAcsEntrancesRequest
         {
@@ -967,9 +1183,15 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// IDs of the entrances that you want to remove from the space.
+            /// </summary>
             [DataMember(Name = "acs_entrance_ids", IsRequired = true, EmitDefaultValue = false)]
             public List<string> AcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// ID of the space from which you want to remove entrances.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -993,6 +1215,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Removes [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) from a specific space.
+        /// </summary>
         public void RemoveAcsEntrances(RemoveAcsEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1000,6 +1225,9 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/remove_acs_entrances", requestOptions);
         }
 
+        /// <summary>
+        /// Removes [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) from a specific space.
+        /// </summary>
         public void RemoveAcsEntrances(
             List<string> acsEntranceIds = default,
             string spaceId = default
@@ -1010,6 +1238,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Removes [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) from a specific space.
+        /// </summary>
         public async Task RemoveAcsEntrancesAsync(RemoveAcsEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1017,6 +1248,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/remove_acs_entrances", requestOptions);
         }
 
+        /// <summary>
+        /// Removes [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) from a specific space.
+        /// </summary>
         public async Task RemoveAcsEntrancesAsync(
             List<string> acsEntranceIds = default,
             string spaceId = default
@@ -1027,6 +1261,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Remove a Connected Account from a Space.
+        /// </summary>
         [DataContract(Name = "removeConnectedAccountRequest_request")]
         public class RemoveConnectedAccountRequest
         {
@@ -1042,9 +1279,15 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// ID of the connected account that you want to remove from the space.
+            /// </summary>
             [DataMember(Name = "connected_account_id", IsRequired = true, EmitDefaultValue = false)]
             public string ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// ID of the space from which you want to remove the connected account.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -1068,6 +1311,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.
+        /// </summary>
         public void RemoveConnectedAccount(RemoveConnectedAccountRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1075,6 +1321,9 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/remove_connected_account", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.
+        /// </summary>
         public void RemoveConnectedAccount(
             string connectedAccountId = default,
             string spaceId = default
@@ -1088,6 +1337,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.
+        /// </summary>
         public async Task RemoveConnectedAccountAsync(RemoveConnectedAccountRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1095,6 +1347,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/remove_connected_account", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.
+        /// </summary>
         public async Task RemoveConnectedAccountAsync(
             string connectedAccountId = default,
             string spaceId = default
@@ -1108,6 +1363,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Remove Devices from a Space.
+        /// </summary>
         [DataContract(Name = "removeDevicesRequest_request")]
         public class RemoveDevicesRequest
         {
@@ -1120,9 +1378,15 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// IDs of the devices that you want to remove from the space.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = true, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
+            /// <summary>
+            /// ID of the space from which you want to remove devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = true, EmitDefaultValue = false)]
             public string SpaceId { get; set; }
 
@@ -1146,6 +1410,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Removes devices from a specific space.
+        /// </summary>
         public void RemoveDevices(RemoveDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1153,11 +1420,17 @@ namespace Seam.Api
             _seam.Post<object>("/spaces/remove_devices", requestOptions);
         }
 
+        /// <summary>
+        /// Removes devices from a specific space.
+        /// </summary>
         public void RemoveDevices(List<string> deviceIds = default, string spaceId = default)
         {
             RemoveDevices(new RemoveDevicesRequest(deviceIds: deviceIds, spaceId: spaceId));
         }
 
+        /// <summary>
+        /// Removes devices from a specific space.
+        /// </summary>
         public async Task RemoveDevicesAsync(RemoveDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1165,6 +1438,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/spaces/remove_devices", requestOptions);
         }
 
+        /// <summary>
+        /// Removes devices from a specific space.
+        /// </summary>
         public async Task RemoveDevicesAsync(
             List<string> deviceIds = default,
             string spaceId = default
@@ -1175,6 +1451,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update a Space.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -1198,21 +1477,39 @@ namespace Seam.Api
                 SpaceKey = spaceKey;
             }
 
+            /// <summary>
+            /// IDs of the entrances that you want to set for the space. If specified, this will replace all existing entrances.
+            /// </summary>
             [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsEntranceIds { get; set; }
 
+            /// <summary>
+            /// Reservation/stay-related defaults for the space. Only the keys you provide are updated; omit a key to leave it unchanged. Pass null on a key to clear it.
+            /// </summary>
             [DataMember(Name = "customer_data", IsRequired = false, EmitDefaultValue = false)]
             public UpdateRequestCustomerData? CustomerData { get; set; }
 
+            /// <summary>
+            /// IDs of the devices that you want to set for the space. If specified, this will replace all existing devices.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Name of the space.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// ID of the space that you want to update.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            /// <summary>
+            /// Unique key of the space that you want to update.
+            /// </summary>
             [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceKey { get; set; }
 
@@ -1255,9 +1552,15 @@ namespace Seam.Api
                 TimeZone = timeZone;
             }
 
+            /// <summary>
+            /// Postal address for the space.
+            /// </summary>
             [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
             public string? Address { get; set; }
 
+            /// <summary>
+            /// Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkin_time",
                 IsRequired = false,
@@ -1265,6 +1568,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckinTime { get; set; }
 
+            /// <summary>
+            /// Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+            /// </summary>
             [DataMember(
                 Name = "default_checkout_time",
                 IsRequired = false,
@@ -1272,6 +1578,9 @@ namespace Seam.Api
             )]
             public string? DefaultCheckoutTime { get; set; }
 
+            /// <summary>
+            /// IANA time zone for the space, e.g. America/Los_Angeles.
+            /// </summary>
             [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
             public string? TimeZone { get; set; }
 
@@ -1306,6 +1615,9 @@ namespace Seam.Api
                 Space = space;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "space", IsRequired = false, EmitDefaultValue = false)]
             public Space Space { get; set; }
 
@@ -1329,6 +1641,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates an existing space.
+        /// </summary>
         public Space Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1336,6 +1651,9 @@ namespace Seam.Api
             return _seam.Post<UpdateResponse>("/spaces/update", requestOptions).Data.Space;
         }
 
+        /// <summary>
+        /// Updates an existing space.
+        /// </summary>
         public Space Update(
             List<string>? acsEntranceIds = default,
             UpdateRequestCustomerData? customerData = default,
@@ -1357,6 +1675,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates an existing space.
+        /// </summary>
         public async Task<Space> UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1366,6 +1687,9 @@ namespace Seam.Api
                 .Space;
         }
 
+        /// <summary>
+        /// Updates an existing space.
+        /// </summary>
         public async Task<Space> UpdateAsync(
             List<string>? acsEntranceIds = default,
             UpdateRequestCustomerData? customerData = default,

--- a/output/csharp/src/Seam/Api/SystemsAcs.cs
+++ b/output/csharp/src/Seam/Api/SystemsAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an ACS System.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 AcsSystemId = acsSystemId;
             }
 
+            /// <summary>
+            /// ID of the access system that you want to get.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsSystemId { get; set; }
 
@@ -63,6 +69,9 @@ namespace Seam.Api
                 AcsSystem = acsSystem;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_system", IsRequired = false, EmitDefaultValue = false)]
             public AcsSystem AcsSystem { get; set; }
 
@@ -86,6 +95,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         public AcsSystem Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -93,11 +105,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/acs/systems/get", requestOptions).Data.AcsSystem;
         }
 
+        /// <summary>
+        /// Returns a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         public AcsSystem Get(string acsSystemId = default)
         {
             return Get(new GetRequest(acsSystemId: acsSystemId));
         }
 
+        /// <summary>
+        /// Returns a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         public async Task<AcsSystem> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -107,11 +125,17 @@ namespace Seam.Api
                 .AcsSystem;
         }
 
+        /// <summary>
+        /// Returns a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         public async Task<AcsSystem> GetAsync(string acsSystemId = default)
         {
             return (await GetAsync(new GetRequest(acsSystemId: acsSystemId)));
         }
 
+        /// <summary>
+        /// Request parameters for List ACS Systems.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -129,6 +153,9 @@ namespace Seam.Api
                 Search = search;
             }
 
+            /// <summary>
+            /// ID of the connected account by which you want to filter the list of access systems.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -136,9 +163,15 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list access systems.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned access systems to include all records that satisfy a partial match using `name` or `acs_system_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
@@ -173,6 +206,9 @@ namespace Seam.Api
                 AcsSystems = acsSystems;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_systems", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsSystem> AcsSystems { get; set; }
 
@@ -196,6 +232,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// To filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.
+        /// </summary>
         public List<AcsSystem> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -203,6 +244,11 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/acs/systems/list", requestOptions).Data.AcsSystems;
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// To filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.
+        /// </summary>
         public List<AcsSystem> List(
             string? connectedAccountId = default,
             string? customerKey = default,
@@ -218,6 +264,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// To filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.
+        /// </summary>
         public async Task<List<AcsSystem>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -227,6 +278,11 @@ namespace Seam.Api
                 .AcsSystems;
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// To filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.
+        /// </summary>
         public async Task<List<AcsSystem>> ListAsync(
             string? connectedAccountId = default,
             string? customerKey = default,
@@ -244,6 +300,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Compatible Credential Manager ACS Systems.
+        /// </summary>
         [DataContract(Name = "listCompatibleCredentialManagerAcsSystemsRequest_request")]
         public class ListCompatibleCredentialManagerAcsSystemsRequest
         {
@@ -255,6 +314,9 @@ namespace Seam.Api
                 AcsSystemId = acsSystemId;
             }
 
+            /// <summary>
+            /// ID of the access system for which you want to retrieve all compatible credential manager systems.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsSystemId { get; set; }
 
@@ -291,6 +353,9 @@ namespace Seam.Api
                 AcsSystems = acsSystems;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_systems", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsSystem> AcsSystems { get; set; }
 
@@ -314,6 +379,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// Specify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.
+        /// </summary>
         public List<AcsSystem> ListCompatibleCredentialManagerAcsSystems(
             ListCompatibleCredentialManagerAcsSystemsRequest request
         )
@@ -328,6 +398,11 @@ namespace Seam.Api
                 .Data.AcsSystems;
         }
 
+        /// <summary>
+        /// Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// Specify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.
+        /// </summary>
         public List<AcsSystem> ListCompatibleCredentialManagerAcsSystems(
             string acsSystemId = default
         )
@@ -337,6 +412,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// Specify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.
+        /// </summary>
         public async Task<List<AcsSystem>> ListCompatibleCredentialManagerAcsSystemsAsync(
             ListCompatibleCredentialManagerAcsSystemsRequest request
         )
@@ -353,6 +433,11 @@ namespace Seam.Api
                 .AcsSystems;
         }
 
+        /// <summary>
+        /// Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// Specify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.
+        /// </summary>
         public async Task<List<AcsSystem>> ListCompatibleCredentialManagerAcsSystemsAsync(
             string acsSystemId = default
         )
@@ -364,6 +449,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Report Devices.
+        /// </summary>
         [DataContract(Name = "reportDevicesRequest_request")]
         public class ReportDevicesRequest
         {
@@ -381,12 +469,21 @@ namespace Seam.Api
                 AcsSystemId = acsSystemId;
             }
 
+            /// <summary>
+            /// Array of ACS encoders to report
+            /// </summary>
             [DataMember(Name = "acs_encoders", IsRequired = false, EmitDefaultValue = false)]
             public List<ReportDevicesRequestAcsEncoders>? AcsEncoders { get; set; }
 
+            /// <summary>
+            /// Array of ACS entrances to report
+            /// </summary>
             [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
             public List<ReportDevicesRequestAcsEntrances>? AcsEntrances { get; set; }
 
+            /// <summary>
+            /// ID of the ACS system to report resources for
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsSystemId { get; set; }
 
@@ -425,9 +522,15 @@ namespace Seam.Api
                 IsRemoved = isRemoved;
             }
 
+            /// <summary>
+            /// Hotek-specific metadata associated with the entrance.
+            /// </summary>
             [DataMember(Name = "hotek_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ReportDevicesRequestAcsEncodersHotekMetadata? HotekMetadata { get; set; }
 
+            /// <summary>
+            /// Whether the encoder is removed
+            /// </summary>
             [DataMember(Name = "is_removed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsRemoved { get; set; }
 
@@ -462,6 +565,9 @@ namespace Seam.Api
                 EncoderNumber = encoderNumber;
             }
 
+            /// <summary>
+            /// The encoder number determined by the USB port connection.
+            /// </summary>
             [DataMember(Name = "encoder_number", IsRequired = false, EmitDefaultValue = false)]
             public string? EncoderNumber { get; set; }
 
@@ -500,9 +606,15 @@ namespace Seam.Api
                 IsRemoved = isRemoved;
             }
 
+            /// <summary>
+            /// Hotek-specific metadata associated with the entrance.
+            /// </summary>
             [DataMember(Name = "hotek_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ReportDevicesRequestAcsEntrancesHotekMetadata? HotekMetadata { get; set; }
 
+            /// <summary>
+            /// Whether the entrance is removed
+            /// </summary>
             [DataMember(Name = "is_removed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsRemoved { get; set; }
 
@@ -543,12 +655,21 @@ namespace Seam.Api
                 RoomNumber = roomNumber;
             }
 
+            /// <summary>
+            /// The common area name
+            /// </summary>
             [DataMember(Name = "common_area_name", IsRequired = false, EmitDefaultValue = false)]
             public string? CommonAreaName { get; set; }
 
+            /// <summary>
+            /// The room number identifier
+            /// </summary>
             [DataMember(Name = "common_area_number", IsRequired = false, EmitDefaultValue = false)]
             public string? CommonAreaNumber { get; set; }
 
+            /// <summary>
+            /// The room number identifier
+            /// </summary>
             [DataMember(Name = "room_number", IsRequired = false, EmitDefaultValue = false)]
             public string? RoomNumber { get; set; }
 
@@ -572,6 +693,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Reports ACS system device status including encoders and entrances.
+        /// </summary>
         public void ReportDevices(ReportDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -579,6 +703,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/systems/report_devices", requestOptions);
         }
 
+        /// <summary>
+        /// Reports ACS system device status including encoders and entrances.
+        /// </summary>
         public void ReportDevices(
             List<ReportDevicesRequestAcsEncoders>? acsEncoders = default,
             List<ReportDevicesRequestAcsEntrances>? acsEntrances = default,
@@ -594,6 +721,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Reports ACS system device status including encoders and entrances.
+        /// </summary>
         public async Task ReportDevicesAsync(ReportDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -601,6 +731,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/systems/report_devices", requestOptions);
         }
 
+        /// <summary>
+        /// Reports ACS system device status including encoders and entrances.
+        /// </summary>
         public async Task ReportDevicesAsync(
             List<ReportDevicesRequestAcsEncoders>? acsEncoders = default,
             List<ReportDevicesRequestAcsEntrances>? acsEntrances = default,

--- a/output/csharp/src/Seam/Api/Thermostats.cs
+++ b/output/csharp/src/Seam/Api/Thermostats.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Activate a Climate Preset.
+        /// </summary>
         [DataContract(Name = "activateClimatePresetRequest_request")]
         public class ActivateClimatePresetRequest
         {
@@ -33,9 +36,15 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Climate preset key of the climate preset that you want to activate.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = true, EmitDefaultValue = false)]
             public string ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to activate a climate preset.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -70,6 +79,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -93,6 +105,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Activates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ActionAttempt ActivateClimatePreset(ActivateClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -105,6 +120,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Activates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ActionAttempt ActivateClimatePreset(
             string climatePresetKey = default,
             string deviceId = default
@@ -118,6 +136,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Activates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ActionAttempt> ActivateClimatePresetAsync(
             ActivateClimatePresetRequest request
         )
@@ -134,6 +155,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Activates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ActionAttempt> ActivateClimatePresetAsync(
             string climatePresetKey = default,
             string deviceId = default
@@ -149,6 +173,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set to Cool Mode.
+        /// </summary>
         [DataContract(Name = "coolRequest_request")]
         public class CoolRequest
         {
@@ -166,6 +193,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_celsius",
                 IsRequired = false,
@@ -173,6 +203,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_fahrenheit",
                 IsRequired = false,
@@ -180,6 +213,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device that you want to set to cool mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -214,6 +250,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -237,6 +276,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [cool mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt Cool(CoolRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -244,6 +286,9 @@ namespace Seam.Api
             return _seam.Post<CoolResponse>("/thermostats/cool", requestOptions).Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [cool mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt Cool(
             float? coolingSetPointCelsius = default,
             float? coolingSetPointFahrenheit = default,
@@ -259,6 +304,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [cool mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> CoolAsync(CoolRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -268,6 +316,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [cool mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> CoolAsync(
             float? coolingSetPointCelsius = default,
             float? coolingSetPointFahrenheit = default,
@@ -285,6 +336,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Create a Climate Preset.
+        /// </summary>
         [DataContract(Name = "createClimatePresetRequest_request")]
         public class CreateClimatePresetRequest
         {
@@ -320,6 +374,9 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ClimatePresetModeEnum
             {
@@ -345,6 +402,9 @@ namespace Seam.Api
                 Unoccupied = 6,
             }
 
+            /// <summary>
+            /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum FanModeSettingEnum
             {
@@ -361,6 +421,9 @@ namespace Seam.Api
                 Circulate = 3,
             }
 
+            /// <summary>
+            /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum HvacModeSettingEnum
             {
@@ -383,12 +446,21 @@ namespace Seam.Api
                 Eco = 5,
             }
 
+            /// <summary>
+            /// Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = true, EmitDefaultValue = false)]
             public string ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+            /// </summary>
             [DataMember(Name = "climate_preset_mode", IsRequired = false, EmitDefaultValue = false)]
             public CreateClimatePresetRequest.ClimatePresetModeEnum? ClimatePresetMode { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_celsius",
                 IsRequired = false,
@@ -396,6 +468,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_fahrenheit",
                 IsRequired = false,
@@ -403,15 +478,27 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want create a climate preset.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Metadata specific to the Ecobee climate, if applicable.
+            /// </summary>
             [DataMember(Name = "ecobee_metadata", IsRequired = false, EmitDefaultValue = false)]
             public CreateClimatePresetRequestEcobeeMetadata? EcobeeMetadata { get; set; }
 
+            /// <summary>
+            /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+            /// </summary>
             [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
             public CreateClimatePresetRequest.FanModeSettingEnum? FanModeSetting { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_celsius",
                 IsRequired = false,
@@ -419,6 +506,9 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_fahrenheit",
                 IsRequired = false,
@@ -426,9 +516,16 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+            /// </summary>
             [DataMember(Name = "hvac_mode_setting", IsRequired = false, EmitDefaultValue = false)]
             public CreateClimatePresetRequest.HvacModeSettingEnum? HvacModeSetting { get; set; }
 
+            /// <summary>
+            /// Indicates whether a person at the thermostat or using the API can change the thermostat&apos;s settings.
+            /// </summary>
+            [Obsolete("Use 'thermostat_schedule.is_override_allowed'")]
             [DataMember(
                 Name = "manual_override_allowed",
                 IsRequired = false,
@@ -436,6 +533,9 @@ namespace Seam.Api
             )]
             public bool? ManualOverrideAllowed { get; set; }
 
+            /// <summary>
+            /// User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -476,6 +576,9 @@ namespace Seam.Api
                 Owner = owner;
             }
 
+            /// <summary>
+            /// Indicates whether the climate preset is owned by the user or the system.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum OwnerEnum
             {
@@ -489,12 +592,21 @@ namespace Seam.Api
                 System = 2,
             }
 
+            /// <summary>
+            /// Reference to the Ecobee climate, if applicable.
+            /// </summary>
             [DataMember(Name = "climate_ref", IsRequired = false, EmitDefaultValue = false)]
             public string? ClimateRef { get; set; }
 
+            /// <summary>
+            /// Indicates if the climate preset is optimized by Ecobee.
+            /// </summary>
             [DataMember(Name = "is_optimized", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsOptimized { get; set; }
 
+            /// <summary>
+            /// Indicates whether the climate preset is owned by the user or the system.
+            /// </summary>
             [DataMember(Name = "owner", IsRequired = false, EmitDefaultValue = false)]
             public CreateClimatePresetRequestEcobeeMetadata.OwnerEnum? Owner { get; set; }
 
@@ -518,6 +630,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void CreateClimatePreset(CreateClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -525,6 +640,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/create_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Creates a [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void CreateClimatePreset(
             string climatePresetKey = default,
             CreateClimatePresetRequest.ClimatePresetModeEnum? climatePresetMode = default,
@@ -558,6 +676,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task CreateClimatePresetAsync(CreateClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -565,6 +686,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/create_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Creates a [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task CreateClimatePresetAsync(
             string climatePresetKey = default,
             CreateClimatePresetRequest.ClimatePresetModeEnum? climatePresetMode = default,
@@ -598,6 +722,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Climate Preset.
+        /// </summary>
         [DataContract(Name = "deleteClimatePresetRequest_request")]
         public class DeleteClimatePresetRequest
         {
@@ -613,9 +740,15 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Climate preset key of the climate preset that you want to delete.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = true, EmitDefaultValue = false)]
             public string ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to delete a climate preset.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -639,6 +772,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void DeleteClimatePreset(DeleteClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -646,6 +782,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/delete_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void DeleteClimatePreset(
             string climatePresetKey = default,
             string deviceId = default
@@ -659,6 +798,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task DeleteClimatePresetAsync(DeleteClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -666,6 +808,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/delete_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task DeleteClimatePresetAsync(
             string climatePresetKey = default,
             string deviceId = default
@@ -679,6 +824,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set to Heat Mode.
+        /// </summary>
         [DataContract(Name = "heatRequest_request")]
         public class HeatRequest
         {
@@ -696,9 +844,15 @@ namespace Seam.Api
                 HeatingSetPointFahrenheit = heatingSetPointFahrenheit;
             }
 
+            /// <summary>
+            /// ID of the thermostat device that you want to set to heat mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_celsius",
                 IsRequired = false,
@@ -706,6 +860,9 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_fahrenheit",
                 IsRequired = false,
@@ -744,6 +901,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -767,6 +927,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt Heat(HeatRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -774,6 +937,9 @@ namespace Seam.Api
             return _seam.Post<HeatResponse>("/thermostats/heat", requestOptions).Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt Heat(
             string deviceId = default,
             float? heatingSetPointCelsius = default,
@@ -789,6 +955,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> HeatAsync(HeatRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -798,6 +967,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> HeatAsync(
             string deviceId = default,
             float? heatingSetPointCelsius = default,
@@ -815,6 +987,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set to Heat-Cool (Auto) Mode.
+        /// </summary>
         [DataContract(Name = "heatCoolRequest_request")]
         public class HeatCoolRequest
         {
@@ -836,6 +1011,9 @@ namespace Seam.Api
                 HeatingSetPointFahrenheit = heatingSetPointFahrenheit;
             }
 
+            /// <summary>
+            /// [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_celsius",
                 IsRequired = false,
@@ -843,6 +1021,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_fahrenheit",
                 IsRequired = false,
@@ -850,9 +1031,15 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device that you want to set to heat-cool mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_celsius",
                 IsRequired = false,
@@ -860,6 +1047,9 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_fahrenheit",
                 IsRequired = false,
@@ -898,6 +1088,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -921,6 +1114,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat-cool (&quot;auto&quot;) mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt HeatCool(HeatCoolRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -930,6 +1126,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat-cool (&quot;auto&quot;) mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt HeatCool(
             float? coolingSetPointCelsius = default,
             float? coolingSetPointFahrenheit = default,
@@ -949,6 +1148,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat-cool (&quot;auto&quot;) mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> HeatCoolAsync(HeatCoolRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -960,6 +1162,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat-cool (&quot;auto&quot;) mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> HeatCoolAsync(
             float? coolingSetPointCelsius = default,
             float? coolingSetPointFahrenheit = default,
@@ -981,6 +1186,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Thermostats.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -1024,6 +1232,9 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Device type by which you want to filter thermostat devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypeEnum
             {
@@ -1049,6 +1260,9 @@ namespace Seam.Api
                 SmartthingsThermostat = 6,
             }
 
+            /// <summary>
+            /// Array of device types by which you want to filter thermostat devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypesEnum
             {
@@ -1074,6 +1288,9 @@ namespace Seam.Api
                 SmartthingsThermostat = 6,
             }
 
+            /// <summary>
+            /// Manufacturer by which you want to filter thermostat devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ManufacturerEnum
             {
@@ -1099,9 +1316,15 @@ namespace Seam.Api
                 Tado = 6,
             }
 
+            /// <summary>
+            /// ID of the Connect Webview for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -1109,6 +1332,9 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Array of IDs of the connected accounts for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -1116,39 +1342,73 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Array of device IDs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Device type by which you want to filter thermostat devices.
+            /// </summary>
             [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.DeviceTypeEnum? DeviceType { get; set; }
 
+            /// <summary>
+            /// Array of device types by which you want to filter thermostat devices.
+            /// </summary>
             [DataMember(Name = "device_types", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequest.DeviceTypesEnum>? DeviceTypes { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of devices to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Manufacturer by which you want to filter thermostat devices.
+            /// </summary>
             [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.ManufacturerEnum? Manufacturer { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(
                 Name = "unstable_location_id",
                 IsRequired = false,
@@ -1156,6 +1416,9 @@ namespace Seam.Api
             )]
             public string? UnstableLocationId { get; set; }
 
+            /// <summary>
+            /// Your own internal user ID for the user for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -1190,6 +1453,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
             public List<Device> Devices { get; set; }
 
@@ -1213,6 +1479,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public List<Device> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1220,6 +1489,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/thermostats/list", requestOptions).Data.Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public List<Device> List(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -1261,6 +1533,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<List<Device>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1270,6 +1545,9 @@ namespace Seam.Api
                 .Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<List<Device>> ListAsync(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -1313,6 +1591,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set to Off Mode.
+        /// </summary>
         [DataContract(Name = "offRequest_request")]
         public class OffRequest
         {
@@ -1324,6 +1605,9 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the thermostat device that you want to set to off mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -1358,6 +1642,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -1381,6 +1668,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [&quot;off&quot; mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt Off(OffRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1388,11 +1678,17 @@ namespace Seam.Api
             return _seam.Post<OffResponse>("/thermostats/off", requestOptions).Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [&quot;off&quot; mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public ActionAttempt Off(string deviceId = default)
         {
             return Off(new OffRequest(deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [&quot;off&quot; mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> OffAsync(OffRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1402,11 +1698,17 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [&quot;off&quot; mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).
+        /// </summary>
         public async Task<ActionAttempt> OffAsync(string deviceId = default)
         {
             return (await OffAsync(new OffRequest(deviceId: deviceId)));
         }
 
+        /// <summary>
+        /// Request parameters for Set the Fallback Climate Preset.
+        /// </summary>
         [DataContract(Name = "setFallbackClimatePresetRequest_request")]
         public class SetFallbackClimatePresetRequest
         {
@@ -1422,9 +1724,15 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// Climate preset key of the climate preset that you want to set as the fallback climate preset.
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = true, EmitDefaultValue = false)]
             public string ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to set the fallback climate preset.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
@@ -1448,6 +1756,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) as the [&quot;fallback&quot;](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void SetFallbackClimatePreset(SetFallbackClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1455,6 +1766,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/set_fallback_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Sets a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) as the [&quot;fallback&quot;](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void SetFallbackClimatePreset(
             string climatePresetKey = default,
             string deviceId = default
@@ -1468,6 +1782,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) as the [&quot;fallback&quot;](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task SetFallbackClimatePresetAsync(SetFallbackClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1478,6 +1795,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) as the [&quot;fallback&quot;](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task SetFallbackClimatePresetAsync(
             string climatePresetKey = default,
             string deviceId = default
@@ -1491,6 +1811,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set the Fan Mode Setting.
+        /// </summary>
         [DataContract(Name = "setFanModeRequest_request")]
         public class SetFanModeRequest
         {
@@ -1508,6 +1831,9 @@ namespace Seam.Api
                 FanModeSetting = fanModeSetting;
             }
 
+            /// <summary>
+            /// Fan mode setting for the thermostat, such as `auto`, `on`, or `circulate`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum FanModeEnum
             {
@@ -1524,6 +1850,9 @@ namespace Seam.Api
                 Circulate = 3,
             }
 
+            /// <summary>
+            /// [Fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) that you want to set for the thermostat.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum FanModeSettingEnum
             {
@@ -1540,12 +1869,22 @@ namespace Seam.Api
                 Circulate = 3,
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to set the fan mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Fan mode setting for the thermostat, such as `auto`, `on`, or `circulate`.
+            /// </summary>
+            [Obsolete("Use `fan_mode_setting` instead.")]
             [DataMember(Name = "fan_mode", IsRequired = false, EmitDefaultValue = false)]
             public SetFanModeRequest.FanModeEnum? FanMode { get; set; }
 
+            /// <summary>
+            /// [Fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) that you want to set for the thermostat.
+            /// </summary>
             [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
             public SetFanModeRequest.FanModeSettingEnum? FanModeSetting { get; set; }
 
@@ -1580,6 +1919,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -1603,6 +1945,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets the [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ActionAttempt SetFanMode(SetFanModeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1612,6 +1957,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets the [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ActionAttempt SetFanMode(
             string deviceId = default,
             SetFanModeRequest.FanModeEnum? fanMode = default,
@@ -1627,6 +1975,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets the [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ActionAttempt> SetFanModeAsync(SetFanModeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1641,6 +1992,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets the [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ActionAttempt> SetFanModeAsync(
             string deviceId = default,
             SetFanModeRequest.FanModeEnum? fanMode = default,
@@ -1658,6 +2012,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set the HVAC Mode.
+        /// </summary>
         [DataContract(Name = "setHvacModeRequest_request")]
         public class SetHvacModeRequest
         {
@@ -1703,12 +2060,18 @@ namespace Seam.Api
                 Eco = 5,
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to set the HVAC mode.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
             [DataMember(Name = "hvac_mode_setting", IsRequired = true, EmitDefaultValue = false)]
             public SetHvacModeRequest.HvacModeSettingEnum HvacModeSetting { get; set; }
 
+            /// <summary>
+            /// [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_celsius",
                 IsRequired = false,
@@ -1716,6 +2079,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// [Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_fahrenheit",
                 IsRequired = false,
@@ -1723,6 +2089,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_celsius",
                 IsRequired = false,
@@ -1730,6 +2099,9 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// [Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_fahrenheit",
                 IsRequired = false,
@@ -1768,6 +2140,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -1791,6 +2166,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ActionAttempt SetHvacMode(SetHvacModeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1800,6 +2178,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public ActionAttempt SetHvacMode(
             string deviceId = default,
             SetHvacModeRequest.HvacModeSettingEnum hvacModeSetting = default,
@@ -1821,6 +2202,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ActionAttempt> SetHvacModeAsync(SetHvacModeRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1835,6 +2219,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Sets the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task<ActionAttempt> SetHvacModeAsync(
             string deviceId = default,
             SetHvacModeRequest.HvacModeSettingEnum hvacModeSetting = default,
@@ -1858,6 +2245,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Set a Temperature Threshold.
+        /// </summary>
         [DataContract(Name = "setTemperatureThresholdRequest_request")]
         public class SetTemperatureThresholdRequest
         {
@@ -1879,12 +2269,21 @@ namespace Seam.Api
                 UpperLimitFahrenheit = upperLimitFahrenheit;
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to set a temperature threshold.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Lower temperature limit in in °C. Seam alerts you if the reported temperature is lower than this value. You can specify either `lower_limit` but not both.
+            /// </summary>
             [DataMember(Name = "lower_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
             public float? LowerLimitCelsius { get; set; }
 
+            /// <summary>
+            /// Lower temperature limit in in °F. Seam alerts you if the reported temperature is lower than this value. You can specify either `lower_limit` but not both.
+            /// </summary>
             [DataMember(
                 Name = "lower_limit_fahrenheit",
                 IsRequired = false,
@@ -1892,9 +2291,15 @@ namespace Seam.Api
             )]
             public float? LowerLimitFahrenheit { get; set; }
 
+            /// <summary>
+            /// Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either `upper_limit` but not both.
+            /// </summary>
             [DataMember(Name = "upper_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
             public float? UpperLimitCelsius { get; set; }
 
+            /// <summary>
+            /// Upper temperature limit in in °C. Seam alerts you if the reported temperature is higher than this value. You can specify either `upper_limit` but not both.
+            /// </summary>
             [DataMember(
                 Name = "upper_limit_fahrenheit",
                 IsRequired = false,
@@ -1922,6 +2327,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.
+        /// </summary>
         public void SetTemperatureThreshold(SetTemperatureThresholdRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1929,6 +2337,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/set_temperature_threshold", requestOptions);
         }
 
+        /// <summary>
+        /// Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.
+        /// </summary>
         public void SetTemperatureThreshold(
             string deviceId = default,
             float? lowerLimitCelsius = default,
@@ -1948,6 +2359,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.
+        /// </summary>
         public async Task SetTemperatureThresholdAsync(SetTemperatureThresholdRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1955,6 +2369,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/set_temperature_threshold", requestOptions);
         }
 
+        /// <summary>
+        /// Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.
+        /// </summary>
         public async Task SetTemperatureThresholdAsync(
             string deviceId = default,
             float? lowerLimitCelsius = default,
@@ -1974,6 +2391,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update a Climate Preset.
+        /// </summary>
         [DataContract(Name = "updateClimatePresetRequest_request")]
         public class UpdateClimatePresetRequest
         {
@@ -2009,6 +2429,9 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ClimatePresetModeEnum
             {
@@ -2034,6 +2457,9 @@ namespace Seam.Api
                 Unoccupied = 6,
             }
 
+            /// <summary>
+            /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum FanModeSettingEnum
             {
@@ -2050,6 +2476,9 @@ namespace Seam.Api
                 Circulate = 3,
             }
 
+            /// <summary>
+            /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum HvacModeSettingEnum
             {
@@ -2072,12 +2501,21 @@ namespace Seam.Api
                 Eco = 5,
             }
 
+            /// <summary>
+            /// Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+            /// </summary>
             [DataMember(Name = "climate_preset_key", IsRequired = true, EmitDefaultValue = false)]
             public string ClimatePresetKey { get; set; }
 
+            /// <summary>
+            /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+            /// </summary>
             [DataMember(Name = "climate_preset_mode", IsRequired = false, EmitDefaultValue = false)]
             public UpdateClimatePresetRequest.ClimatePresetModeEnum? ClimatePresetMode { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_celsius",
                 IsRequired = false,
@@ -2085,6 +2523,9 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "cooling_set_point_fahrenheit",
                 IsRequired = false,
@@ -2092,15 +2533,27 @@ namespace Seam.Api
             )]
             public float? CoolingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to update a climate preset.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Metadata specific to the Ecobee climate, if applicable.
+            /// </summary>
             [DataMember(Name = "ecobee_metadata", IsRequired = false, EmitDefaultValue = false)]
             public UpdateClimatePresetRequestEcobeeMetadata? EcobeeMetadata { get; set; }
 
+            /// <summary>
+            /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+            /// </summary>
             [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
             public UpdateClimatePresetRequest.FanModeSettingEnum? FanModeSetting { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_celsius",
                 IsRequired = false,
@@ -2108,6 +2561,9 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointCelsius { get; set; }
 
+            /// <summary>
+            /// Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+            /// </summary>
             [DataMember(
                 Name = "heating_set_point_fahrenheit",
                 IsRequired = false,
@@ -2115,9 +2571,16 @@ namespace Seam.Api
             )]
             public float? HeatingSetPointFahrenheit { get; set; }
 
+            /// <summary>
+            /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+            /// </summary>
             [DataMember(Name = "hvac_mode_setting", IsRequired = false, EmitDefaultValue = false)]
             public UpdateClimatePresetRequest.HvacModeSettingEnum? HvacModeSetting { get; set; }
 
+            /// <summary>
+            /// Indicates whether a person at the thermostat can change the thermostat&apos;s settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+            /// </summary>
+            [Obsolete("Use 'thermostat_schedule.is_override_allowed'")]
             [DataMember(
                 Name = "manual_override_allowed",
                 IsRequired = false,
@@ -2125,6 +2588,9 @@ namespace Seam.Api
             )]
             public bool? ManualOverrideAllowed { get; set; }
 
+            /// <summary>
+            /// User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -2165,6 +2631,9 @@ namespace Seam.Api
                 Owner = owner;
             }
 
+            /// <summary>
+            /// Indicates whether the climate preset is owned by the user or the system.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum OwnerEnum
             {
@@ -2178,12 +2647,21 @@ namespace Seam.Api
                 System = 2,
             }
 
+            /// <summary>
+            /// Reference to the Ecobee climate, if applicable.
+            /// </summary>
             [DataMember(Name = "climate_ref", IsRequired = false, EmitDefaultValue = false)]
             public string? ClimateRef { get; set; }
 
+            /// <summary>
+            /// Indicates if the climate preset is optimized by Ecobee.
+            /// </summary>
             [DataMember(Name = "is_optimized", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsOptimized { get; set; }
 
+            /// <summary>
+            /// Indicates whether the climate preset is owned by the user or the system.
+            /// </summary>
             [DataMember(Name = "owner", IsRequired = false, EmitDefaultValue = false)]
             public UpdateClimatePresetRequestEcobeeMetadata.OwnerEnum? Owner { get; set; }
 
@@ -2207,6 +2685,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void UpdateClimatePreset(UpdateClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2214,6 +2695,9 @@ namespace Seam.Api
             _seam.Post<object>("/thermostats/update_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public void UpdateClimatePreset(
             string climatePresetKey = default,
             UpdateClimatePresetRequest.ClimatePresetModeEnum? climatePresetMode = default,
@@ -2247,6 +2731,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task UpdateClimatePresetAsync(UpdateClimatePresetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2254,6 +2741,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/thermostats/update_climate_preset", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).
+        /// </summary>
         public async Task UpdateClimatePresetAsync(
             string climatePresetKey = default,
             UpdateClimatePresetRequest.ClimatePresetModeEnum? climatePresetMode = default,
@@ -2287,6 +2777,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update the Thermostat Weekly Program.
+        /// </summary>
         [DataContract(Name = "updateWeeklyProgramRequest_request")]
         public class UpdateWeeklyProgramRequest
         {
@@ -2314,27 +2807,51 @@ namespace Seam.Api
                 WednesdayProgramId = wednesdayProgramId;
             }
 
+            /// <summary>
+            /// ID of the thermostat device for which you want to update the weekly program.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Fridays.
+            /// </summary>
             [DataMember(Name = "friday_program_id", IsRequired = false, EmitDefaultValue = false)]
             public string? FridayProgramId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Mondays.
+            /// </summary>
             [DataMember(Name = "monday_program_id", IsRequired = false, EmitDefaultValue = false)]
             public string? MondayProgramId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Saturdays.
+            /// </summary>
             [DataMember(Name = "saturday_program_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SaturdayProgramId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Sundays.
+            /// </summary>
             [DataMember(Name = "sunday_program_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SundayProgramId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Thursdays.
+            /// </summary>
             [DataMember(Name = "thursday_program_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ThursdayProgramId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Tuesdays.
+            /// </summary>
             [DataMember(Name = "tuesday_program_id", IsRequired = false, EmitDefaultValue = false)]
             public string? TuesdayProgramId { get; set; }
 
+            /// <summary>
+            /// ID of the thermostat daily program to run on Wednesdays.
+            /// </summary>
             [DataMember(
                 Name = "wednesday_program_id",
                 IsRequired = false,
@@ -2373,6 +2890,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -2396,6 +2916,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates the thermostat weekly program for a thermostat device. To configure a weekly program, specify the ID of the daily program that you want to use for each day of the week. When you update a weekly program, the set of programs that you specify overwrites any previous weekly program for the thermostat.
+        /// </summary>
         public ActionAttempt UpdateWeeklyProgram(UpdateWeeklyProgramRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -2408,6 +2931,9 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Updates the thermostat weekly program for a thermostat device. To configure a weekly program, specify the ID of the daily program that you want to use for each day of the week. When you update a weekly program, the set of programs that you specify overwrites any previous weekly program for the thermostat.
+        /// </summary>
         public ActionAttempt UpdateWeeklyProgram(
             string deviceId = default,
             string? fridayProgramId = default,
@@ -2433,6 +2959,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates the thermostat weekly program for a thermostat device. To configure a weekly program, specify the ID of the daily program that you want to use for each day of the week. When you update a weekly program, the set of programs that you specify overwrites any previous weekly program for the thermostat.
+        /// </summary>
         public async Task<ActionAttempt> UpdateWeeklyProgramAsync(
             UpdateWeeklyProgramRequest request
         )
@@ -2449,6 +2978,9 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Updates the thermostat weekly program for a thermostat device. To configure a weekly program, specify the ID of the daily program that you want to use for each day of the week. When you update a weekly program, the set of programs that you specify overwrites any previous weekly program for the thermostat.
+        /// </summary>
         public async Task<ActionAttempt> UpdateWeeklyProgramAsync(
             string deviceId = default,
             string? fridayProgramId = default,

--- a/output/csharp/src/Seam/Api/UnmanagedAccessCodes.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessCodes.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Convert an Unmanaged Access Code.
+        /// </summary>
         [DataContract(Name = "convertToManagedRequest_request")]
         public class ConvertToManagedRequest
         {
@@ -37,9 +40,15 @@ namespace Seam.Api
                 IsExternalModificationAllowed = isExternalModificationAllowed;
             }
 
+            /// <summary>
+            /// ID of the unmanaged access code that you want to convert to a managed access code.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessCodeId { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the access code is allowed.
+            /// </summary>
             [DataMember(
                 Name = "allow_external_modification",
                 IsRequired = false,
@@ -47,9 +56,15 @@ namespace Seam.Api
             )]
             public bool? AllowExternalModification { get; set; }
 
+            /// <summary>
+            /// Indicates whether to force the access code conversion. To switch management of an access code from one Seam workspace to another, set `force` to `true`.
+            /// </summary>
             [DataMember(Name = "force", IsRequired = false, EmitDefaultValue = false)]
             public bool? Force { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the access code is allowed.
+            /// </summary>
             [DataMember(
                 Name = "is_external_modification_allowed",
                 IsRequired = false,
@@ -77,6 +92,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Converts an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// An unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.
+        ///
+        /// Note that not all device providers support converting an unmanaged access code to a managed access code.
+        /// </summary>
         public void ConvertToManaged(ConvertToManagedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -84,6 +106,13 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/unmanaged/convert_to_managed", requestOptions);
         }
 
+        /// <summary>
+        /// Converts an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// An unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.
+        ///
+        /// Note that not all device providers support converting an unmanaged access code to a managed access code.
+        /// </summary>
         public void ConvertToManaged(
             string accessCodeId = default,
             bool? allowExternalModification = default,
@@ -101,6 +130,13 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Converts an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// An unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.
+        ///
+        /// Note that not all device providers support converting an unmanaged access code to a managed access code.
+        /// </summary>
         public async Task ConvertToManagedAsync(ConvertToManagedRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,6 +147,13 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Converts an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// An unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.
+        ///
+        /// Note that not all device providers support converting an unmanaged access code to a managed access code.
+        /// </summary>
         public async Task ConvertToManagedAsync(
             string accessCodeId = default,
             bool? allowExternalModification = default,
@@ -128,6 +171,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete an Unmanaged Access Code.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -139,6 +185,9 @@ namespace Seam.Api
                 AccessCodeId = accessCodeId;
             }
 
+            /// <summary>
+            /// ID of the unmanaged access code that you want to delete.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessCodeId { get; set; }
 
@@ -162,6 +211,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -169,11 +221,17 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/unmanaged/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public void Delete(string accessCodeId = default)
         {
             Delete(new DeleteRequest(accessCodeId: accessCodeId));
         }
 
+        /// <summary>
+        /// Deletes an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -181,11 +239,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_codes/unmanaged/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes an [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public async Task DeleteAsync(string accessCodeId = default)
         {
             await DeleteAsync(new DeleteRequest(accessCodeId: accessCodeId));
         }
 
+        /// <summary>
+        /// Request parameters for Get an Unmanaged Access Code.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -203,12 +267,21 @@ namespace Seam.Api
                 DeviceId = deviceId;
             }
 
+            /// <summary>
+            /// ID of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessCodeId { get; set; }
 
+            /// <summary>
+            /// Code of the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
+            /// <summary>
+            /// ID of the device containing the unmanaged access code that you want to get. You must specify either `access_code_id` or both `device_id` and `code`.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
@@ -243,6 +316,9 @@ namespace Seam.Api
                 AccessCode = accessCode;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_code", IsRequired = false, EmitDefaultValue = false)]
             public UnmanagedAccessCode AccessCode { get; set; }
 
@@ -266,6 +342,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public UnmanagedAccessCode Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -275,6 +356,11 @@ namespace Seam.Api
                 .Data.AccessCode;
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public UnmanagedAccessCode Get(
             string? accessCodeId = default,
             string? code = default,
@@ -284,6 +370,11 @@ namespace Seam.Api
             return Get(new GetRequest(accessCodeId: accessCodeId, code: code, deviceId: deviceId));
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public async Task<UnmanagedAccessCode> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -295,6 +386,11 @@ namespace Seam.Api
                 .AccessCode;
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        ///
+        /// You must specify either `access_code_id` or both `device_id` and `code`.
+        /// </summary>
         public async Task<UnmanagedAccessCode> GetAsync(
             string? accessCodeId = default,
             string? code = default,
@@ -308,6 +404,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Unmanaged Access Codes.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -329,18 +428,33 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// ID of the device for which you want to list unmanaged access codes.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of unmanaged access codes to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned access codes to include all records that satisfy a partial match using `name`, `code` or `access_code_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// Your user ID for the user by which to filter unmanaged access codes.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -375,6 +489,9 @@ namespace Seam.Api
                 AccessCodes = accessCodes;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_codes", IsRequired = false, EmitDefaultValue = false)]
             public List<UnmanagedAccessCode> AccessCodes { get; set; }
 
@@ -398,6 +515,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public List<UnmanagedAccessCode> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -407,6 +527,9 @@ namespace Seam.Api
                 .Data.AccessCodes;
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public List<UnmanagedAccessCode> List(
             string deviceId = default,
             float? limit = default,
@@ -426,6 +549,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public async Task<List<UnmanagedAccessCode>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -437,6 +563,9 @@ namespace Seam.Api
                 .AccessCodes;
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public async Task<List<UnmanagedAccessCode>> ListAsync(
             string deviceId = default,
             float? limit = default,
@@ -458,6 +587,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an Unmanaged Access Code.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -479,9 +611,15 @@ namespace Seam.Api
                 IsManaged = isManaged;
             }
 
+            /// <summary>
+            /// ID of the unmanaged access code that you want to update.
+            /// </summary>
             [DataMember(Name = "access_code_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessCodeId { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed.
+            /// </summary>
             [DataMember(
                 Name = "allow_external_modification",
                 IsRequired = false,
@@ -489,9 +627,15 @@ namespace Seam.Api
             )]
             public bool? AllowExternalModification { get; set; }
 
+            /// <summary>
+            /// Indicates whether to force the unmanaged access code update.
+            /// </summary>
             [DataMember(Name = "force", IsRequired = false, EmitDefaultValue = false)]
             public bool? Force { get; set; }
 
+            /// <summary>
+            /// Indicates whether [external modification](https://docs.seam.co/low-level-apis/smart-locks/access-codes#external-modification) of the code is allowed.
+            /// </summary>
             [DataMember(
                 Name = "is_external_modification_allowed",
                 IsRequired = false,
@@ -522,6 +666,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -529,6 +676,9 @@ namespace Seam.Api
             _seam.Post<object>("/access_codes/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public void Update(
             string accessCodeId = default,
             bool? allowExternalModification = default,
@@ -548,6 +698,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -555,6 +708,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_codes/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        /// </summary>
         public async Task UpdateAsync(
             string accessCodeId = default,
             bool? allowExternalModification = default,

--- a/output/csharp/src/Seam/Api/UnmanagedAccessGrants.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessGrants.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Unmanaged Access Grant.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 AccessGrantId = accessGrantId;
             }
 
+            /// <summary>
+            /// ID of unmanaged Access Grant to get.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessGrantId { get; set; }
 
@@ -63,6 +69,9 @@ namespace Seam.Api
                 AccessGrant = accessGrant;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_grant", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrant AccessGrant { get; set; }
 
@@ -86,6 +95,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Get an unmanaged Access Grant (where is_managed = false).
+        /// </summary>
         public AccessGrant Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -95,11 +107,17 @@ namespace Seam.Api
                 .Data.AccessGrant;
         }
 
+        /// <summary>
+        /// Get an unmanaged Access Grant (where is_managed = false).
+        /// </summary>
         public AccessGrant Get(string accessGrantId = default)
         {
             return Get(new GetRequest(accessGrantId: accessGrantId));
         }
 
+        /// <summary>
+        /// Get an unmanaged Access Grant (where is_managed = false).
+        /// </summary>
         public async Task<AccessGrant> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,11 +129,17 @@ namespace Seam.Api
                 .AccessGrant;
         }
 
+        /// <summary>
+        /// Get an unmanaged Access Grant (where is_managed = false).
+        /// </summary>
         public async Task<AccessGrant> GetAsync(string accessGrantId = default)
         {
             return (await GetAsync(new GetRequest(accessGrantId: accessGrantId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Unmanaged Access Grants.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -139,21 +163,39 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the entrance by which you want to filter the list of unmanaged Access Grants.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// ID of the access system by which you want to filter the list of unmanaged Access Grants.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of unmanaged access grants to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// Filter unmanaged Access Grants by reservation_key.
+            /// </summary>
             [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
             public string? ReservationKey { get; set; }
 
+            /// <summary>
+            /// ID of user identity by which you want to filter the list of unmanaged Access Grants.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -188,6 +230,9 @@ namespace Seam.Api
                 AccessGrants = accessGrants;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_grants", IsRequired = false, EmitDefaultValue = false)]
             public List<object> AccessGrants { get; set; }
 
@@ -211,6 +256,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets unmanaged Access Grants (where is_managed = false).
+        /// </summary>
         public List<object> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -220,6 +268,9 @@ namespace Seam.Api
                 .Data.AccessGrants;
         }
 
+        /// <summary>
+        /// Gets unmanaged Access Grants (where is_managed = false).
+        /// </summary>
         public List<object> List(
             string? acsEntranceId = default,
             string? acsSystemId = default,
@@ -241,6 +292,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Gets unmanaged Access Grants (where is_managed = false).
+        /// </summary>
         public async Task<List<object>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -252,6 +306,9 @@ namespace Seam.Api
                 .AccessGrants;
         }
 
+        /// <summary>
+        /// Gets unmanaged Access Grants (where is_managed = false).
+        /// </summary>
         public async Task<List<object>> ListAsync(
             string? acsEntranceId = default,
             string? acsSystemId = default,
@@ -275,6 +332,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an Unmanaged Access Grant.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -292,12 +352,21 @@ namespace Seam.Api
                 IsManaged = isManaged;
             }
 
+            /// <summary>
+            /// ID of the unmanaged Access Grant to update.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessGrantId { get; set; }
 
+            /// <summary>
+            /// Unique key for the access grant. If not provided, the existing key will be preserved.
+            /// </summary>
             [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
             public string? AccessGrantKey { get; set; }
 
+            /// <summary>
+            /// Must be set to true to convert the unmanaged access grant to managed.
+            /// </summary>
             [DataMember(Name = "is_managed", IsRequired = true, EmitDefaultValue = false)]
             public bool IsManaged { get; set; }
 
@@ -321,6 +390,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates an unmanaged Access Grant to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged access grants to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed access grants back to unmanaged.
+        ///
+        /// When converting an unmanaged access grant to managed, all associated access methods will also be converted to managed.
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -328,6 +404,13 @@ namespace Seam.Api
             _seam.Post<object>("/access_grants/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates an unmanaged Access Grant to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged access grants to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed access grants back to unmanaged.
+        ///
+        /// When converting an unmanaged access grant to managed, all associated access methods will also be converted to managed.
+        /// </summary>
         public void Update(
             string accessGrantId = default,
             string? accessGrantKey = default,
@@ -343,6 +426,13 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates an unmanaged Access Grant to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged access grants to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed access grants back to unmanaged.
+        ///
+        /// When converting an unmanaged access grant to managed, all associated access methods will also be converted to managed.
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -350,6 +440,13 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/access_grants/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates an unmanaged Access Grant to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged access grants to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed access grants back to unmanaged.
+        ///
+        /// When converting an unmanaged access grant to managed, all associated access methods will also be converted to managed.
+        /// </summary>
         public async Task UpdateAsync(
             string accessGrantId = default,
             string? accessGrantKey = default,

--- a/output/csharp/src/Seam/Api/UnmanagedAccessMethods.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessMethods.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Unmanaged Access Method.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 AccessMethodId = accessMethodId;
             }
 
+            /// <summary>
+            /// ID of unmanaged access method to get.
+            /// </summary>
             [DataMember(Name = "access_method_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessMethodId { get; set; }
 
@@ -63,6 +69,9 @@ namespace Seam.Api
                 AccessMethod = accessMethod;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_method", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethod AccessMethod { get; set; }
 
@@ -86,6 +95,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets an unmanaged access method (where is_managed = false).
+        /// </summary>
         public AccessMethod Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -95,11 +107,17 @@ namespace Seam.Api
                 .Data.AccessMethod;
         }
 
+        /// <summary>
+        /// Gets an unmanaged access method (where is_managed = false).
+        /// </summary>
         public AccessMethod Get(string accessMethodId = default)
         {
             return Get(new GetRequest(accessMethodId: accessMethodId));
         }
 
+        /// <summary>
+        /// Gets an unmanaged access method (where is_managed = false).
+        /// </summary>
         public async Task<AccessMethod> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,11 +129,17 @@ namespace Seam.Api
                 .AccessMethod;
         }
 
+        /// <summary>
+        /// Gets an unmanaged access method (where is_managed = false).
+        /// </summary>
         public async Task<AccessMethod> GetAsync(string accessMethodId = default)
         {
             return (await GetAsync(new GetRequest(accessMethodId: accessMethodId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Unmanaged Access Methods.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -135,15 +159,27 @@ namespace Seam.Api
                 SpaceId = spaceId;
             }
 
+            /// <summary>
+            /// ID of Access Grant to list unmanaged access methods for.
+            /// </summary>
             [DataMember(Name = "access_grant_id", IsRequired = true, EmitDefaultValue = false)]
             public string AccessGrantId { get; set; }
 
+            /// <summary>
+            /// ID of the entrance for which you want to retrieve all unmanaged access methods.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
+            /// <summary>
+            /// ID of the device for which you want to retrieve all unmanaged access methods.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to retrieve all unmanaged access methods.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
@@ -178,6 +214,9 @@ namespace Seam.Api
                 AccessMethods = accessMethods;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "access_methods", IsRequired = false, EmitDefaultValue = false)]
             public List<object> AccessMethods { get; set; }
 
@@ -201,6 +240,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Lists all unmanaged access methods (where is_managed = false), usually filtered by Access Grant.
+        /// </summary>
         public List<object> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -210,6 +252,9 @@ namespace Seam.Api
                 .Data.AccessMethods;
         }
 
+        /// <summary>
+        /// Lists all unmanaged access methods (where is_managed = false), usually filtered by Access Grant.
+        /// </summary>
         public List<object> List(
             string accessGrantId = default,
             string? acsEntranceId = default,
@@ -227,6 +272,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Lists all unmanaged access methods (where is_managed = false), usually filtered by Access Grant.
+        /// </summary>
         public async Task<List<object>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -241,6 +289,9 @@ namespace Seam.Api
                 .AccessMethods;
         }
 
+        /// <summary>
+        /// Lists all unmanaged access methods (where is_managed = false), usually filtered by Access Grant.
+        /// </summary>
         public async Task<List<object>> ListAsync(
             string accessGrantId = default,
             string? acsEntranceId = default,

--- a/output/csharp/src/Seam/Api/UnmanagedDevices.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedDevices.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Unmanaged Device.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -30,9 +33,15 @@ namespace Seam.Api
                 Name = name;
             }
 
+            /// <summary>
+            /// ID of the unmanaged device that you want to get.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string? DeviceId { get; set; }
 
+            /// <summary>
+            /// Name of the unmanaged device that you want to get.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -67,6 +76,9 @@ namespace Seam.Api
                 Device = device;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "device", IsRequired = false, EmitDefaultValue = false)]
             public UnmanagedDevice Device { get; set; }
 
@@ -90,6 +102,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public UnmanagedDevice Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -97,11 +116,25 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/devices/unmanaged/get", requestOptions).Data.Device;
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public UnmanagedDevice Get(string? deviceId = default, string? name = default)
         {
             return Get(new GetRequest(deviceId: deviceId, name: name));
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public async Task<UnmanagedDevice> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,6 +144,13 @@ namespace Seam.Api
                 .Device;
         }
 
+        /// <summary>
+        /// Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        ///
+        /// You must specify either `device_id` or `name`.
+        /// </summary>
         public async Task<UnmanagedDevice> GetAsync(
             string? deviceId = default,
             string? name = default
@@ -119,6 +159,9 @@ namespace Seam.Api
             return (await GetAsync(new GetRequest(deviceId: deviceId, name: name)));
         }
 
+        /// <summary>
+        /// Request parameters for List Unmanaged Devices.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -162,6 +205,9 @@ namespace Seam.Api
                 UserIdentifierKey = userIdentifierKey;
             }
 
+            /// <summary>
+            /// Device type for which you want to list devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypeEnum
             {
@@ -292,6 +338,9 @@ namespace Seam.Api
                 RingCamera = 41,
             }
 
+            /// <summary>
+            /// Array of device types for which you want to list devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum DeviceTypesEnum
             {
@@ -422,6 +471,9 @@ namespace Seam.Api
                 RingCamera = 41,
             }
 
+            /// <summary>
+            /// Manufacturer for which you want to list devices.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ManufacturerEnum
             {
@@ -579,9 +631,15 @@ namespace Seam.Api
                 Slack = 50,
             }
 
+            /// <summary>
+            /// ID of the Connect Webview for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
             public string? ConnectWebviewId { get; set; }
 
+            /// <summary>
+            /// ID of the connected account for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_id",
                 IsRequired = false,
@@ -589,6 +647,9 @@ namespace Seam.Api
             )]
             public string? ConnectedAccountId { get; set; }
 
+            /// <summary>
+            /// Array of IDs of the connected accounts for which you want to list devices.
+            /// </summary>
             [DataMember(
                 Name = "connected_account_ids",
                 IsRequired = false,
@@ -596,39 +657,73 @@ namespace Seam.Api
             )]
             public List<string>? ConnectedAccountIds { get; set; }
 
+            /// <summary>
+            /// Timestamp by which to limit returned devices. Returns devices created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "custom_metadata_has", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadataHas { get; set; }
 
+            /// <summary>
+            /// Customer key for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CustomerKey { get; set; }
 
+            /// <summary>
+            /// Array of device IDs for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? DeviceIds { get; set; }
 
+            /// <summary>
+            /// Device type for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.DeviceTypeEnum? DeviceType { get; set; }
 
+            /// <summary>
+            /// Array of device types for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "device_types", IsRequired = false, EmitDefaultValue = false)]
             public List<ListRequest.DeviceTypesEnum>? DeviceTypes { get; set; }
 
+            /// <summary>
+            /// Numerical limit on the number of devices to return.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public float? Limit { get; set; }
 
+            /// <summary>
+            /// Manufacturer for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
             public ListRequest.ManufacturerEnum? Manufacturer { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned devices to include all records that satisfy a partial match using `device_id` (full or partial UUID prefix, minimum 4 characters), `connected_account_id`, `display_name`, `custom_metadata` or `location.location_name`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// ID of the space for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SpaceId { get; set; }
 
+            [Obsolete("Use `space_id`.")]
             [DataMember(
                 Name = "unstable_location_id",
                 IsRequired = false,
@@ -636,6 +731,9 @@ namespace Seam.Api
             )]
             public string? UnstableLocationId { get; set; }
 
+            /// <summary>
+            /// Your own internal user ID for the user for which you want to list devices.
+            /// </summary>
             [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentifierKey { get; set; }
 
@@ -670,6 +768,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
             public List<UnmanagedDevice> Devices { get; set; }
 
@@ -693,6 +794,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public List<UnmanagedDevice> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -700,6 +806,11 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/devices/unmanaged/list", requestOptions).Data.Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public List<UnmanagedDevice> List(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -741,6 +852,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public async Task<List<UnmanagedDevice>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -750,6 +866,11 @@ namespace Seam.Api
                 .Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public async Task<List<UnmanagedDevice>> ListAsync(
             string? connectWebviewId = default,
             string? connectedAccountId = default,
@@ -793,6 +914,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an Unmanaged Device.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -810,12 +934,21 @@ namespace Seam.Api
                 IsManaged = isManaged;
             }
 
+            /// <summary>
+            /// Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs.
+            /// </summary>
             [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
             public object? CustomMetadata { get; set; }
 
+            /// <summary>
+            /// ID of the unmanaged device that you want to update.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Indicates whether the device is managed. Set this parameter to `true` to convert an unmanaged device to managed.
+            /// </summary>
             [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsManaged { get; set; }
 
@@ -839,6 +972,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -846,6 +984,11 @@ namespace Seam.Api
             _seam.Post<object>("/devices/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public void Update(
             object? customMetadata = default,
             string deviceId = default,
@@ -861,6 +1004,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -868,6 +1016,11 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/devices/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.
+        ///
+        /// An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         public async Task UpdateAsync(
             object? customMetadata = default,
             string deviceId = default,

--- a/output/csharp/src/Seam/Api/UnmanagedUserIdentities.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedUserIdentities.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Get an Unmanaged User Identity.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -29,6 +32,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the unmanaged user identity that you want to get.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -63,6 +69,9 @@ namespace Seam.Api
                 UserIdentity = userIdentity;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "user_identity", IsRequired = false, EmitDefaultValue = false)]
             public UserIdentity UserIdentity { get; set; }
 
@@ -86,6 +95,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public UserIdentity Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -95,11 +107,17 @@ namespace Seam.Api
                 .Data.UserIdentity;
         }
 
+        /// <summary>
+        /// Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public UserIdentity Get(string userIdentityId = default)
         {
             return Get(new GetRequest(userIdentityId: userIdentityId));
         }
 
+        /// <summary>
+        /// Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public async Task<UserIdentity> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,11 +129,17 @@ namespace Seam.Api
                 .UserIdentity;
         }
 
+        /// <summary>
+        /// Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public async Task<UserIdentity> GetAsync(string userIdentityId = default)
         {
             return (await GetAsync(new GetRequest(userIdentityId: userIdentityId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Unmanaged User Identities.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -135,15 +159,27 @@ namespace Seam.Api
                 Search = search;
             }
 
+            /// <summary>
+            /// Timestamp by which to limit returned unmanaged user identities. Returns user identities created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public int? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned unmanaged user identities to include all records that satisfy a partial match using `full_name`, `phone_number`, `email_address`,  `user_identity_id` or `acs_system_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
@@ -178,6 +214,9 @@ namespace Seam.Api
                 UserIdentities = userIdentities;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "user_identities", IsRequired = false, EmitDefaultValue = false)]
             public List<object> UserIdentities { get; set; }
 
@@ -201,6 +240,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public List<object> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -210,6 +252,9 @@ namespace Seam.Api
                 .Data.UserIdentities;
         }
 
+        /// <summary>
+        /// Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public List<object> List(
             string? createdBefore = default,
             int? limit = default,
@@ -227,6 +272,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public async Task<List<object>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -241,6 +289,9 @@ namespace Seam.Api
                 .UserIdentities;
         }
 
+        /// <summary>
+        /// Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).
+        /// </summary>
         public async Task<List<object>> ListAsync(
             string? createdBefore = default,
             int? limit = default,
@@ -260,6 +311,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an Unmanaged User Identity.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -277,12 +331,21 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// Must be set to true to convert the unmanaged user identity to managed.
+            /// </summary>
             [DataMember(Name = "is_managed", IsRequired = true, EmitDefaultValue = false)]
             public bool IsManaged { get; set; }
 
+            /// <summary>
+            /// ID of the unmanaged user identity that you want to update.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Unique key for the user identity. If not provided, the existing key will be preserved.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -306,6 +369,11 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -313,6 +381,11 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.
+        /// </summary>
         public void Update(
             bool isManaged = default,
             string userIdentityId = default,
@@ -328,6 +401,11 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -335,6 +413,11 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/user_identities/unmanaged/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.
+        ///
+        /// This endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.
+        /// </summary>
         public async Task UpdateAsync(
             bool isManaged = default,
             string userIdentityId = default,

--- a/output/csharp/src/Seam/Api/UserIdentities.cs
+++ b/output/csharp/src/Seam/Api/UserIdentities.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Add an ACS User to a User Identity.
+        /// </summary>
         [DataContract(Name = "addAcsUserRequest_request")]
         public class AddAcsUserRequest
         {
@@ -35,12 +38,21 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// ID of the access system user that you want to add to the user identity.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity to which you want to add an access system user.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Key of the user identity to which you want to add an access system user.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -64,6 +76,13 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        ///
+        /// You must specify either `user_identity_id` or `user_identity_key` to identify the user identity.
+        ///
+        /// If `user_identity_key` is provided, but the user identity doesn&apos;t exist, a new user identity will be created automatically using information from the ACS user.
+        /// </summary>
         public void AddAcsUser(AddAcsUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -71,6 +90,13 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/add_acs_user", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        ///
+        /// You must specify either `user_identity_id` or `user_identity_key` to identify the user identity.
+        ///
+        /// If `user_identity_key` is provided, but the user identity doesn&apos;t exist, a new user identity will be created automatically using information from the ACS user.
+        /// </summary>
         public void AddAcsUser(
             string acsUserId = default,
             string? userIdentityId = default,
@@ -86,6 +112,13 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        ///
+        /// You must specify either `user_identity_id` or `user_identity_key` to identify the user identity.
+        ///
+        /// If `user_identity_key` is provided, but the user identity doesn&apos;t exist, a new user identity will be created automatically using information from the ACS user.
+        /// </summary>
         public async Task AddAcsUserAsync(AddAcsUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -93,6 +126,13 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/user_identities/add_acs_user", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        ///
+        /// You must specify either `user_identity_id` or `user_identity_key` to identify the user identity.
+        ///
+        /// If `user_identity_key` is provided, but the user identity doesn&apos;t exist, a new user identity will be created automatically using information from the ACS user.
+        /// </summary>
         public async Task AddAcsUserAsync(
             string acsUserId = default,
             string? userIdentityId = default,
@@ -108,6 +148,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Create a User Identity.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -129,18 +172,33 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// List of access system IDs to associate with the new user identity through access system users. If there&apos;s no user with the same email address or phone number in the specified access systems, a new access system user is created. If there is an existing user with the same email or phone number in the specified access systems, the user is linked to the user identity.
+            /// </summary>
             [DataMember(Name = "acs_system_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? AcsSystemIds { get; set; }
 
+            /// <summary>
+            /// Unique email address for the new user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the user associated with the new user identity.
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
             public string? FullName { get; set; }
 
+            /// <summary>
+            /// Unique phone number for the new user identity in E.164 format (for example, +15555550100).
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// Unique key for the new user identity.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -175,6 +233,9 @@ namespace Seam.Api
                 UserIdentity = userIdentity;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "user_identity", IsRequired = false, EmitDefaultValue = false)]
             public UserIdentity UserIdentity { get; set; }
 
@@ -198,6 +259,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public UserIdentity Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -207,6 +271,9 @@ namespace Seam.Api
                 .Data.UserIdentity;
         }
 
+        /// <summary>
+        /// Creates a new [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public UserIdentity Create(
             List<string>? acsSystemIds = default,
             string? emailAddress = default,
@@ -226,6 +293,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<UserIdentity> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -237,6 +307,9 @@ namespace Seam.Api
                 .UserIdentity;
         }
 
+        /// <summary>
+        /// Creates a new [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<UserIdentity> CreateAsync(
             List<string>? acsSystemIds = default,
             string? emailAddress = default,
@@ -258,6 +331,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete a User Identity.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -269,6 +345,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the user identity that you want to delete.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -292,6 +371,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -299,11 +381,17 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).
+        /// </summary>
         public void Delete(string userIdentityId = default)
         {
             Delete(new DeleteRequest(userIdentityId: userIdentityId));
         }
 
+        /// <summary>
+        /// Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -311,11 +399,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/user_identities/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).
+        /// </summary>
         public async Task DeleteAsync(string userIdentityId = default)
         {
             await DeleteAsync(new DeleteRequest(userIdentityId: userIdentityId));
         }
 
+        /// <summary>
+        /// Request parameters for Generate an Instant Key.
+        /// </summary>
         [DataContract(Name = "generateInstantKeyRequest_request")]
         public class GenerateInstantKeyRequest
         {
@@ -340,9 +434,15 @@ namespace Seam.Api
             )]
             public string? CustomizationProfileId { get; set; }
 
+            /// <summary>
+            /// Maximum number of times the instant key can be used. Default: 1.
+            /// </summary>
             [DataMember(Name = "max_use_count", IsRequired = false, EmitDefaultValue = false)]
             public float? MaxUseCount { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for which you want to generate an instant key.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -377,6 +477,9 @@ namespace Seam.Api
                 InstantKey = instantKey;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "instant_key", IsRequired = false, EmitDefaultValue = false)]
             public InstantKey InstantKey { get; set; }
 
@@ -400,6 +503,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Generates a new [instant key](https://docs.seam.co/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public InstantKey GenerateInstantKey(GenerateInstantKeyRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -412,6 +518,9 @@ namespace Seam.Api
                 .Data.InstantKey;
         }
 
+        /// <summary>
+        /// Generates a new [instant key](https://docs.seam.co/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public InstantKey GenerateInstantKey(
             string? customizationProfileId = default,
             float? maxUseCount = default,
@@ -427,6 +536,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Generates a new [instant key](https://docs.seam.co/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<InstantKey> GenerateInstantKeyAsync(GenerateInstantKeyRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -441,6 +553,9 @@ namespace Seam.Api
                 .InstantKey;
         }
 
+        /// <summary>
+        /// Generates a new [instant key](https://docs.seam.co/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<InstantKey> GenerateInstantKeyAsync(
             string? customizationProfileId = default,
             float? maxUseCount = default,
@@ -458,6 +573,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get a User Identity.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -470,6 +588,9 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// ID of the user identity that you want to get.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -507,6 +628,9 @@ namespace Seam.Api
                 UserIdentity = userIdentity;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "user_identity", IsRequired = false, EmitDefaultValue = false)]
             public UserIdentity UserIdentity { get; set; }
 
@@ -530,6 +654,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public UserIdentity Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -539,6 +666,9 @@ namespace Seam.Api
                 .Data.UserIdentity;
         }
 
+        /// <summary>
+        /// Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public UserIdentity Get(string? userIdentityId = default, string? userIdentityKey = default)
         {
             return Get(
@@ -546,6 +676,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<UserIdentity> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -555,6 +688,9 @@ namespace Seam.Api
                 .UserIdentity;
         }
 
+        /// <summary>
+        /// Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<UserIdentity> GetAsync(
             string? userIdentityId = default,
             string? userIdentityKey = default
@@ -567,6 +703,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Grant a User Identity Access to a Device.
+        /// </summary>
         [DataContract(Name = "grantAccessToDeviceRequest_request")]
         public class GrantAccessToDeviceRequest
         {
@@ -582,9 +721,15 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the managed device to which you want to grant access to the user identity.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to grant access to a device.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -608,6 +753,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).
+        /// </summary>
         public void GrantAccessToDevice(GrantAccessToDeviceRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -615,6 +763,9 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/grant_access_to_device", requestOptions);
         }
 
+        /// <summary>
+        /// Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).
+        /// </summary>
         public void GrantAccessToDevice(string deviceId = default, string userIdentityId = default)
         {
             GrantAccessToDevice(
@@ -622,6 +773,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).
+        /// </summary>
         public async Task GrantAccessToDeviceAsync(GrantAccessToDeviceRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -632,6 +786,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).
+        /// </summary>
         public async Task GrantAccessToDeviceAsync(
             string deviceId = default,
             string userIdentityId = default
@@ -642,6 +799,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List User Identities.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -665,9 +825,15 @@ namespace Seam.Api
                 UserIdentityIds = userIdentityIds;
             }
 
+            /// <summary>
+            /// Timestamp by which to limit returned user identities. Returns user identities created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// `acs_system_id` of the credential manager by which you want to filter the list of user identities.
+            /// </summary>
             [DataMember(
                 Name = "credential_manager_acs_system_id",
                 IsRequired = false,
@@ -675,15 +841,27 @@ namespace Seam.Api
             )]
             public string? CredentialManagerAcsSystemId { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public int? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned user identities to include all records that satisfy a partial match using `full_name`, `phone_number`, `email_address` or `user_identity_id`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// Array of user identity IDs by which to filter the list of user identities.
+            /// </summary>
             [DataMember(Name = "user_identity_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? UserIdentityIds { get; set; }
 
@@ -718,6 +896,9 @@ namespace Seam.Api
                 UserIdentities = userIdentities;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "user_identities", IsRequired = false, EmitDefaultValue = false)]
             public List<UserIdentity> UserIdentities { get; set; }
 
@@ -741,6 +922,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public List<UserIdentity> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -750,6 +934,9 @@ namespace Seam.Api
                 .Data.UserIdentities;
         }
 
+        /// <summary>
+        /// Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public List<UserIdentity> List(
             string? createdBefore = default,
             string? credentialManagerAcsSystemId = default,
@@ -771,6 +958,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<List<UserIdentity>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -780,6 +970,9 @@ namespace Seam.Api
                 .UserIdentities;
         }
 
+        /// <summary>
+        /// Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<List<UserIdentity>> ListAsync(
             string? createdBefore = default,
             string? credentialManagerAcsSystemId = default,
@@ -803,6 +996,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Accessible Devices for a User Identity.
+        /// </summary>
         [DataContract(Name = "listAccessibleDevicesRequest_request")]
         public class ListAccessibleDevicesRequest
         {
@@ -814,6 +1010,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all accessible devices.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -848,6 +1047,9 @@ namespace Seam.Api
                 Devices = devices;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
             public List<Device> Devices { get; set; }
 
@@ -871,6 +1073,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.
+        /// </summary>
         public List<Device> ListAccessibleDevices(ListAccessibleDevicesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -883,6 +1088,9 @@ namespace Seam.Api
                 .Data.Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.
+        /// </summary>
         public List<Device> ListAccessibleDevices(string userIdentityId = default)
         {
             return ListAccessibleDevices(
@@ -890,6 +1098,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.
+        /// </summary>
         public async Task<List<Device>> ListAccessibleDevicesAsync(
             ListAccessibleDevicesRequest request
         )
@@ -906,6 +1117,9 @@ namespace Seam.Api
                 .Devices;
         }
 
+        /// <summary>
+        /// Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.
+        /// </summary>
         public async Task<List<Device>> ListAccessibleDevicesAsync(string userIdentityId = default)
         {
             return (
@@ -915,6 +1129,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List Accessible Entrances for a User Identity.
+        /// </summary>
         [DataContract(Name = "listAccessibleEntrancesRequest_request")]
         public class ListAccessibleEntrancesRequest
         {
@@ -926,6 +1143,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all accessible entrances.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -960,6 +1180,9 @@ namespace Seam.Api
                 AcsEntrances = acsEntrances;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsEntrance> AcsEntrances { get; set; }
 
@@ -983,6 +1206,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(ListAccessibleEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -995,6 +1221,9 @@ namespace Seam.Api
                 .Data.AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(string userIdentityId = default)
         {
             return ListAccessibleEntrances(
@@ -1002,6 +1231,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             ListAccessibleEntrancesRequest request
         )
@@ -1018,6 +1250,9 @@ namespace Seam.Api
                 .AcsEntrances;
         }
 
+        /// <summary>
+        /// Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             string userIdentityId = default
         )
@@ -1029,6 +1264,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List ACS Systems Associated with a User Identity.
+        /// </summary>
         [DataContract(Name = "listAcsSystemsRequest_request")]
         public class ListAcsSystemsRequest
         {
@@ -1040,6 +1278,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all access systems.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -1074,6 +1315,9 @@ namespace Seam.Api
                 AcsSystems = acsSystems;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_systems", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsSystem> AcsSystems { get; set; }
 
@@ -1097,6 +1341,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public List<AcsSystem> ListAcsSystems(ListAcsSystemsRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1106,11 +1353,17 @@ namespace Seam.Api
                 .Data.AcsSystems;
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public List<AcsSystem> ListAcsSystems(string userIdentityId = default)
         {
             return ListAcsSystems(new ListAcsSystemsRequest(userIdentityId: userIdentityId));
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<List<AcsSystem>> ListAcsSystemsAsync(ListAcsSystemsRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1125,6 +1378,9 @@ namespace Seam.Api
                 .AcsSystems;
         }
 
+        /// <summary>
+        /// Returns a list of all [access systems](https://docs.seam.co/low-level-apis/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<List<AcsSystem>> ListAcsSystemsAsync(string userIdentityId = default)
         {
             return (
@@ -1132,6 +1388,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List ACS Users Associated with a User Identity.
+        /// </summary>
         [DataContract(Name = "listAcsUsersRequest_request")]
         public class ListAcsUsersRequest
         {
@@ -1143,6 +1402,9 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all access system users.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -1177,6 +1439,9 @@ namespace Seam.Api
                 AcsUsers = acsUsers;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_users", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsUser> AcsUsers { get; set; }
 
@@ -1200,6 +1465,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public List<AcsUser> ListAcsUsers(ListAcsUsersRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1209,11 +1477,17 @@ namespace Seam.Api
                 .Data.AcsUsers;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public List<AcsUser> ListAcsUsers(string userIdentityId = default)
         {
             return ListAcsUsers(new ListAcsUsersRequest(userIdentityId: userIdentityId));
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<List<AcsUser>> ListAcsUsersAsync(ListAcsUsersRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1228,6 +1502,9 @@ namespace Seam.Api
                 .AcsUsers;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task<List<AcsUser>> ListAcsUsersAsync(string userIdentityId = default)
         {
             return (
@@ -1235,6 +1512,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Remove an ACS User from a User Identity.
+        /// </summary>
         [DataContract(Name = "removeAcsUserRequest_request")]
         public class RemoveAcsUserRequest
         {
@@ -1247,9 +1527,15 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system user that you want to remove from the user identity..
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity from which you want to remove an access system user.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -1273,6 +1559,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public void RemoveAcsUser(RemoveAcsUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1280,6 +1569,9 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/remove_acs_user", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public void RemoveAcsUser(string acsUserId = default, string userIdentityId = default)
         {
             RemoveAcsUser(
@@ -1287,6 +1579,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task RemoveAcsUserAsync(RemoveAcsUserRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1294,6 +1589,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/user_identities/remove_acs_user", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task RemoveAcsUserAsync(
             string acsUserId = default,
             string userIdentityId = default
@@ -1304,6 +1602,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Revoke Access to a Device from a User Identity.
+        /// </summary>
         [DataContract(Name = "revokeAccessToDeviceRequest_request")]
         public class RevokeAccessToDeviceRequest
         {
@@ -1319,9 +1620,15 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the managed device to which you want to revoke access from the user identity.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = true, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity from which you want to revoke access to a device.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
@@ -1345,6 +1652,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public void RevokeAccessToDevice(RevokeAccessToDeviceRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1352,6 +1662,9 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/revoke_access_to_device", requestOptions);
         }
 
+        /// <summary>
+        /// Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public void RevokeAccessToDevice(string deviceId = default, string userIdentityId = default)
         {
             RevokeAccessToDevice(
@@ -1359,6 +1672,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task RevokeAccessToDeviceAsync(RevokeAccessToDeviceRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1369,6 +1685,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task RevokeAccessToDeviceAsync(
             string deviceId = default,
             string userIdentityId = default
@@ -1379,6 +1698,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update a User Identity.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -1400,18 +1722,33 @@ namespace Seam.Api
                 UserIdentityKey = userIdentityKey;
             }
 
+            /// <summary>
+            /// Unique email address for the user identity.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the user associated with the user identity.
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
             public string? FullName { get; set; }
 
+            /// <summary>
+            /// Unique phone number for the user identity.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to update.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = true, EmitDefaultValue = false)]
             public string UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Unique key for the user identity.
+            /// </summary>
             [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityKey { get; set; }
 
@@ -1435,6 +1772,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1442,6 +1782,9 @@ namespace Seam.Api
             _seam.Post<object>("/user_identities/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public void Update(
             string? emailAddress = default,
             string? fullName = default,
@@ -1461,6 +1804,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1468,6 +1814,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/user_identities/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).
+        /// </summary>
         public async Task UpdateAsync(
             string? emailAddress = default,
             string? fullName = default,

--- a/output/csharp/src/Seam/Api/UsersAcs.cs
+++ b/output/csharp/src/Seam/Api/UsersAcs.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Add an ACS User to an Access Group.
+        /// </summary>
         [DataContract(Name = "addToAccessGroupRequest_request")]
         public class AddToAccessGroupRequest
         {
@@ -33,9 +36,15 @@ namespace Seam.Api
                 AcsUserId = acsUserId;
             }
 
+            /// <summary>
+            /// ID of the access group to which you want to add an access system user.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to add to an access group.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsUserId { get; set; }
 
@@ -59,6 +68,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void AddToAccessGroup(AddToAccessGroupRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -66,6 +78,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/add_to_access_group", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void AddToAccessGroup(string acsAccessGroupId = default, string acsUserId = default)
         {
             AddToAccessGroup(
@@ -76,6 +91,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task AddToAccessGroupAsync(AddToAccessGroupRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -83,6 +101,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/users/add_to_access_group", requestOptions);
         }
 
+        /// <summary>
+        /// Adds a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) to a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task AddToAccessGroupAsync(
             string acsAccessGroupId = default,
             string acsUserId = default
@@ -96,6 +117,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Create an ACS User.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -123,9 +147,15 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// `starts_at` and `ends_at` timestamps for the new access system user&apos;s access. If you specify an `access_schedule`, you may include both `starts_at` and `ends_at`. If you omit `starts_at`, it defaults to the current time. `ends_at` is optional and must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "access_schedule", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestAccessSchedule? AccessSchedule { get; set; }
 
+            /// <summary>
+            /// Array of access group IDs to indicate the access groups to which you want to add the new access system user.
+            /// </summary>
             [DataMember(
                 Name = "acs_access_group_ids",
                 IsRequired = false,
@@ -133,21 +163,37 @@ namespace Seam.Api
             )]
             public List<string>? AcsAccessGroupIds { get; set; }
 
+            /// <summary>
+            /// ID of the access system to which you want to add the new access system user.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsSystemId { get; set; }
 
+            [Obsolete("use email_address.")]
             [DataMember(Name = "email", IsRequired = false, EmitDefaultValue = false)]
             public string? Email { get; set; }
 
+            /// <summary>
+            /// Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the new access system user.
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = true, EmitDefaultValue = false)]
             public string FullName { get; set; }
 
+            /// <summary>
+            /// Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// ID of the user identity with which you want to associate the new access system user.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -183,9 +229,15 @@ namespace Seam.Api
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Ending timestamp for the new access system user&apos;s access.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Starting timestamp for the new access system user&apos;s access.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -220,6 +272,9 @@ namespace Seam.Api
                 AcsUser = acsUser;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_user", IsRequired = false, EmitDefaultValue = false)]
             public AcsUser AcsUser { get; set; }
 
@@ -243,6 +298,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public AcsUser Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -250,6 +308,9 @@ namespace Seam.Api
             return _seam.Post<CreateResponse>("/acs/users/create", requestOptions).Data.AcsUser;
         }
 
+        /// <summary>
+        /// Creates a new [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public AcsUser Create(
             CreateRequestAccessSchedule? accessSchedule = default,
             List<string>? acsAccessGroupIds = default,
@@ -275,6 +336,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task<AcsUser> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -284,6 +348,9 @@ namespace Seam.Api
                 .AcsUser;
         }
 
+        /// <summary>
+        /// Creates a new [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task<AcsUser> CreateAsync(
             CreateRequestAccessSchedule? accessSchedule = default,
             List<string>? acsAccessGroupIds = default,
@@ -311,6 +378,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Delete an ACS User.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -328,12 +398,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system that you want to delete. You must provide acs_system_id with user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to delete. You must provide either acs_user_id or user_identity_id
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to delete. You must provide either acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -357,6 +436,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) and invalidates the access system user&apos;s [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -364,6 +446,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) and invalidates the access system user&apos;s [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public void Delete(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -379,6 +464,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Deletes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) and invalidates the access system user&apos;s [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -386,6 +474,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/users/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) and invalidates the access system user&apos;s [credentials](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         public async Task DeleteAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -401,6 +492,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get an ACS User.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -418,12 +512,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system that you want to get. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to get. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to get. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -458,6 +561,9 @@ namespace Seam.Api
                 AcsUser = acsUser;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_user", IsRequired = false, EmitDefaultValue = false)]
             public AcsUser AcsUser { get; set; }
 
@@ -481,6 +587,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public AcsUser Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -488,6 +597,9 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/acs/users/get", requestOptions).Data.AcsUser;
         }
 
+        /// <summary>
+        /// Returns a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public AcsUser Get(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -503,6 +615,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task<AcsUser> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -512,6 +627,9 @@ namespace Seam.Api
                 .AcsUser;
         }
 
+        /// <summary>
+        /// Returns a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task<AcsUser> GetAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -529,6 +647,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List ACS Users.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -556,21 +677,39 @@ namespace Seam.Api
                 UserIdentityPhoneNumber = userIdentityPhoneNumber;
             }
 
+            /// <summary>
+            /// ID of the `acs_system` for which you want to retrieve all access system users.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// Timestamp by which to limit returned access system users. Returns users created before this timestamp.
+            /// </summary>
             [DataMember(Name = "created_before", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedBefore { get; set; }
 
+            /// <summary>
+            /// Maximum number of records to return per page.
+            /// </summary>
             [DataMember(Name = "limit", IsRequired = false, EmitDefaultValue = false)]
             public int? Limit { get; set; }
 
+            /// <summary>
+            /// Identifies the specific page of results to return, obtained from the previous page&apos;s `next_page_cursor`.
+            /// </summary>
             [DataMember(Name = "page_cursor", IsRequired = false, EmitDefaultValue = false)]
             public string? PageCursor { get; set; }
 
+            /// <summary>
+            /// String for which to search. Filters returned access system users to include all records that satisfy a partial match using `full_name`, `phone_number`, `email_address`, `acs_user_id`, `user_identity_id`, `user_identity_full_name` or `user_identity_phone_number`.
+            /// </summary>
             [DataMember(Name = "search", IsRequired = false, EmitDefaultValue = false)]
             public string? Search { get; set; }
 
+            /// <summary>
+            /// Email address of the user identity for which you want to retrieve all access system users.
+            /// </summary>
             [DataMember(
                 Name = "user_identity_email_address",
                 IsRequired = false,
@@ -578,9 +717,15 @@ namespace Seam.Api
             )]
             public string? UserIdentityEmailAddress { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for which you want to retrieve all access system users.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
+            /// <summary>
+            /// Phone number of the user identity for which you want to retrieve all access system users, in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, `+15555550100`).
+            /// </summary>
             [DataMember(
                 Name = "user_identity_phone_number",
                 IsRequired = false,
@@ -619,6 +764,9 @@ namespace Seam.Api
                 AcsUsers = acsUsers;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_users", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsUser> AcsUsers { get; set; }
 
@@ -642,6 +790,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public List<AcsUser> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -649,6 +800,9 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/acs/users/list", requestOptions).Data.AcsUsers;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public List<AcsUser> List(
             string? acsSystemId = default,
             string? createdBefore = default,
@@ -674,6 +828,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task<List<AcsUser>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -683,6 +840,9 @@ namespace Seam.Api
                 .AcsUsers;
         }
 
+        /// <summary>
+        /// Returns a list of all [access system users](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task<List<AcsUser>> ListAsync(
             string? acsSystemId = default,
             string? createdBefore = default,
@@ -710,6 +870,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for List ACS User-Accessible Entrances.
+        /// </summary>
         [DataContract(Name = "listAccessibleEntrancesRequest_request")]
         public class ListAccessibleEntrancesRequest
         {
@@ -727,12 +890,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system for which you want to list accessible entrances. You can only provide acs_system_id with user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for whom you want to list accessible entrances. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -767,6 +939,9 @@ namespace Seam.Api
                 AcsEntrances = acsEntrances;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
             public List<AcsEntrance> AcsEntrances { get; set; }
 
@@ -790,6 +965,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) has access.
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(ListAccessibleEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -802,6 +980,9 @@ namespace Seam.Api
                 .Data.AcsEntrances;
         }
 
+        /// <summary>
+        /// Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) has access.
+        /// </summary>
         public List<AcsEntrance> ListAccessibleEntrances(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -817,6 +998,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) has access.
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             ListAccessibleEntrancesRequest request
         )
@@ -833,6 +1017,9 @@ namespace Seam.Api
                 .AcsEntrances;
         }
 
+        /// <summary>
+        /// Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) has access.
+        /// </summary>
         public async Task<List<AcsEntrance>> ListAccessibleEntrancesAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -850,6 +1037,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Remove an ACS User from an Access Group.
+        /// </summary>
         [DataContract(Name = "removeFromAccessGroupRequest_request")]
         public class RemoveFromAccessGroupRequest
         {
@@ -867,12 +1057,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access group from which you want to remove an access system user.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = true, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to remove from an access group. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -896,6 +1095,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void RemoveFromAccessGroup(RemoveFromAccessGroupRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -903,6 +1105,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/remove_from_access_group", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public void RemoveFromAccessGroup(
             string acsAccessGroupId = default,
             string? acsUserId = default,
@@ -918,6 +1123,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task RemoveFromAccessGroupAsync(RemoveFromAccessGroupRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -925,6 +1133,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/users/remove_from_access_group", requestOptions);
         }
 
+        /// <summary>
+        /// Removes a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) from a specified [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups).
+        /// </summary>
         public async Task RemoveFromAccessGroupAsync(
             string acsAccessGroupId = default,
             string? acsUserId = default,
@@ -940,6 +1151,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Revoke ACS User Access to All Entrances.
+        /// </summary>
         [DataContract(Name = "revokeAccessToAllEntrancesRequest_request")]
         public class RevokeAccessToAllEntrancesRequest
         {
@@ -957,12 +1171,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system for which you want to revoke access. You can only provide acs_system_id with user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity for whom you want to revoke access. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -986,6 +1209,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Revokes access to all [entrances](https://docs.seam.co/api/acs/entrances) for a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void RevokeAccessToAllEntrances(RevokeAccessToAllEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -993,6 +1219,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/revoke_access_to_all_entrances", requestOptions);
         }
 
+        /// <summary>
+        /// Revokes access to all [entrances](https://docs.seam.co/api/acs/entrances) for a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void RevokeAccessToAllEntrances(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -1008,6 +1237,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Revokes access to all [entrances](https://docs.seam.co/api/acs/entrances) for a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task RevokeAccessToAllEntrancesAsync(RevokeAccessToAllEntrancesRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1018,6 +1250,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Revokes access to all [entrances](https://docs.seam.co/api/acs/entrances) for a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task RevokeAccessToAllEntrancesAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -1033,6 +1268,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Suspend an ACS User.
+        /// </summary>
         [DataContract(Name = "suspendRequest_request")]
         public class SuspendRequest
         {
@@ -1050,12 +1288,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to suspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -1079,6 +1326,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// [Suspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user&apos;s access, you can [unsuspend](https://docs.seam.co/api/acs/users/unsuspend) them.
+        /// </summary>
         public void Suspend(SuspendRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1086,6 +1336,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/suspend", requestOptions);
         }
 
+        /// <summary>
+        /// [Suspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user&apos;s access, you can [unsuspend](https://docs.seam.co/api/acs/users/unsuspend) them.
+        /// </summary>
         public void Suspend(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -1101,6 +1354,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// [Suspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user&apos;s access, you can [unsuspend](https://docs.seam.co/api/acs/users/unsuspend) them.
+        /// </summary>
         public async Task SuspendAsync(SuspendRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1108,6 +1364,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/users/suspend", requestOptions);
         }
 
+        /// <summary>
+        /// [Suspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user&apos;s access, you can [unsuspend](https://docs.seam.co/api/acs/users/unsuspend) them.
+        /// </summary>
         public async Task SuspendAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -1123,6 +1382,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Unsuspend an ACS User.
+        /// </summary>
         [DataContract(Name = "unsuspendRequest_request")]
         public class UnsuspendRequest
         {
@@ -1140,12 +1402,21 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// ID of the access system of the user that you want to unsuspend. You can only provide acs_system_id with user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to unsuspend. You can only provide acs_user_id or the combination of acs_system_id and user_identity_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -1169,6 +1440,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// [Unsuspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.
+        /// </summary>
         public void Unsuspend(UnsuspendRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1176,6 +1450,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/unsuspend", requestOptions);
         }
 
+        /// <summary>
+        /// [Unsuspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.
+        /// </summary>
         public void Unsuspend(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -1191,6 +1468,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// [Unsuspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.
+        /// </summary>
         public async Task UnsuspendAsync(UnsuspendRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1198,6 +1478,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/users/unsuspend", requestOptions);
         }
 
+        /// <summary>
+        /// [Unsuspends](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.
+        /// </summary>
         public async Task UnsuspendAsync(
             string? acsSystemId = default,
             string? acsUserId = default,
@@ -1213,6 +1496,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Update an ACS User.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -1242,30 +1528,55 @@ namespace Seam.Api
                 UserIdentityId = userIdentityId;
             }
 
+            /// <summary>
+            /// `starts_at` and `ends_at` timestamps for the access system user&apos;s access. If you specify an `access_schedule`, you may include both `starts_at` and `ends_at`. If you omit `starts_at`, it defaults to the current time. `ends_at` is optional and must be a time in the future and after `starts_at`.
+            /// </summary>
             [DataMember(Name = "access_schedule", IsRequired = false, EmitDefaultValue = false)]
             public UpdateRequestAccessSchedule? AccessSchedule { get; set; }
 
+            /// <summary>
+            /// ID of the access system that you want to update. You can only provide acs_system_id with user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that you want to update. You can only provide acs_user_id or user_identity_id.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
+            [Obsolete("use email_address.")]
             [DataMember(Name = "email", IsRequired = false, EmitDefaultValue = false)]
             public string? Email { get; set; }
 
+            /// <summary>
+            /// Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
             public string? FullName { get; set; }
 
+            /// <summary>
+            /// ID of the HID access control system associated with the user.
+            /// </summary>
             [DataMember(Name = "hid_acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public string? HidAcsSystemId { get; set; }
 
+            /// <summary>
+            /// Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
+            /// <summary>
+            /// ID of the user identity that you want to update. You can only provide acs_user_id or user_identity_id. If you provide user_identity_id, you must also provide acs_system_id.
+            /// </summary>
             [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
             public string? UserIdentityId { get; set; }
 
@@ -1301,9 +1612,15 @@ namespace Seam.Api
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Ending timestamp for the access system user&apos;s access.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Starting timestamp for the access system user&apos;s access.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -1327,6 +1644,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates the properties of a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1334,6 +1654,9 @@ namespace Seam.Api
             _seam.Post<object>("/acs/users/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates the properties of a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public void Update(
             UpdateRequestAccessSchedule? accessSchedule = default,
             string? acsSystemId = default,
@@ -1361,6 +1684,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates the properties of a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -1368,6 +1694,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/acs/users/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates the properties of a specified [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         public async Task UpdateAsync(
             UpdateRequestAccessSchedule? accessSchedule = default,
             string? acsSystemId = default,

--- a/output/csharp/src/Seam/Api/Webhooks.cs
+++ b/output/csharp/src/Seam/Api/Webhooks.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Webhook.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -30,9 +33,15 @@ namespace Seam.Api
                 Url = url;
             }
 
+            /// <summary>
+            /// Types of events that you want the new webhook to receive.
+            /// </summary>
             [DataMember(Name = "event_types", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? EventTypes { get; set; }
 
+            /// <summary>
+            /// URL for the new webhook.
+            /// </summary>
             [DataMember(Name = "url", IsRequired = true, EmitDefaultValue = false)]
             public string Url { get; set; }
 
@@ -67,6 +76,9 @@ namespace Seam.Api
                 Webhook = webhook;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "webhook", IsRequired = false, EmitDefaultValue = false)]
             public Webhook Webhook { get; set; }
 
@@ -90,6 +102,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public Webhook Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -97,11 +112,17 @@ namespace Seam.Api
             return _seam.Post<CreateResponse>("/webhooks/create", requestOptions).Data.Webhook;
         }
 
+        /// <summary>
+        /// Creates a new [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public Webhook Create(List<string>? eventTypes = default, string url = default)
         {
             return Create(new CreateRequest(eventTypes: eventTypes, url: url));
         }
 
+        /// <summary>
+        /// Creates a new [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task<Webhook> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -111,6 +132,9 @@ namespace Seam.Api
                 .Webhook;
         }
 
+        /// <summary>
+        /// Creates a new [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task<Webhook> CreateAsync(
             List<string>? eventTypes = default,
             string url = default
@@ -119,6 +143,9 @@ namespace Seam.Api
             return (await CreateAsync(new CreateRequest(eventTypes: eventTypes, url: url)));
         }
 
+        /// <summary>
+        /// Request parameters for Delete a Webhook.
+        /// </summary>
         [DataContract(Name = "deleteRequest_request")]
         public class DeleteRequest
         {
@@ -130,6 +157,9 @@ namespace Seam.Api
                 WebhookId = webhookId;
             }
 
+            /// <summary>
+            /// ID of the webhook that you want to delete.
+            /// </summary>
             [DataMember(Name = "webhook_id", IsRequired = true, EmitDefaultValue = false)]
             public string WebhookId { get; set; }
 
@@ -153,6 +183,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public void Delete(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -160,11 +193,17 @@ namespace Seam.Api
             _seam.Post<object>("/webhooks/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public void Delete(string webhookId = default)
         {
             Delete(new DeleteRequest(webhookId: webhookId));
         }
 
+        /// <summary>
+        /// Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task DeleteAsync(DeleteRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -172,11 +211,17 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/webhooks/delete", requestOptions);
         }
 
+        /// <summary>
+        /// Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task DeleteAsync(string webhookId = default)
         {
             await DeleteAsync(new DeleteRequest(webhookId: webhookId));
         }
 
+        /// <summary>
+        /// Request parameters for Get a Webhook.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -188,6 +233,9 @@ namespace Seam.Api
                 WebhookId = webhookId;
             }
 
+            /// <summary>
+            /// ID of the webhook that you want to get.
+            /// </summary>
             [DataMember(Name = "webhook_id", IsRequired = true, EmitDefaultValue = false)]
             public string WebhookId { get; set; }
 
@@ -222,6 +270,9 @@ namespace Seam.Api
                 Webhook = webhook;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "webhook", IsRequired = false, EmitDefaultValue = false)]
             public Webhook Webhook { get; set; }
 
@@ -245,6 +296,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public Webhook Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -252,11 +306,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/webhooks/get", requestOptions).Data.Webhook;
         }
 
+        /// <summary>
+        /// Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public Webhook Get(string webhookId = default)
         {
             return Get(new GetRequest(webhookId: webhookId));
         }
 
+        /// <summary>
+        /// Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task<Webhook> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -266,11 +326,17 @@ namespace Seam.Api
                 .Webhook;
         }
 
+        /// <summary>
+        /// Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task<Webhook> GetAsync(string webhookId = default)
         {
             return (await GetAsync(new GetRequest(webhookId: webhookId)));
         }
 
+        /// <summary>
+        /// Request parameters for List Webhooks.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -308,6 +374,9 @@ namespace Seam.Api
                 Webhooks = webhooks;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "webhooks", IsRequired = false, EmitDefaultValue = false)]
             public List<Webhook> Webhooks { get; set; }
 
@@ -331,6 +400,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public List<Webhook> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -338,11 +410,17 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/webhooks/list", requestOptions).Data.Webhooks;
         }
 
+        /// <summary>
+        /// Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public List<Webhook> List()
         {
             return List(new ListRequest());
         }
 
+        /// <summary>
+        /// Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task<List<Webhook>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -352,11 +430,17 @@ namespace Seam.Api
                 .Webhooks;
         }
 
+        /// <summary>
+        /// Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task<List<Webhook>> ListAsync()
         {
             return (await ListAsync(new ListRequest()));
         }
 
+        /// <summary>
+        /// Request parameters for Update a Webhook.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -369,9 +453,15 @@ namespace Seam.Api
                 WebhookId = webhookId;
             }
 
+            /// <summary>
+            /// Types of events that you want the webhook to receive.
+            /// </summary>
             [DataMember(Name = "event_types", IsRequired = true, EmitDefaultValue = false)]
             public List<string> EventTypes { get; set; }
 
+            /// <summary>
+            /// ID of the webhook that you want to update.
+            /// </summary>
             [DataMember(Name = "webhook_id", IsRequired = true, EmitDefaultValue = false)]
             public string WebhookId { get; set; }
 
@@ -395,6 +485,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -402,11 +495,17 @@ namespace Seam.Api
             _seam.Post<object>("/webhooks/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public void Update(List<string> eventTypes = default, string webhookId = default)
         {
             Update(new UpdateRequest(eventTypes: eventTypes, webhookId: webhookId));
         }
 
+        /// <summary>
+        /// Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -414,6 +513,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/webhooks/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         public async Task UpdateAsync(List<string> eventTypes = default, string webhookId = default)
         {
             await UpdateAsync(new UpdateRequest(eventTypes: eventTypes, webhookId: webhookId));

--- a/output/csharp/src/Seam/Api/Workspaces.cs
+++ b/output/csharp/src/Seam/Api/Workspaces.cs
@@ -18,6 +18,9 @@ namespace Seam.Api
             _seam = seam;
         }
 
+        /// <summary>
+        /// Request parameters for Create a Workspace.
+        /// </summary>
         [DataContract(Name = "createRequest_request")]
         public class CreateRequest
         {
@@ -62,9 +65,16 @@ namespace Seam.Api
                 Square = 2,
             }
 
+            /// <summary>
+            /// Company name for the new workspace.
+            /// </summary>
             [DataMember(Name = "company_name", IsRequired = false, EmitDefaultValue = false)]
             public string? CompanyName { get; set; }
 
+            /// <summary>
+            /// Connect partner name for the new workspace.
+            /// </summary>
+            [Obsolete("Use `company_name` instead.")]
             [DataMember(
                 Name = "connect_partner_name",
                 IsRequired = false,
@@ -72,6 +82,9 @@ namespace Seam.Api
             )]
             public string? ConnectPartnerName { get; set; }
 
+            /// <summary>
+            /// [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "connect_webview_customization",
                 IsRequired = false,
@@ -79,18 +92,29 @@ namespace Seam.Api
             )]
             public CreateRequestConnectWebviewCustomization? ConnectWebviewCustomization { get; set; }
 
+            /// <summary>
+            /// Indicates whether the new workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+            /// </summary>
             [DataMember(Name = "is_sandbox", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsSandbox { get; set; }
 
+            /// <summary>
+            /// Name of the new workspace.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = true, EmitDefaultValue = false)]
             public string Name { get; set; }
 
+            /// <summary>
+            /// ID of the organization to associate with the new workspace.
+            /// </summary>
             [DataMember(Name = "organization_id", IsRequired = false, EmitDefaultValue = false)]
             public string? OrganizationId { get; set; }
 
+            [Obsolete("Use `connect_webview_customization.webview_logo_shape` instead.")]
             [DataMember(Name = "webview_logo_shape", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequest.WebviewLogoShapeEnum? WebviewLogoShape { get; set; }
 
+            [Obsolete("Use `connect_webview_customization.webview_primary_button_color` instead.")]
             [DataMember(
                 Name = "webview_primary_button_color",
                 IsRequired = false,
@@ -98,6 +122,9 @@ namespace Seam.Api
             )]
             public string? WebviewPrimaryButtonColor { get; set; }
 
+            [Obsolete(
+                "Use `connect_webview_customization.webview_primary_button_text_color` instead."
+            )]
             [DataMember(
                 Name = "webview_primary_button_text_color",
                 IsRequired = false,
@@ -105,6 +132,7 @@ namespace Seam.Api
             )]
             public string? WebviewPrimaryButtonTextColor { get; set; }
 
+            [Obsolete("Use `connect_webview_customization.webview_success_message` instead.")]
             [DataMember(
                 Name = "webview_success_message",
                 IsRequired = false,
@@ -151,6 +179,9 @@ namespace Seam.Api
                 SuccessMessage = successMessage;
             }
 
+            /// <summary>
+            /// Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum LogoShapeEnum
             {
@@ -164,9 +195,15 @@ namespace Seam.Api
                 Square = 2,
             }
 
+            /// <summary>
+            /// Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(Name = "logo_shape", IsRequired = false, EmitDefaultValue = false)]
             public CreateRequestConnectWebviewCustomization.LogoShapeEnum? LogoShape { get; set; }
 
+            /// <summary>
+            /// Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "primary_button_color",
                 IsRequired = false,
@@ -174,6 +211,9 @@ namespace Seam.Api
             )]
             public string? PrimaryButtonColor { get; set; }
 
+            /// <summary>
+            /// Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "primary_button_text_color",
                 IsRequired = false,
@@ -181,6 +221,9 @@ namespace Seam.Api
             )]
             public string? PrimaryButtonTextColor { get; set; }
 
+            /// <summary>
+            /// Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(Name = "success_message", IsRequired = false, EmitDefaultValue = false)]
             public string? SuccessMessage { get; set; }
 
@@ -215,6 +258,9 @@ namespace Seam.Api
                 Workspace = workspace;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "workspace", IsRequired = false, EmitDefaultValue = false)]
             public Workspace Workspace { get; set; }
 
@@ -238,6 +284,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Creates a new [workspace](https://docs.seam.co/core-concepts/workspaces).
+        /// </summary>
         public Workspace Create(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -245,6 +294,9 @@ namespace Seam.Api
             return _seam.Post<CreateResponse>("/workspaces/create", requestOptions).Data.Workspace;
         }
 
+        /// <summary>
+        /// Creates a new [workspace](https://docs.seam.co/core-concepts/workspaces).
+        /// </summary>
         public Workspace Create(
             string? companyName = default,
             string? connectPartnerName = default,
@@ -274,6 +326,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Creates a new [workspace](https://docs.seam.co/core-concepts/workspaces).
+        /// </summary>
         public async Task<Workspace> CreateAsync(CreateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -283,6 +338,9 @@ namespace Seam.Api
                 .Workspace;
         }
 
+        /// <summary>
+        /// Creates a new [workspace](https://docs.seam.co/core-concepts/workspaces).
+        /// </summary>
         public async Task<Workspace> CreateAsync(
             string? companyName = default,
             string? connectPartnerName = default,
@@ -314,6 +372,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Request parameters for Get a Workspace.
+        /// </summary>
         [DataContract(Name = "getRequest_request")]
         public class GetRequest
         {
@@ -351,6 +412,9 @@ namespace Seam.Api
                 Workspace = workspace;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "workspace", IsRequired = false, EmitDefaultValue = false)]
             public Workspace Workspace { get; set; }
 
@@ -374,6 +438,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public Workspace Get(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -381,11 +448,17 @@ namespace Seam.Api
             return _seam.Post<GetResponse>("/workspaces/get", requestOptions).Data.Workspace;
         }
 
+        /// <summary>
+        /// Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public Workspace Get()
         {
             return Get(new GetRequest());
         }
 
+        /// <summary>
+        /// Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public async Task<Workspace> GetAsync(GetRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -395,11 +468,17 @@ namespace Seam.Api
                 .Workspace;
         }
 
+        /// <summary>
+        /// Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public async Task<Workspace> GetAsync()
         {
             return (await GetAsync(new GetRequest()));
         }
 
+        /// <summary>
+        /// Request parameters for List Workspaces.
+        /// </summary>
         [DataContract(Name = "listRequest_request")]
         public class ListRequest
         {
@@ -437,6 +516,9 @@ namespace Seam.Api
                 Workspaces = workspaces;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "workspaces", IsRequired = false, EmitDefaultValue = false)]
             public List<Workspace> Workspaces { get; set; }
 
@@ -460,6 +542,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public List<Workspace> List(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -467,11 +552,17 @@ namespace Seam.Api
             return _seam.Post<ListResponse>("/workspaces/list", requestOptions).Data.Workspaces;
         }
 
+        /// <summary>
+        /// Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public List<Workspace> List()
         {
             return List(new ListRequest());
         }
 
+        /// <summary>
+        /// Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public async Task<List<Workspace>> ListAsync(ListRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -481,11 +572,17 @@ namespace Seam.Api
                 .Workspaces;
         }
 
+        /// <summary>
+        /// Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public async Task<List<Workspace>> ListAsync()
         {
             return (await ListAsync(new ListRequest()));
         }
 
+        /// <summary>
+        /// Request parameters for Reset a Sandbox Workspace.
+        /// </summary>
         [DataContract(Name = "resetSandboxRequest_request")]
         public class ResetSandboxRequest
         {
@@ -523,6 +620,9 @@ namespace Seam.Api
                 ActionAttempt = actionAttempt;
             }
 
+            /// <summary>
+            /// OK
+            /// </summary>
             [DataMember(Name = "action_attempt", IsRequired = false, EmitDefaultValue = false)]
             public ActionAttempt ActionAttempt { get; set; }
 
@@ -546,6 +646,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Resets the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.
+        /// </summary>
         public ActionAttempt ResetSandbox(ResetSandboxRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -555,11 +658,17 @@ namespace Seam.Api
                 .Data.ActionAttempt;
         }
 
+        /// <summary>
+        /// Resets the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.
+        /// </summary>
         public ActionAttempt ResetSandbox()
         {
             return ResetSandbox(new ResetSandboxRequest());
         }
 
+        /// <summary>
+        /// Resets the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.
+        /// </summary>
         public async Task<ActionAttempt> ResetSandboxAsync(ResetSandboxRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -574,11 +683,17 @@ namespace Seam.Api
                 .ActionAttempt;
         }
 
+        /// <summary>
+        /// Resets the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.
+        /// </summary>
         public async Task<ActionAttempt> ResetSandboxAsync()
         {
             return (await ResetSandboxAsync(new ResetSandboxRequest()));
         }
 
+        /// <summary>
+        /// Request parameters for Update a Workspace.
+        /// </summary>
         [DataContract(Name = "updateRequest_request")]
         public class UpdateRequest
         {
@@ -602,6 +717,9 @@ namespace Seam.Api
                 OrganizationId = organizationId;
             }
 
+            /// <summary>
+            /// Connect partner name for the workspace.
+            /// </summary>
             [DataMember(
                 Name = "connect_partner_name",
                 IsRequired = false,
@@ -609,6 +727,9 @@ namespace Seam.Api
             )]
             public string? ConnectPartnerName { get; set; }
 
+            /// <summary>
+            /// [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "connect_webview_customization",
                 IsRequired = false,
@@ -616,6 +737,9 @@ namespace Seam.Api
             )]
             public UpdateRequestConnectWebviewCustomization? ConnectWebviewCustomization { get; set; }
 
+            /// <summary>
+            /// Indicates whether publishable key authentication is enabled for this workspace.
+            /// </summary>
             [DataMember(
                 Name = "is_publishable_key_auth_enabled",
                 IsRequired = false,
@@ -623,12 +747,21 @@ namespace Seam.Api
             )]
             public bool? IsPublishableKeyAuthEnabled { get; set; }
 
+            /// <summary>
+            /// Indicates whether the workspace is suspended.
+            /// </summary>
             [DataMember(Name = "is_suspended", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsSuspended { get; set; }
 
+            /// <summary>
+            /// Name of the workspace.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
+            /// <summary>
+            /// ID of the organization to assign the workspace to. The authenticated user must be the owner of the workspace and an admin of the target organization.
+            /// </summary>
             [DataMember(Name = "organization_id", IsRequired = false, EmitDefaultValue = false)]
             public string? OrganizationId { get; set; }
 
@@ -671,6 +804,9 @@ namespace Seam.Api
                 SuccessMessage = successMessage;
             }
 
+            /// <summary>
+            /// Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum LogoShapeEnum
             {
@@ -684,9 +820,15 @@ namespace Seam.Api
                 Square = 2,
             }
 
+            /// <summary>
+            /// Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(Name = "logo_shape", IsRequired = false, EmitDefaultValue = false)]
             public UpdateRequestConnectWebviewCustomization.LogoShapeEnum? LogoShape { get; set; }
 
+            /// <summary>
+            /// Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "primary_button_color",
                 IsRequired = false,
@@ -694,6 +836,9 @@ namespace Seam.Api
             )]
             public string? PrimaryButtonColor { get; set; }
 
+            /// <summary>
+            /// Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(
                 Name = "primary_button_text_color",
                 IsRequired = false,
@@ -701,6 +846,9 @@ namespace Seam.Api
             )]
             public string? PrimaryButtonTextColor { get; set; }
 
+            /// <summary>
+            /// Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+            /// </summary>
             [DataMember(Name = "success_message", IsRequired = false, EmitDefaultValue = false)]
             public string? SuccessMessage { get; set; }
 
@@ -724,6 +872,9 @@ namespace Seam.Api
             }
         }
 
+        /// <summary>
+        /// Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public void Update(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -731,6 +882,9 @@ namespace Seam.Api
             _seam.Post<object>("/workspaces/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public void Update(
             string? connectPartnerName = default,
             UpdateRequestConnectWebviewCustomization? connectWebviewCustomization = default,
@@ -752,6 +906,9 @@ namespace Seam.Api
             );
         }
 
+        /// <summary>
+        /// Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public async Task UpdateAsync(UpdateRequest request)
         {
             var requestOptions = new RequestOptions();
@@ -759,6 +916,9 @@ namespace Seam.Api
             await _seam.PostAsync<object>("/workspaces/update", requestOptions);
         }
 
+        /// <summary>
+        /// Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.
+        /// </summary>
         public async Task UpdateAsync(
             string? connectPartnerName = default,
             UpdateRequestConnectWebviewCustomization? connectWebviewCustomization = default,

--- a/output/csharp/src/Seam/Model/AccessCode.cs
+++ b/output/csharp/src/Seam/Model/AccessCode.cs
@@ -8,6 +8,17 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a smart lock [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+    ///
+    /// An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.
+    ///
+    /// Seam supports programming two types of access codes: [ongoing](https://docs.seam.co/low-level-apis/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/low-level-apis/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the `type` property of the access code. Ongoing codes display as `ongoing`, whereas time-bound codes are labeled `time_bound`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both `starts_at` and `ends_at` empty. A time-bound access code will be programmed at the `starts_at` time and removed at the `ends_at` time.
+    ///
+    /// In addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.
+    ///
+    /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+    /// </summary>
     [DataContract(Name = "seamModel_accessCode_model")]
     public class AccessCode
     {
@@ -169,12 +180,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "provider_issue";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -182,6 +199,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -224,12 +244,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_set_on_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -237,6 +263,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -279,12 +308,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_remove_from_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -292,6 +327,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -338,12 +376,18 @@ namespace Seam.Model
                 UnmanagedAccessCodeId = unmanagedAccessCodeId;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "duplicate_code_on_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -351,6 +395,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
+            /// </summary>
             [DataMember(
                 Name = "managed_access_code_id",
                 IsRequired = false,
@@ -358,9 +405,15 @@ namespace Seam.Model
             )]
             public string? ManagedAccessCodeId { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
+            /// </summary>
             [DataMember(
                 Name = "unmanaged_access_code_id",
                 IsRequired = false,
@@ -407,12 +460,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "no_space_for_access_code_on_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -420,6 +479,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -468,6 +530,9 @@ namespace Seam.Model
                 ModifiedFields = modifiedFields;
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ChangeTypeEnum
             {
@@ -481,15 +546,24 @@ namespace Seam.Model
                 Removed = 2,
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [DataMember(Name = "change_type", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodeErrorsConflictingExternalModification.ChangeTypeEnum? ChangeType { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "conflicting_external_modification";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -497,9 +571,15 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// List of fields that were changed externally, with their previous and new values.
+            /// </summary>
             [DataMember(Name = "modified_fields", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessCodeErrorsConflictingExternalModificationModifiedFields>? ModifiedFields { get; set; }
 
@@ -542,12 +622,21 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            /// </summary>
             [DataMember(Name = "field", IsRequired = false, EmitDefaultValue = false)]
             public string Field { get; set; }
 
+            /// <summary>
+            /// The previous value of the field.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public string? From { get; set; }
 
+            /// <summary>
+            /// The new value of the field.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public string? To { get; set; }
 
@@ -590,12 +679,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "access_code_inactive";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -603,6 +698,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -645,12 +743,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "insufficient_permissions";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -658,6 +762,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -702,12 +809,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "account_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -715,9 +828,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -762,12 +881,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -775,9 +900,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -822,12 +953,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "dormakaba_sites_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -835,9 +972,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -880,15 +1023,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_offline";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -931,15 +1083,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_removed";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -982,15 +1143,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "hub_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1033,15 +1203,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1084,15 +1263,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "empty_backup_access_code_pool";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1135,15 +1323,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "august_lock_not_authorized";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1186,15 +1383,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "missing_device_credentials";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1237,15 +1443,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "auxiliary_heat_running";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1288,15 +1503,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "subscription_required";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1341,15 +1565,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "bridge_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -1357,6 +1590,9 @@ namespace Seam.Model
             )]
             public bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1398,6 +1634,9 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1463,9 +1702,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1511,15 +1756,24 @@ namespace Seam.Model
                 ScheduledAt = scheduledAt;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "deferring_creation";
 
+            /// <summary>
+            /// Date and time at which Seam will attempt to program this access code on the device.
+            /// </summary>
             [DataMember(Name = "scheduled_at", IsRequired = false, EmitDefaultValue = false)]
             public string ScheduledAt { get; set; }
 
@@ -1560,9 +1814,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1610,18 +1870,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous code configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodePendingMutationsUpdatingCodeFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_code";
 
+            /// <summary>
+            /// New code configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodePendingMutationsUpdatingCodeTo To { get; set; }
 
@@ -1656,6 +1928,9 @@ namespace Seam.Model
                 Code = code;
             }
 
+            /// <summary>
+            /// Previous PIN code.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
@@ -1690,6 +1965,9 @@ namespace Seam.Model
                 Code = code;
             }
 
+            /// <summary>
+            /// New PIN code.
+            /// </summary>
             [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
             public string? Code { get; set; }
 
@@ -1734,18 +2012,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous name configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodePendingMutationsUpdatingNameFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_name";
 
+            /// <summary>
+            /// New name configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodePendingMutationsUpdatingNameTo To { get; set; }
 
@@ -1780,6 +2070,9 @@ namespace Seam.Model
                 Name = name;
             }
 
+            /// <summary>
+            /// Previous access code name.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -1814,6 +2107,9 @@ namespace Seam.Model
                 Name = name;
             }
 
+            /// <summary>
+            /// New access code name.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -1858,18 +2154,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous time frame configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodePendingMutationsUpdatingTimeFrameFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_time_frame";
 
+            /// <summary>
+            /// New time frame configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodePendingMutationsUpdatingTimeFrameTo To { get; set; }
 
@@ -1908,9 +2216,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Previous end time for the access code.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Previous start time for the access code.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -1949,9 +2263,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// New end time for the access code.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// New start time for the access code.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -1995,9 +2315,15 @@ namespace Seam.Model
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2021,6 +2347,9 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/lifecycle-of-access-codes).
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum StatusEnum
         {
@@ -2043,6 +2372,9 @@ namespace Seam.Model
             Unknown = 5,
         }
 
+        /// <summary>
+        /// Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum TypeEnum
         {
@@ -2127,9 +2459,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2175,9 +2513,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2227,6 +2571,9 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ChangeTypeEnum
             {
@@ -2240,15 +2587,27 @@ namespace Seam.Model
                 Removed = 2,
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [DataMember(Name = "change_type", IsRequired = false, EmitDefaultValue = false)]
             public AccessCodeWarningsExternalModificationInEffect.ChangeTypeEnum? ChangeType { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// List of fields that were changed externally, with their previous and new values.
+            /// </summary>
             [DataMember(Name = "modified_fields", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessCodeWarningsExternalModificationInEffectModifiedFields>? ModifiedFields { get; set; }
 
@@ -2294,12 +2653,21 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            /// </summary>
             [DataMember(Name = "field", IsRequired = false, EmitDefaultValue = false)]
             public string Field { get; set; }
 
+            /// <summary>
+            /// The previous value of the field.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public string? From { get; set; }
 
+            /// <summary>
+            /// The new value of the field.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public string? To { get; set; }
 
@@ -2340,9 +2708,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2386,9 +2760,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2432,9 +2812,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2480,9 +2866,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2527,9 +2919,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2573,9 +2971,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2619,9 +3023,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2665,9 +3075,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2714,9 +3130,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2740,21 +3162,39 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Unique identifier for the access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Code used for access. Typically, a numeric or alphanumeric string.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Unique identifier for a group of access codes that share the same code.
+        /// </summary>
         [DataMember(Name = "common_code_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CommonCodeKey { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access code was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the device associated with the access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Metadata for a dormakaba Oracode managed access code. Only present for access codes from dormakaba Oracode devices.
+        /// </summary>
         [DataMember(
             Name = "dormakaba_oracode_metadata",
             IsRequired = false,
@@ -2762,15 +3202,27 @@ namespace Seam.Model
         )]
         public AccessCodeDormakabaOracodeMetadata? DormakabaOracodeMetadata { get; set; }
 
+        /// <summary>
+        /// Date and time after which the time-bound access code becomes inactive.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessCodeErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access code is a backup code.
+        /// </summary>
         [DataMember(Name = "is_backup", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsBackup { get; set; }
 
+        /// <summary>
+        /// Indicates whether a backup access code is available for use if the primary access code is lost or compromised.
+        /// </summary>
         [DataMember(
             Name = "is_backup_access_code_available",
             IsRequired = false,
@@ -2778,6 +3230,9 @@ namespace Seam.Model
         )]
         public bool IsBackupAccessCodeAvailable { get; set; }
 
+        /// <summary>
+        /// Indicates whether changes to the access code from external sources are permitted.
+        /// </summary>
         [DataMember(
             Name = "is_external_modification_allowed",
             IsRequired = false,
@@ -2785,18 +3240,33 @@ namespace Seam.Model
         )]
         public bool IsExternalModificationAllowed { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam manages the access code.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access code is intended for use in offline scenarios. If `true`, this code can be created on a device without a network connection.
+        /// </summary>
         [DataMember(Name = "is_offline_access_code", IsRequired = false, EmitDefaultValue = false)]
         public bool IsOfflineAccessCode { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access code can only be used once. If `true`, the code becomes invalid after the first use.
+        /// </summary>
         [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
         public bool IsOneTimeUse { get; set; }
 
+        /// <summary>
+        /// Indicates whether the code is set on the device according to a preconfigured schedule.
+        /// </summary>
         [DataMember(Name = "is_scheduled_on_device", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsScheduledOnDevice { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access code is waiting for a code assignment.
+        /// </summary>
         [DataMember(
             Name = "is_waiting_for_code_assignment",
             IsRequired = false,
@@ -2804,12 +3274,21 @@ namespace Seam.Model
         )]
         public bool? IsWaitingForCodeAssignment { get; set; }
 
+        /// <summary>
+        /// Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider&apos;s app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider&apos;s app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider&apos;s app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Collection of pending mutations for the access code. Indicates changes that Seam is in the process of pushing to the device.
+        /// </summary>
         [DataMember(Name = "pending_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessCodePendingMutations> PendingMutations { get; set; }
 
+        /// <summary>
+        /// Identifier of the pulled backup access code. Used to associate the pulled backup access code with the original access code.
+        /// </summary>
         [DataMember(
             Name = "pulled_backup_access_code_id",
             IsRequired = false,
@@ -2817,18 +3296,33 @@ namespace Seam.Model
         )]
         public string? PulledBackupAccessCodeId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the time-bound access code becomes active.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/lifecycle-of-access-codes).
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public AccessCode.StatusEnum Status { get; set; }
 
+        /// <summary>
+        /// Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public AccessCode.TypeEnum Type { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessCodeWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the Seam workspace associated with the access code.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -2879,27 +3373,51 @@ namespace Seam.Model
             UserLevelName = userLevelName;
         }
 
+        /// <summary>
+        /// Indicates whether the stay can be cancelled via the Dormakaba Oracode API.
+        /// </summary>
         [DataMember(Name = "is_cancellable", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsCancellable { get; set; }
 
+        /// <summary>
+        /// Indicates whether early check-in is available for this stay.
+        /// </summary>
         [DataMember(Name = "is_early_checkin_able", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsEarlyCheckinAble { get; set; }
 
+        /// <summary>
+        /// Indicates whether the stay can be extended via the Dormakaba Oracode API.
+        /// </summary>
         [DataMember(Name = "is_extendable", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsExtendable { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access code can be overridden. When false, the maximum number of overrides has been reached.
+        /// </summary>
         [DataMember(Name = "is_overridable", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOverridable { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode site name associated with this access code.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode stay ID associated with this access code.
+        /// </summary>
         [DataMember(Name = "stay_id", IsRequired = false, EmitDefaultValue = false)]
         public float? StayId { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode user level ID associated with this access code.
+        /// </summary>
         [DataMember(Name = "user_level_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserLevelId { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode user level name associated with this access code.
+        /// </summary>
         [DataMember(Name = "user_level_name", IsRequired = false, EmitDefaultValue = false)]
         public string? UserLevelName { get; set; }
 

--- a/output/csharp/src/Seam/Model/AccessGrant.cs
+++ b/output/csharp/src/Seam/Model/AccessGrant.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an Access Grant. Access Grants enable you to grant a user identity access to spaces, entrances, and devices through one or more access methods, such as mobile keys, plastic cards, and PIN codes. You can create an Access Grant for an existing user identity, or you can create a new user identity *while* creating the new Access Grant.
+    /// </summary>
     [DataContract(Name = "seamModel_accessGrant_model")]
     public class AccessGrant
     {
@@ -95,15 +98,24 @@ namespace Seam.Model
                 MissingDeviceIds = missingDeviceIds;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "cannot_create_requested_access_methods";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// IDs of the devices that did not receive an access code at grant creation. Use these to identify which specific devices failed when the message reports a partial failure.
+            /// </summary>
             [DataMember(Name = "missing_device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string>? MissingDeviceIds { get; set; }
 
@@ -147,9 +159,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -215,18 +233,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous location configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrantPendingMutationsUpdatingSpacesFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_spaces";
 
+            /// <summary>
+            /// New location configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrantPendingMutationsUpdatingSpacesTo To { get; set; }
 
@@ -261,6 +291,9 @@ namespace Seam.Model
                 DeviceIds = deviceIds;
             }
 
+            /// <summary>
+            /// Previous device IDs where access codes existed.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
@@ -299,9 +332,15 @@ namespace Seam.Model
                 DeviceIds = deviceIds;
             }
 
+            /// <summary>
+            /// Common code key to ensure PIN code reuse across devices.
+            /// </summary>
             [DataMember(Name = "common_code_key", IsRequired = false, EmitDefaultValue = false)]
             public string? CommonCodeKey { get; set; }
 
+            /// <summary>
+            /// New device IDs where access codes should be created.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
@@ -348,21 +387,36 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// IDs of the access methods being updated.
+            /// </summary>
             [DataMember(Name = "access_method_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> AccessMethodIds { get; set; }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous access time configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrantPendingMutationsUpdatingAccessTimesFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_access_times";
 
+            /// <summary>
+            /// New access time configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrantPendingMutationsUpdatingAccessTimesTo To { get; set; }
 
@@ -401,9 +455,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Previous end time for access.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Previous start time for access.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -442,9 +502,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// New end time for access.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// New start time for access.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -488,9 +554,15 @@ namespace Seam.Model
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -569,9 +641,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -615,9 +693,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -664,12 +748,21 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Devices whose access codes could not be revoked during reconciliation. Present when the provider does not support revoking an offline access code (e.g. Dormakaba oracode with exhausted override budget).
+            /// </summary>
             [DataMember(Name = "failed_devices", IsRequired = false, EmitDefaultValue = false)]
             public List<AccessGrantWarningsOverprovisionedAccessFailedDevices>? FailedDevices { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -715,12 +808,21 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Device whose access code could not be revoked.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Reason the access code could not be revoked (e.g. `offline_access_code_not_revocable`).
+            /// </summary>
             [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
             public string ErrorCode { get; set; }
 
+            /// <summary>
+            /// Human-readable description of why revocation failed.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public string Message { get; set; }
 
@@ -763,12 +865,21 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// IDs of the access methods being updated.
+            /// </summary>
             [DataMember(Name = "access_method_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> AccessMethodIds { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -818,18 +929,33 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// ID of the device where the requested code was unavailable.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// The new PIN code that was assigned instead.
+            /// </summary>
             [DataMember(Name = "new_code", IsRequired = false, EmitDefaultValue = false)]
             public string NewCode { get; set; }
 
+            /// <summary>
+            /// The originally requested PIN code that was unavailable.
+            /// </summary>
             [DataMember(Name = "original_code", IsRequired = false, EmitDefaultValue = false)]
             public string OriginalCode { get; set; }
 
@@ -875,12 +1001,21 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// ID of the device that does not support access codes.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -928,6 +1063,9 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Specific reason why the grant&apos;s times are not programmable on the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ReasonEnum
             {
@@ -944,15 +1082,27 @@ namespace Seam.Model
                 OngoingNotSupported = 3,
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// ID of the device whose time constraints the access grant violates.
+            /// </summary>
             [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
             public string DeviceId { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// Specific reason why the grant&apos;s times are not programmable on the device.
+            /// </summary>
             [DataMember(Name = "reason", IsRequired = false, EmitDefaultValue = false)]
             public AccessGrantWarningsDeviceTimeConstraintsViolated.ReasonEnum Reason { get; set; }
 
@@ -999,9 +1149,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1025,21 +1181,39 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// ID of the Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// Unique key for the access grant within the workspace.
+        /// </summary>
         [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessGrantKey { get; set; }
 
+        /// <summary>
+        /// IDs of the access methods created for the Access Grant.
+        /// </summary>
         [DataMember(Name = "access_method_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessMethodIds { get; set; }
 
+        /// <summary>
+        /// Client Session Token. Only returned if the Access Grant has a mobile_key access method.
+        /// </summary>
         [DataMember(Name = "client_session_token", IsRequired = false, EmitDefaultValue = false)]
         public string? ClientSessionToken { get; set; }
 
+        /// <summary>
+        /// Date and time at which the Access Grant was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the customization profile associated with the Access Grant.
+        /// </summary>
         [DataMember(
             Name = "customization_profile_id",
             IsRequired = false,
@@ -1047,27 +1221,49 @@ namespace Seam.Model
         )]
         public string? CustomizationProfileId { get; set; }
 
+        /// <summary>
+        /// Display name of the Access Grant.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Date and time at which the Access Grant ends.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessGrantErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Instant Key URL. Only returned if the Access Grant has a single mobile_key access_method.
+        /// </summary>
         [DataMember(Name = "instant_key_url", IsRequired = false, EmitDefaultValue = false)]
         public string? InstantKeyUrl { get; set; }
 
+        [Obsolete("Use `space_ids`.")]
         [DataMember(Name = "location_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> LocationIds { get; set; }
 
+        /// <summary>
+        /// Name of the Access Grant. If not provided, the display name will be computed.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// List of pending mutations for the access grant. This shows updates that are in progress.
+        /// </summary>
         [DataMember(Name = "pending_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessGrantPendingMutations> PendingMutations { get; set; }
 
+        /// <summary>
+        /// Access methods that the user requested for the Access Grant.
+        /// </summary>
         [DataMember(
             Name = "requested_access_methods",
             IsRequired = false,
@@ -1075,21 +1271,39 @@ namespace Seam.Model
         )]
         public List<AccessGrantRequestedAccessMethods> RequestedAccessMethods { get; set; }
 
+        /// <summary>
+        /// Reservation key for the access grant.
+        /// </summary>
         [DataMember(Name = "reservation_key", IsRequired = false, EmitDefaultValue = false)]
         public string? ReservationKey { get; set; }
 
+        /// <summary>
+        /// IDs of the spaces to which the Access Grant gives access.
+        /// </summary>
         [DataMember(Name = "space_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> SpaceIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the Access Grant starts.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of user identity to which the Access Grant gives access.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access grant](https://docs.seam.co/use-cases/granting-access).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessGrantWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the Seam workspace associated with the Access Grant.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -1136,6 +1350,9 @@ namespace Seam.Model
             Mode = mode;
         }
 
+        /// <summary>
+        /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ModeEnum
         {
@@ -1155,9 +1372,15 @@ namespace Seam.Model
             CloudKey = 4,
         }
 
+        /// <summary>
+        /// Specific PIN code to use for this access method. Only applicable when mode is &apos;code&apos;.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// IDs of the access methods created for the requested access method.
+        /// </summary>
         [DataMember(
             Name = "created_access_method_ids",
             IsRequired = false,
@@ -1165,12 +1388,21 @@ namespace Seam.Model
         )]
         public List<string> CreatedAccessMethodIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the requested access method was added to the Access Grant.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name of the access method.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Maximum number of times the instant key can be used. Only applicable when mode is &apos;mobile_key&apos;. Defaults to 1 if not specified.
+        /// </summary>
         [DataMember(
             Name = "instant_key_max_use_count",
             IsRequired = false,
@@ -1178,6 +1410,9 @@ namespace Seam.Model
         )]
         public int? InstantKeyMaxUseCount { get; set; }
 
+        /// <summary>
+        /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "mode", IsRequired = false, EmitDefaultValue = false)]
         public AccessGrantRequestedAccessMethods.ModeEnum Mode { get; set; }
 

--- a/output/csharp/src/Seam/Model/AccessMethod.cs
+++ b/output/csharp/src/Seam/Model/AccessMethod.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an access method for an Access Grant. Access methods describe the modes of access, such as PIN codes, plastic cards, and mobile keys. For a mobile key, the access method also stores the URL for the associated Instant Key.
+    /// </summary>
     [DataContract(Name = "seamModel_accessMethod_model")]
     public class AccessMethod
     {
@@ -86,12 +89,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_issue";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -135,9 +144,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -161,6 +176,9 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ModeEnum
         {
@@ -226,18 +244,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous device configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethodPendingMutationsProvisioningAccessFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "provisioning_access";
 
+            /// <summary>
+            /// New device configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethodPendingMutationsProvisioningAccessTo To { get; set; }
 
@@ -274,6 +304,9 @@ namespace Seam.Model
                 DeviceIds = deviceIds;
             }
 
+            /// <summary>
+            /// Previous device IDs where access was provisioned.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
@@ -310,6 +343,9 @@ namespace Seam.Model
                 DeviceIds = deviceIds;
             }
 
+            /// <summary>
+            /// New device IDs where access is being provisioned.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
@@ -354,18 +390,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous device configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethodPendingMutationsRevokingAccessFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "revoking_access";
 
+            /// <summary>
+            /// New device configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethodPendingMutationsRevokingAccessTo To { get; set; }
 
@@ -400,6 +448,9 @@ namespace Seam.Model
                 DeviceIds = deviceIds;
             }
 
+            /// <summary>
+            /// Previous device IDs where access existed.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
@@ -434,6 +485,9 @@ namespace Seam.Model
                 DeviceIds = deviceIds;
             }
 
+            /// <summary>
+            /// New device IDs where access should remain.
+            /// </summary>
             [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
             public List<string> DeviceIds { get; set; }
 
@@ -478,18 +532,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous access time configuration.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethodPendingMutationsUpdatingAccessTimesFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_access_times";
 
+            /// <summary>
+            /// New access time configuration.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AccessMethodPendingMutationsUpdatingAccessTimesTo To { get; set; }
 
@@ -528,9 +594,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Previous end time for access.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Previous start time for access.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -569,9 +641,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// New end time for access.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// New start time for access.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -615,9 +693,15 @@ namespace Seam.Model
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -681,9 +765,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -727,9 +817,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -775,12 +871,21 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// ID of the original access method from which this backup access method was split, if applicable.
+            /// </summary>
             [DataMember(
                 Name = "original_access_method_id",
                 IsRequired = false,
@@ -828,9 +933,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -877,9 +988,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -903,18 +1020,33 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// ID of the access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Token of the client session associated with the access method.
+        /// </summary>
         [DataMember(Name = "client_session_token", IsRequired = false, EmitDefaultValue = false)]
         public string? ClientSessionToken { get; set; }
 
+        /// <summary>
+        /// The actual PIN code for code access methods.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access method was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the customization profile associated with the access method.
+        /// </summary>
         [DataMember(
             Name = "customization_profile_id",
             IsRequired = false,
@@ -922,42 +1054,81 @@ namespace Seam.Model
         )]
         public string? CustomizationProfileId { get; set; }
 
+        /// <summary>
+        /// Display name of the access method.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessMethodErrors> Errors { get; set; }
 
+        /// <summary>
+        /// URL of the Instant Key for mobile key access methods.
+        /// </summary>
         [DataMember(Name = "instant_key_url", IsRequired = false, EmitDefaultValue = false)]
         public string? InstantKeyUrl { get; set; }
 
+        /// <summary>
+        /// Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
+        /// </summary>
         [DataMember(Name = "is_assignment_required", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsAssignmentRequired { get; set; }
 
+        /// <summary>
+        /// Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
+        /// </summary>
         [DataMember(Name = "is_encoding_required", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsEncodingRequired { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access method has been issued.
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool IsIssued { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
+        /// </summary>
         [DataMember(Name = "is_ready_for_assignment", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsReadyForAssignment { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
+        /// </summary>
         [DataMember(Name = "is_ready_for_encoding", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsReadyForEncoding { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access method was issued.
+        /// </summary>
         [DataMember(Name = "issued_at", IsRequired = false, EmitDefaultValue = false)]
         public string? IssuedAt { get; set; }
 
+        /// <summary>
+        /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "mode", IsRequired = false, EmitDefaultValue = false)]
         public AccessMethod.ModeEnum Mode { get; set; }
 
+        /// <summary>
+        /// Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+        /// </summary>
         [DataMember(Name = "pending_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessMethodPendingMutations> PendingMutations { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AccessMethodWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the Seam workspace associated with the access method.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 

--- a/output/csharp/src/Seam/Model/AcsAccessGroup.cs
+++ b/output/csharp/src/Seam/Model/AcsAccessGroup.cs
@@ -8,6 +8,13 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.
+    ///
+    /// Some access control systems use [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
+    ///
+    /// To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+    /// </summary>
     [DataContract(Name = "seamModel_acsAccessGroup_model")]
     public class AcsAccessGroup
     {
@@ -119,12 +126,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_create_on_acs_system";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -168,9 +181,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -194,6 +213,9 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the access group type.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -284,9 +306,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -330,9 +358,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -377,9 +411,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -430,18 +470,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old access group information.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingGroupInformationFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_group_information";
 
+            /// <summary>
+            /// New access group information.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingGroupInformationTo To { get; set; }
 
@@ -480,6 +532,9 @@ namespace Seam.Model
                 Name = name;
             }
 
+            /// <summary>
+            /// Name of the access group.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -516,6 +571,9 @@ namespace Seam.Model
                 Name = name;
             }
 
+            /// <summary>
+            /// Name of the access group.
+            /// </summary>
             [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
             public string? Name { get; set; }
 
@@ -563,18 +621,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old access schedule information.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingAccessScheduleFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_access_schedule";
 
+            /// <summary>
+            /// New access schedule information.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingAccessScheduleTo To { get; set; }
 
@@ -615,9 +685,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Ending time for the access schedule.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Starting time for the access schedule.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -658,9 +734,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Ending time for the access schedule.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Starting time for the access schedule.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -708,18 +790,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old user membership.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingUserMembershipFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_user_membership";
 
+            /// <summary>
+            /// New user membership.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingUserMembershipTo To { get; set; }
 
@@ -758,6 +852,9 @@ namespace Seam.Model
                 AcsUserId = acsUserId;
             }
 
+            /// <summary>
+            /// Old user ID.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
@@ -796,6 +893,9 @@ namespace Seam.Model
                 AcsUserId = acsUserId;
             }
 
+            /// <summary>
+            /// New user ID.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsUserId { get; set; }
 
@@ -843,18 +943,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old entrance membership.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingEntranceMembershipFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_entrance_membership";
 
+            /// <summary>
+            /// New entrance membership.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsUpdatingEntranceMembershipTo To { get; set; }
 
@@ -893,6 +1005,9 @@ namespace Seam.Model
                 AcsEntranceId = acsEntranceId;
             }
 
+            /// <summary>
+            /// Old entrance ID.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
@@ -931,6 +1046,9 @@ namespace Seam.Model
                 AcsEntranceId = acsEntranceId;
             }
 
+            /// <summary>
+            /// New entrance ID.
+            /// </summary>
             [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsEntranceId { get; set; }
 
@@ -979,6 +1097,9 @@ namespace Seam.Model
                 Variant = variant;
             }
 
+            /// <summary>
+            /// Whether the user is scheduled to be added to or removed from this access group.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum VariantEnum
             {
@@ -992,18 +1113,30 @@ namespace Seam.Model
                 Removing = 2,
             }
 
+            /// <summary>
+            /// ID of the user involved in the scheduled change.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public string AcsUserId { get; set; }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "deferring_user_membership_update";
 
+            /// <summary>
+            /// Whether the user is scheduled to be added to or removed from this access group.
+            /// </summary>
             [DataMember(Name = "variant", IsRequired = false, EmitDefaultValue = false)]
             public AcsAccessGroupPendingMutationsDeferringUserMembershipUpdate.VariantEnum Variant { get; set; }
 
@@ -1047,9 +1180,15 @@ namespace Seam.Model
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1073,9 +1212,11 @@ namespace Seam.Model
             }
         }
 
+        [Obsolete("Use `external_type`.")]
         [DataMember(Name = "access_group_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsAccessGroup.AccessGroupTypeEnum AccessGroupType { get; set; }
 
+        [Obsolete("Use `external_type_display_name`.")]
         [DataMember(
             Name = "access_group_type_display_name",
             IsRequired = false,
@@ -1083,30 +1224,57 @@ namespace Seam.Model
         )]
         public string AccessGroupTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// `starts_at` and `ends_at` timestamps for the access group&apos;s access.
+        /// </summary>
         [DataMember(Name = "access_schedule", IsRequired = false, EmitDefaultValue = false)]
         public AcsAccessGroupAccessSchedule? AccessSchedule { get; set; }
 
+        /// <summary>
+        /// ID of the access group.
+        /// </summary>
         [DataMember(Name = "acs_access_group_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsAccessGroupId { get; set; }
 
+        /// <summary>
+        /// ID of the access control system that contains the access group.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account that contains the access group.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access group was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name for the access group.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Errors associated with the `acs_access_group`.
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsAccessGroupErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the access group type.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsAccessGroup.ExternalTypeEnum ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the access group type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -1114,18 +1282,33 @@ namespace Seam.Model
         )]
         public string ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam manages the access group.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Name of the access group.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Collection of pending mutations for the access group. Represents operations that have been requested but not yet completed on the integrated access system.
+        /// </summary>
         [DataMember(Name = "pending_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsAccessGroupPendingMutations> PendingMutations { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the `acs_access_group`.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsAccessGroupWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the access group.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -1161,9 +1344,15 @@ namespace Seam.Model
             StartsAt = startsAt;
         }
 
+        /// <summary>
+        /// Date and time at which the user&apos;s access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the user&apos;s access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAt { get; set; }
 
@@ -1204,6 +1393,9 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum WarningCodeEnum
         {
@@ -1217,12 +1409,21 @@ namespace Seam.Model
             BeingDeleted = 2,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public AcsAccessGroupWarnings.WarningCodeEnum WarningCode { get; set; }
 

--- a/output/csharp/src/Seam/Model/AcsCredential.cs
+++ b/output/csharp/src/Seam/Model/AcsCredential.cs
@@ -8,6 +8,15 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Means by which an [access control system user](https://docs.seam.co/low-level-apis/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+    ///
+    /// An access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.
+    ///
+    /// For each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.
+    ///
+    /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach. Use the lower-level ACS credential API directly only when you specifically need to manage individual credentials.
+    /// </summary>
     [DataContract(Name = "seamModel_acsCredential_model")]
     public class AcsCredential
     {
@@ -75,6 +84,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AccessMethodEnum
         {
@@ -94,6 +106,9 @@ namespace Seam.Model
             CloudKey = 4,
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -191,9 +206,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -237,9 +258,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -283,9 +310,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -329,9 +362,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -375,9 +414,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -421,9 +466,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -470,9 +521,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -496,21 +553,39 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "access_method", IsRequired = false, EmitDefaultValue = false)]
         public AcsCredential.AccessMethodEnum AccessMethod { get; set; }
 
+        /// <summary>
+        /// ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the credential pool to which the credential belongs.
+        /// </summary>
         [DataMember(Name = "acs_credential_pool_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsCredentialPoolId { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_vostio_metadata",
             IsRequired = false,
@@ -518,30 +593,57 @@ namespace Seam.Model
         )]
         public AcsCredentialAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+        /// <summary>
+        /// Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_number", IsRequired = false, EmitDefaultValue = false)]
         public string? CardNumber { get; set; }
 
+        /// <summary>
+        /// Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsCredentialErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsCredential.ExternalTypeEnum? ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -549,9 +651,15 @@ namespace Seam.Model
         )]
         public string? ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsIssued { get; set; }
 
+        /// <summary>
+        /// Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "is_latest_desired_state_synced_with_provider",
             IsRequired = false,
@@ -559,9 +667,15 @@ namespace Seam.Model
         )]
         public bool? IsLatestDesiredStateSyncedWithProvider { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam manages the credential.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+        /// </summary>
         [DataMember(
             Name = "is_multi_phone_sync_credential",
             IsRequired = false,
@@ -569,12 +683,21 @@ namespace Seam.Model
         )]
         public bool? IsMultiPhoneSyncCredential { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+        /// </summary>
         [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOneTimeUse { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+        /// </summary>
         [DataMember(Name = "issued_at", IsRequired = false, EmitDefaultValue = false)]
         public string? IssuedAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "latest_desired_state_synced_with_provider_at",
             IsRequired = false,
@@ -582,6 +705,9 @@ namespace Seam.Model
         )]
         public string? LatestDesiredStateSyncedWithProviderAt { get; set; }
 
+        /// <summary>
+        /// ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "parent_acs_credential_id",
             IsRequired = false,
@@ -589,18 +715,33 @@ namespace Seam.Model
         )]
         public string? ParentAcsCredentialId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsCredentialVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsCredentialWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -647,21 +788,39 @@ namespace Seam.Model
             OverrideGuestAcsEntranceIds = overrideGuestAcsEntranceIds;
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Names of the doors to which to grant access in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_names", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? DoorNames { get; set; }
 
+        /// <summary>
+        /// Endpoint ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "endpoint_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EndpointId { get; set; }
 
+        /// <summary>
+        /// Key ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyId { get; set; }
 
+        /// <summary>
+        /// Key issuing request ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_issuing_request_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyIssuingRequestId { get; set; }
 
+        /// <summary>
+        /// IDs of the guest entrances to override in the Vostio access system.
+        /// </summary>
         [DataMember(
             Name = "override_guest_acs_entrance_ids",
             IsRequired = false,
@@ -706,6 +865,9 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
@@ -762,6 +924,9 @@ namespace Seam.Model
             JoinerAcsCredentialIds = joinerAcsCredentialIds;
         }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CardFunctionTypeEnum
         {
@@ -775,27 +940,51 @@ namespace Seam.Model
             Staff = 2,
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_function_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsCredentialVisionlineMetadata.CardFunctionTypeEnum? CardFunctionType { get; set; }
 
+        /// <summary>
+        /// ID of the card in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CardId { get; set; }
 
+        /// <summary>
+        /// Common entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "common_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? CommonAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// ID of the credential in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CredentialId { get; set; }
 
+        /// <summary>
+        /// Guest entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "guest_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? GuestAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential is valid.
+        /// </summary>
         [DataMember(Name = "is_valid", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsValid { get; set; }
 
+        /// <summary>
+        /// IDs of the credentials to which you want to join.
+        /// </summary>
         [DataMember(
             Name = "joiner_acs_credential_ids",
             IsRequired = false,

--- a/output/csharp/src/Seam/Model/AcsEncoder.cs
+++ b/output/csharp/src/Seam/Model/AcsEncoder.cs
@@ -8,6 +8,22 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a hardware device that encodes [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+    ///
+    /// Some access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:
+    ///
+    /// 1. Credential creation
+    ///    Configure the access parameters for the credential.
+    /// 2. Card encoding
+    ///    Write the credential data onto the card using a compatible card encoder.
+    ///
+    /// Separately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.
+    ///
+    /// See [Working with Card Encoders and Scanners](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+    ///
+    /// To verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+    /// </summary>
     [DataContract(Name = "seamModel_acsEncoder_model")]
     public class AcsEncoder
     {
@@ -33,24 +49,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         [DataMember(Name = "acs_encoder_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEncoderId { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account that contains the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name for the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsEncoderErrors> Errors { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -91,6 +128,9 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ErrorCodeEnum
         {
@@ -101,12 +141,21 @@ namespace Seam.Model
             AcsEncoderRemoved = 1,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public AcsEncoderErrors.ErrorCodeEnum ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 

--- a/output/csharp/src/Seam/Model/AcsEntrance.cs
+++ b/output/csharp/src/Seam/Model/AcsEntrance.cs
@@ -8,6 +8,11 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+    ///
+    /// In an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.
+    /// </summary>
     [DataContract(Name = "seamModel_acsEntrance_model")]
     public class AcsEntrance
     {
@@ -117,9 +122,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -164,9 +175,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -210,9 +227,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -256,9 +279,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -302,9 +331,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -351,9 +386,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -377,12 +418,21 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// ID of the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_vostio_metadata",
             IsRequired = false,
@@ -390,12 +440,21 @@ namespace Seam.Model
         )]
         public AcsEntranceAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+        /// <summary>
+        /// Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "avigilon_alta_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceAvigilonAltaMetadata? AvigilonAltaMetadata { get; set; }
 
+        /// <summary>
+        /// Brivo-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "brivo_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceBrivoMetadata? BrivoMetadata { get; set; }
 
+        /// <summary>
+        /// Indicates whether the ACS entrance can belong to a reservation via an access_grant.reservation_key.
+        /// </summary>
         [DataMember(
             Name = "can_belong_to_reservation",
             IsRequired = false,
@@ -403,9 +462,15 @@ namespace Seam.Model
         )]
         public bool? CanBelongToReservation { get; set; }
 
+        /// <summary>
+        /// Indicates whether the ACS entrance can be unlocked with card credentials.
+        /// </summary>
         [DataMember(Name = "can_unlock_with_card", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanUnlockWithCard { get; set; }
 
+        /// <summary>
+        /// Indicates whether the ACS entrance can be unlocked with cloud key credentials.
+        /// </summary>
         [DataMember(
             Name = "can_unlock_with_cloud_key",
             IsRequired = false,
@@ -413,9 +478,15 @@ namespace Seam.Model
         )]
         public bool? CanUnlockWithCloudKey { get; set; }
 
+        /// <summary>
+        /// Indicates whether the ACS entrance can be unlocked with pin codes.
+        /// </summary>
         [DataMember(Name = "can_unlock_with_code", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanUnlockWithCode { get; set; }
 
+        /// <summary>
+        /// Indicates whether the ACS entrance can be unlocked with mobile key credentials.
+        /// </summary>
         [DataMember(
             Name = "can_unlock_with_mobile_key",
             IsRequired = false,
@@ -423,15 +494,27 @@ namespace Seam.Model
         )]
         public bool? CanUnlockWithMobileKey { get; set; }
 
+        /// <summary>
+        /// ID of the [connected account](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name for the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(
             Name = "dormakaba_ambiance_metadata",
             IsRequired = false,
@@ -439,6 +522,9 @@ namespace Seam.Model
         )]
         public AcsEntranceDormakabaAmbianceMetadata? DormakabaAmbianceMetadata { get; set; }
 
+        /// <summary>
+        /// dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(
             Name = "dormakaba_community_metadata",
             IsRequired = false,
@@ -446,30 +532,57 @@ namespace Seam.Model
         )]
         public AcsEntranceDormakabaCommunityMetadata? DormakabaCommunityMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsEntranceErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Hotek-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "hotek_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceHotekMetadata? HotekMetadata { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) is currently locked.
+        /// </summary>
         [DataMember(Name = "is_locked", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsLocked { get; set; }
 
+        /// <summary>
+        /// Latch-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "latch_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceLatchMetadata? LatchMetadata { get; set; }
 
+        /// <summary>
+        /// Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceSaltoKsMetadata? SaltoKsMetadata { get; set; }
 
+        /// <summary>
+        /// Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "salto_space_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceSaltoSpaceMetadata? SaltoSpaceMetadata { get; set; }
 
+        /// <summary>
+        /// IDs of the spaces that the entrance is in.
+        /// </summary>
         [DataMember(Name = "space_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> SpaceIds { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsEntranceWarnings> Warnings { get; set; }
 
@@ -514,6 +627,9 @@ namespace Seam.Model
             StandOpen = standOpen;
         }
 
+        /// <summary>
+        /// Type of the door in the Vostio access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DoorTypeEnum
         {
@@ -533,18 +649,33 @@ namespace Seam.Model
             Elevator = 4,
         }
 
+        /// <summary>
+        /// Name of the door in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
+        /// <summary>
+        /// Number of the door in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_number", IsRequired = false, EmitDefaultValue = false)]
         public float? DoorNumber { get; set; }
 
+        /// <summary>
+        /// Type of the door in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceAssaAbloyVostioMetadata.DoorTypeEnum? DoorType { get; set; }
 
+        /// <summary>
+        /// PMS ID of the door in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "pms_id", IsRequired = false, EmitDefaultValue = false)]
         public string? PmsId { get; set; }
 
+        /// <summary>
+        /// Indicates whether keys are allowed to set the door in stand open mode in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "stand_open", IsRequired = false, EmitDefaultValue = false)]
         public bool? StandOpen { get; set; }
 
@@ -593,9 +724,15 @@ namespace Seam.Model
             ZoneName = zoneName;
         }
 
+        /// <summary>
+        /// Entry name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "entry_name", IsRequired = false, EmitDefaultValue = false)]
         public string? EntryName { get; set; }
 
+        /// <summary>
+        /// Total count of entry relays for an Avigilon Alta system.
+        /// </summary>
         [DataMember(
             Name = "entry_relays_total_count",
             IsRequired = false,
@@ -603,18 +740,33 @@ namespace Seam.Model
         )]
         public float? EntryRelaysTotalCount { get; set; }
 
+        /// <summary>
+        /// Organization name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "org_name", IsRequired = false, EmitDefaultValue = false)]
         public string? OrgName { get; set; }
 
+        /// <summary>
+        /// Site ID for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
         public float? SiteId { get; set; }
 
+        /// <summary>
+        /// Site name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
+        /// <summary>
+        /// Zone ID for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "zone_id", IsRequired = false, EmitDefaultValue = false)]
         public float? ZoneId { get; set; }
 
+        /// <summary>
+        /// Zone name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "zone_name", IsRequired = false, EmitDefaultValue = false)]
         public string? ZoneName { get; set; }
 
@@ -655,12 +807,21 @@ namespace Seam.Model
             SiteName = siteName;
         }
 
+        /// <summary>
+        /// ID of the access point in the Brivo access system.
+        /// </summary>
         [DataMember(Name = "access_point_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessPointId { get; set; }
 
+        /// <summary>
+        /// ID of the site that the access point belongs to.
+        /// </summary>
         [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
         public float? SiteId { get; set; }
 
+        /// <summary>
+        /// Name of the site that the access point belongs to.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
@@ -695,6 +856,9 @@ namespace Seam.Model
             AccessPointName = accessPointName;
         }
 
+        /// <summary>
+        /// Name of the access point in the dormakaba Ambiance access system.
+        /// </summary>
         [DataMember(Name = "access_point_name", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessPointName { get; set; }
 
@@ -729,6 +893,9 @@ namespace Seam.Model
             AccessPointProfile = accessPointProfile;
         }
 
+        /// <summary>
+        /// Type of access point profile in the dormakaba Community access system.
+        /// </summary>
         [DataMember(Name = "access_point_profile", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessPointProfile { get; set; }
 
@@ -769,12 +936,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -815,12 +991,21 @@ namespace Seam.Model
             RoomNumber = roomNumber;
         }
 
+        /// <summary>
+        /// Display name of the entrance.
+        /// </summary>
         [DataMember(Name = "common_area_name", IsRequired = false, EmitDefaultValue = false)]
         public string? CommonAreaName { get; set; }
 
+        /// <summary>
+        /// Display name of the entrance.
+        /// </summary>
         [DataMember(Name = "common_area_number", IsRequired = false, EmitDefaultValue = false)]
         public string? CommonAreaNumber { get; set; }
 
+        /// <summary>
+        /// Room number of the entrance.
+        /// </summary>
         [DataMember(Name = "room_number", IsRequired = false, EmitDefaultValue = false)]
         public string? RoomNumber { get; set; }
 
@@ -863,15 +1048,27 @@ namespace Seam.Model
             IsConnected = isConnected;
         }
 
+        /// <summary>
+        /// Accessibility type in the Latch access system.
+        /// </summary>
         [DataMember(Name = "accessibility_type", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessibilityType { get; set; }
 
+        /// <summary>
+        /// Name of the door in the Latch access system.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
+        /// <summary>
+        /// Type of the door in the Latch access system.
+        /// </summary>
         [DataMember(Name = "door_type", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorType { get; set; }
 
+        /// <summary>
+        /// Indicates whether the entrance is connected.
+        /// </summary>
         [DataMember(Name = "is_connected", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsConnected { get; set; }
 
@@ -922,27 +1119,51 @@ namespace Seam.Model
             PrivacyMode = privacyMode;
         }
 
+        /// <summary>
+        /// Battery level of the door access device.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public string? BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Name of the door in the Salto KS access system.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
+        /// <summary>
+        /// Indicates whether an intrusion alarm is active on the door.
+        /// </summary>
         [DataMember(Name = "intrusion_alarm", IsRequired = false, EmitDefaultValue = false)]
         public bool? IntrusionAlarm { get; set; }
 
+        /// <summary>
+        /// Indicates whether the door is left open.
+        /// </summary>
         [DataMember(Name = "left_open_alarm", IsRequired = false, EmitDefaultValue = false)]
         public bool? LeftOpenAlarm { get; set; }
 
+        /// <summary>
+        /// Type of the lock in the Salto KS access system.
+        /// </summary>
         [DataMember(Name = "lock_type", IsRequired = false, EmitDefaultValue = false)]
         public string? LockType { get; set; }
 
+        /// <summary>
+        /// Locked state of the door in the Salto KS access system.
+        /// </summary>
         [DataMember(Name = "locked_state", IsRequired = false, EmitDefaultValue = false)]
         public string? LockedState { get; set; }
 
+        /// <summary>
+        /// Indicates whether the door access device is online.
+        /// </summary>
         [DataMember(Name = "online", IsRequired = false, EmitDefaultValue = false)]
         public bool? Online { get; set; }
 
+        /// <summary>
+        /// Indicates whether privacy mode is enabled for the lock.
+        /// </summary>
         [DataMember(Name = "privacy_mode", IsRequired = false, EmitDefaultValue = false)]
         public bool? PrivacyMode { get; set; }
 
@@ -989,21 +1210,39 @@ namespace Seam.Model
             RoomName = roomName;
         }
 
+        /// <summary>
+        /// Indicates whether AuditOnKeys is enabled for the door in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "audit_on_keys", IsRequired = false, EmitDefaultValue = false)]
         public bool? AuditOnKeys { get; set; }
 
+        /// <summary>
+        /// Description of the door in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "door_description", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorDescription { get; set; }
 
+        /// <summary>
+        /// Door ID in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "door_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorId { get; set; }
 
+        /// <summary>
+        /// Name of the door in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
+        /// <summary>
+        /// Description of the room in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "room_description", IsRequired = false, EmitDefaultValue = false)]
         public string? RoomDescription { get; set; }
 
+        /// <summary>
+        /// Name of the room in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "room_name", IsRequired = false, EmitDefaultValue = false)]
         public string? RoomName { get; set; }
 
@@ -1044,6 +1283,9 @@ namespace Seam.Model
             Profiles = profiles;
         }
 
+        /// <summary>
+        /// Category of the door in the Visionline access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DoorCategoryEnum
         {
@@ -1066,12 +1308,21 @@ namespace Seam.Model
             CommonPms = 5,
         }
 
+        /// <summary>
+        /// Category of the door in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "door_category", IsRequired = false, EmitDefaultValue = false)]
         public AcsEntranceVisionlineMetadata.DoorCategoryEnum? DoorCategory { get; set; }
 
+        /// <summary>
+        /// Name of the door in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
+        /// <summary>
+        /// Profile for the door in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "profiles", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsEntranceVisionlineMetadataProfiles>? Profiles { get; set; }
 
@@ -1111,6 +1362,9 @@ namespace Seam.Model
             VisionlineDoorProfileType = visionlineDoorProfileType;
         }
 
+        /// <summary>
+        /// Door profile type in the Visionline access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum VisionlineDoorProfileTypeEnum
         {
@@ -1127,6 +1381,9 @@ namespace Seam.Model
             Touch = 3,
         }
 
+        /// <summary>
+        /// Door profile ID in the Visionline access system.
+        /// </summary>
         [DataMember(
             Name = "visionline_door_profile_id",
             IsRequired = false,
@@ -1134,6 +1391,9 @@ namespace Seam.Model
         )]
         public string? VisionlineDoorProfileId { get; set; }
 
+        /// <summary>
+        /// Door profile type in the Visionline access system.
+        /// </summary>
         [DataMember(
             Name = "visionline_door_profile_type",
             IsRequired = false,

--- a/output/csharp/src/Seam/Model/AcsSystem.cs
+++ b/output/csharp/src/Seam/Model/AcsSystem.cs
@@ -8,6 +8,13 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+    ///
+    /// Within an `acs_system`, create [`acs_user`s](https://docs.seam.co/api/acs/users/object) and [`acs_credential`s](https://docs.seam.co/api/acs/credentials/object) to grant access to the `acs_user`s.
+    ///
+    /// For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
+    /// </summary>
     [DataContract(Name = "seamModel_acsSystem_model")]
     public class AcsSystem
     {
@@ -121,12 +128,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "seam_bridge_disconnected";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -169,15 +182,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "bridge_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -218,12 +240,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "visionline_instance_unreachable";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -264,12 +292,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -310,12 +344,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "acs_system_disconnected";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -356,12 +396,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "account_disconnected";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -402,12 +448,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_certification_expired";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -448,12 +500,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "provider_service_unavailable";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -497,9 +555,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -523,6 +587,9 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -674,9 +741,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -723,12 +796,19 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            [Obsolete("this field is deprecated.")]
             [DataMember(
                 Name = "misconfigured_acs_entrance_ids",
                 IsRequired = false,
@@ -776,9 +856,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -825,9 +911,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -851,24 +943,46 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Number of access groups in the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "acs_access_group_count", IsRequired = false, EmitDefaultValue = false)]
         public float? AcsAccessGroupCount { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// Number of users in the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "acs_user_count", IsRequired = false, EmitDefaultValue = false)]
         public float? AcsUserCount { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
+        [Obsolete("Use `connected_account_id`.")]
         [DataMember(Name = "connected_account_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> ConnectedAccountIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [access control system](https://docs.seam.co/low-level-apis/access-systems) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the default credential manager `acs_system` for this [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(
             Name = "default_credential_manager_acs_system_id",
             IsRequired = false,
@@ -876,12 +990,21 @@ namespace Seam.Model
         )]
         public string? DefaultCredentialManagerAcsSystemId { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsSystemErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsSystem.ExternalTypeEnum? ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/low-level-apis/access-systems) type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -889,24 +1012,41 @@ namespace Seam.Model
         )]
         public string? ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Alternative text for the [access control system](https://docs.seam.co/low-level-apis/access-systems) image.
+        /// </summary>
         [DataMember(Name = "image_alt_text", IsRequired = false, EmitDefaultValue = false)]
         public string ImageAltText { get; set; }
 
+        /// <summary>
+        /// URL for the image that represents the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string ImageUrl { get; set; }
 
+        /// <summary>
+        /// Indicates whether the `acs_system` is a credential manager.
+        /// </summary>
         [DataMember(Name = "is_credential_manager", IsRequired = false, EmitDefaultValue = false)]
         public bool IsCredentialManager { get; set; }
 
+        /// <summary>
+        /// Location information for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
         public AcsSystemLocation Location { get; set; }
 
+        /// <summary>
+        /// Name of the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        [Obsolete("Use `external_type`.")]
         [DataMember(Name = "system_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsSystem.SystemTypeEnum? SystemType { get; set; }
 
+        [Obsolete("Use `external_type_display_name`.")]
         [DataMember(
             Name = "system_type_display_name",
             IsRequired = false,
@@ -914,12 +1054,21 @@ namespace Seam.Model
         )]
         public string? SystemTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata for the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsSystemVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsSystemWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -954,6 +1103,9 @@ namespace Seam.Model
             TimeZone = timeZone;
         }
 
+        /// <summary>
+        /// Time zone in which the [access control system](https://docs.seam.co/low-level-apis/access-systems) is located.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
@@ -994,12 +1146,21 @@ namespace Seam.Model
             SystemId = systemId;
         }
 
+        /// <summary>
+        /// IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) on the local network.
+        /// </summary>
         [DataMember(Name = "lan_address", IsRequired = false, EmitDefaultValue = false)]
         public string? LanAddress { get; set; }
 
+        /// <summary>
+        /// Keyset loaded into a reader. Mobile keys and reader administration tools securely authenticate only with readers programmed with a matching keyset.
+        /// </summary>
         [DataMember(Name = "mobile_access_uuid", IsRequired = false, EmitDefaultValue = false)]
         public string? MobileAccessUuid { get; set; }
 
+        /// <summary>
+        /// Unique ID assigned by the ASSA ABLOY licensing team that identifies each hotel in your credential manager.
+        /// </summary>
         [DataMember(Name = "system_id", IsRequired = false, EmitDefaultValue = false)]
         public string? SystemId { get; set; }
 

--- a/output/csharp/src/Seam/Model/AcsUser.cs
+++ b/output/csharp/src/Seam/Model/AcsUser.cs
@@ -8,6 +8,13 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [user](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access system](https://docs.seam.co/low-level-apis/access-systems).
+    ///
+    /// An access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.
+    ///
+    /// For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+    /// </summary>
     [DataContract(Name = "seamModel_acsUser_model")]
     public class AcsUser
     {
@@ -120,12 +127,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "deleted_externally";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -166,12 +179,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -212,12 +231,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_create_on_acs_system";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -258,12 +283,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_update_on_acs_system";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -304,12 +335,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_delete_on_acs_system";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -350,12 +387,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "latch_conflict_with_resident_user";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -399,9 +442,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -425,6 +474,9 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -519,9 +571,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -565,9 +623,15 @@ namespace Seam.Model
                 MutationCode = mutationCode;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -613,15 +677,24 @@ namespace Seam.Model
                 ScheduledAt = scheduledAt;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "deferring_creation";
 
+            /// <summary>
+            /// Optional: When the user creation is scheduled to occur.
+            /// </summary>
             [DataMember(Name = "scheduled_at", IsRequired = false, EmitDefaultValue = false)]
             public string? ScheduledAt { get; set; }
 
@@ -666,18 +739,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old access system user information.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingUserInformationFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_user_information";
 
+            /// <summary>
+            /// New access system user information.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingUserInformationTo To { get; set; }
 
@@ -718,12 +803,21 @@ namespace Seam.Model
                 PhoneNumber = phoneNumber;
             }
 
+            /// <summary>
+            /// Email address of the access system user.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the access system user.
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
             public string? FullName { get; set; }
 
+            /// <summary>
+            /// Phone number of the access system user.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
@@ -764,12 +858,21 @@ namespace Seam.Model
                 PhoneNumber = phoneNumber;
             }
 
+            /// <summary>
+            /// Email address of the access system user.
+            /// </summary>
             [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
             public string? EmailAddress { get; set; }
 
+            /// <summary>
+            /// Full name of the access system user.
+            /// </summary>
             [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
             public string? FullName { get; set; }
 
+            /// <summary>
+            /// Phone number of the access system user.
+            /// </summary>
             [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
             public string? PhoneNumber { get; set; }
 
@@ -814,18 +917,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old access schedule information.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingAccessScheduleFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_access_schedule";
 
+            /// <summary>
+            /// New access schedule information.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingAccessScheduleTo To { get; set; }
 
@@ -864,9 +979,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Starting time for the access schedule.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Starting time for the access schedule.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -905,9 +1026,15 @@ namespace Seam.Model
                 StartsAt = startsAt;
             }
 
+            /// <summary>
+            /// Starting time for the access schedule.
+            /// </summary>
             [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
             public string? EndsAt { get; set; }
 
+            /// <summary>
+            /// Starting time for the access schedule.
+            /// </summary>
             [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
             public string? StartsAt { get; set; }
 
@@ -952,18 +1079,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old user suspension state information.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingSuspensionStateFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_suspension_state";
 
+            /// <summary>
+            /// New user suspension state information.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingSuspensionStateTo To { get; set; }
 
@@ -1076,18 +1215,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Old access group membership.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingGroupMembershipFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_group_membership";
 
+            /// <summary>
+            /// New access group membership.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingGroupMembershipTo To { get; set; }
 
@@ -1124,6 +1275,9 @@ namespace Seam.Model
                 AcsAccessGroupId = acsAccessGroupId;
             }
 
+            /// <summary>
+            /// Old access group ID.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsAccessGroupId { get; set; }
 
@@ -1160,6 +1314,9 @@ namespace Seam.Model
                 AcsAccessGroupId = acsAccessGroupId;
             }
 
+            /// <summary>
+            /// New access group ID.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsAccessGroupId { get; set; }
 
@@ -1206,6 +1363,9 @@ namespace Seam.Model
                 Variant = variant;
             }
 
+            /// <summary>
+            /// Whether the user is scheduled to be added to or removed from the access group.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum VariantEnum
             {
@@ -1219,18 +1379,30 @@ namespace Seam.Model
                 Removing = 2,
             }
 
+            /// <summary>
+            /// ID of the access group involved in the scheduled change.
+            /// </summary>
             [DataMember(Name = "acs_access_group_id", IsRequired = false, EmitDefaultValue = false)]
             public string AcsAccessGroupId { get; set; }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "deferring_group_membership_update";
 
+            /// <summary>
+            /// Whether the user is scheduled to be added to or removed from the access group.
+            /// </summary>
             [DataMember(Name = "variant", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsDeferringGroupMembershipUpdate.VariantEnum Variant { get; set; }
 
@@ -1275,18 +1447,30 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Previous credential assignment.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingCredentialAssignmentFrom From { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "updating_credential_assignment";
 
+            /// <summary>
+            /// New credential assignment.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public AcsUserPendingMutationsUpdatingCredentialAssignmentTo To { get; set; }
 
@@ -1325,6 +1509,9 @@ namespace Seam.Model
                 AcsCredentialId = acsCredentialId;
             }
 
+            /// <summary>
+            /// Previous credential ID.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
@@ -1363,6 +1550,9 @@ namespace Seam.Model
                 AcsCredentialId = acsCredentialId;
             }
 
+            /// <summary>
+            /// New credential ID.
+            /// </summary>
             [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
             public string? AcsCredentialId { get; set; }
 
@@ -1406,9 +1596,15 @@ namespace Seam.Model
             [DataMember(Name = "mutation_code", IsRequired = true, EmitDefaultValue = false)]
             public override string MutationCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which the mutation was created.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the mutation.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1473,9 +1669,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1519,9 +1721,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1565,9 +1773,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1611,9 +1825,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1657,9 +1877,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1706,9 +1932,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1732,36 +1964,67 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// `starts_at` and `ends_at` timestamps for the [access system user&apos;s](https://docs.seam.co/low-level-apis/access-systems/user-management) access.
+        /// </summary>
         [DataMember(Name = "access_schedule", IsRequired = false, EmitDefaultValue = false)]
         public AcsUserAccessSchedule? AccessSchedule { get; set; }
 
+        /// <summary>
+        /// ID of the [access system](https://docs.seam.co/low-level-apis/access-systems) that contains the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsUserId { get; set; }
 
+        /// <summary>
+        /// The ID of the connected account that is associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        [Obsolete("use email_address.")]
         [DataMember(Name = "email", IsRequired = false, EmitDefaultValue = false)]
         public string? Email { get; set; }
 
+        /// <summary>
+        /// Email address of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
         public string? EmailAddress { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsUserErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public AcsUser.ExternalTypeEnum? ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -1769,30 +2032,57 @@ namespace Seam.Model
         )]
         public string? ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Full name of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
         public string? FullName { get; set; }
 
+        /// <summary>
+        /// ID of the HID access control system associated with the user.
+        /// </summary>
         [DataMember(Name = "hid_acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string? HidAcsSystemId { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam manages the access system user.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) is currently [suspended](https://docs.seam.co/low-level-apis/access-systems/user-management/suspending-and-unsuspending-users).
+        /// </summary>
         [DataMember(Name = "is_suspended", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsSuspended { get; set; }
 
+        /// <summary>
+        /// Pending mutations associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.
+        /// </summary>
         [DataMember(Name = "pending_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsUserPendingMutations>? PendingMutations { get; set; }
 
+        /// <summary>
+        /// Phone number of the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+        /// </summary>
         [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
         public string? PhoneNumber { get; set; }
 
+        /// <summary>
+        /// Salto KS-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsUserSaltoKsMetadata? SaltoKsMetadata { get; set; }
 
+        /// <summary>
+        /// Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "salto_space_metadata", IsRequired = false, EmitDefaultValue = false)]
         public AcsUserSaltoSpaceMetadata? SaltoSpaceMetadata { get; set; }
 
+        /// <summary>
+        /// Email address of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(
             Name = "user_identity_email_address",
             IsRequired = false,
@@ -1800,12 +2090,21 @@ namespace Seam.Model
         )]
         public string? UserIdentityEmailAddress { get; set; }
 
+        /// <summary>
+        /// Full name of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "user_identity_full_name", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityFullName { get; set; }
 
+        /// <summary>
+        /// ID of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Phone number of the user identity associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) in E.164 format (for example, `+15555550100`).
+        /// </summary>
         [DataMember(
             Name = "user_identity_phone_number",
             IsRequired = false,
@@ -1813,9 +2112,15 @@ namespace Seam.Model
         )]
         public string? UserIdentityPhoneNumber { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<AcsUserWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -1851,9 +2156,15 @@ namespace Seam.Model
             StartsAt = startsAt;
         }
 
+        /// <summary>
+        /// Date and time at which the user&apos;s access ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the user&apos;s access starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAt { get; set; }
 
@@ -1888,6 +2199,9 @@ namespace Seam.Model
             IsSubscribed = isSubscribed;
         }
 
+        /// <summary>
+        /// Indicates whether the user holds an active subscription slot on the Salto KS site. Only subscribed users can unlock doors and count against the site&apos;s user-subscription limit. A user may not be subscribed because their access schedule has not started or has ended, the site has reached its subscription limit, or they were manually unsubscribed. This is distinct from `is_suspended`, which reflects whether the user has been explicitly blocked.
+        /// </summary>
         [DataMember(Name = "is_subscribed", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsSubscribed { get; set; }
 
@@ -1923,9 +2237,15 @@ namespace Seam.Model
             UserId = userId;
         }
 
+        /// <summary>
+        /// Indicates whether AuditOpenings is enabled for the user in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "audit_openings", IsRequired = false, EmitDefaultValue = false)]
         public bool? AuditOpenings { get; set; }
 
+        /// <summary>
+        /// User ID in the Salto Space access system.
+        /// </summary>
         [DataMember(Name = "user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserId { get; set; }
 

--- a/output/csharp/src/Seam/Model/ActionAttempt.cs
+++ b/output/csharp/src/Seam/Model/ActionAttempt.cs
@@ -58,6 +58,9 @@ namespace Seam.Model
         public abstract override string ToString();
     }
 
+    /// <summary>
+    /// Locking a door is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptLockDoor_model")]
     public class ActionAttemptLockDoor : ActionAttempt
     {
@@ -95,15 +98,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "LOCK_DOOR";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptLockDoorError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptLockDoorResult Result { get; set; }
 
@@ -142,9 +154,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -179,6 +197,9 @@ namespace Seam.Model
             WasConfirmedByDevice = wasConfirmedByDevice;
         }
 
+        /// <summary>
+        /// Indicates whether the device confirmed that the lock action occurred.
+        /// </summary>
         [DataMember(Name = "was_confirmed_by_device", IsRequired = false, EmitDefaultValue = false)]
         public bool? WasConfirmedByDevice { get; set; }
 
@@ -202,6 +223,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Unlocking a door is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptUnlockDoor_model")]
     public class ActionAttemptUnlockDoor : ActionAttempt
     {
@@ -239,15 +263,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "UNLOCK_DOOR";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptUnlockDoorError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptUnlockDoorResult Result { get; set; }
 
@@ -286,9 +319,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -323,6 +362,9 @@ namespace Seam.Model
             WasConfirmedByDevice = wasConfirmedByDevice;
         }
 
+        /// <summary>
+        /// Indicates whether the device confirmed that the unlock action occurred.
+        /// </summary>
         [DataMember(Name = "was_confirmed_by_device", IsRequired = false, EmitDefaultValue = false)]
         public bool? WasConfirmedByDevice { get; set; }
 
@@ -346,6 +388,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Reading credential data from the physical encoder is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptScanCredential_model")]
     public class ActionAttemptScanCredential : ActionAttempt
     {
@@ -383,6 +428,9 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
@@ -392,6 +440,9 @@ namespace Seam.Model
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialError Error { get; set; }
 
+        /// <summary>
+        /// Result of scanning a card. If the attempt was successful, includes a snapshot of credential data read from the physical encoder, the corresponding data stored on Seam and the access system, and any associated warnings.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResult Result { get; set; }
 
@@ -433,6 +484,9 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Error type to indicate that the Seam Bridge is disconnected or cannot reach the access control system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum TypeEnum
         {
@@ -458,9 +512,15 @@ namespace Seam.Model
             BridgeDisconnected = 6,
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Error type to indicate that the Seam Bridge is disconnected or cannot reach the access control system.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialError.TypeEnum Type { get; set; }
 
@@ -502,6 +562,9 @@ namespace Seam.Model
             Warnings = warnings;
         }
 
+        /// <summary>
+        /// Snapshot of credential data read from the physical encoder.
+        /// </summary>
         [DataMember(
             Name = "acs_credential_on_encoder",
             IsRequired = false,
@@ -509,9 +572,15 @@ namespace Seam.Model
         )]
         public ActionAttemptScanCredentialResultAcsCredentialOnEncoder? AcsCredentialOnEncoder { get; set; }
 
+        /// <summary>
+        /// Corresponding credential data as stored on Seam and the access system.
+        /// </summary>
         [DataMember(Name = "acs_credential_on_seam", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeam AcsCredentialOnSeam { get; set; }
 
+        /// <summary>
+        /// Warnings related to scanning the credential, such as mismatches between the credential data currently encoded on the card and the corresponding data stored on Seam and the access system.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptScanCredentialResultWarnings> Warnings { get; set; }
 
@@ -559,21 +628,39 @@ namespace Seam.Model
             VisionlineMetadata = visionlineMetadata;
         }
 
+        /// <summary>
+        /// A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_number", IsRequired = false, EmitDefaultValue = false)]
         public string? CardNumber { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string? CreatedAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) will stop being usable.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential has been issued (encoded onto a card).
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsIssued { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) becomes usable.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnEncoderVisionlineMetadata? VisionlineMetadata { get; set; }
 
@@ -635,6 +722,9 @@ namespace Seam.Model
             PendingAutoUpdate = pendingAutoUpdate;
         }
 
+        /// <summary>
+        /// Format of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CardFormatEnum
         {
@@ -648,39 +738,75 @@ namespace Seam.Model
             Rfid48 = 2,
         }
 
+        /// <summary>
+        /// Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is cancelled.
+        /// </summary>
         [DataMember(Name = "cancelled", IsRequired = false, EmitDefaultValue = false)]
         public bool? Cancelled { get; set; }
 
+        /// <summary>
+        /// Format of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_format", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnEncoderVisionlineMetadata.CardFormatEnum? CardFormat { get; set; }
 
+        /// <summary>
+        /// Holder of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_holder", IsRequired = false, EmitDefaultValue = false)]
         public string? CardHolder { get; set; }
 
+        /// <summary>
+        /// Card ID for the Visionline card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CardId { get; set; }
 
+        /// <summary>
+        /// IDs of the common [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "common_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? CommonAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is discarded.
+        /// </summary>
         [DataMember(Name = "discarded", IsRequired = false, EmitDefaultValue = false)]
         public bool? Discarded { get; set; }
 
+        /// <summary>
+        /// Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is expired.
+        /// </summary>
         [DataMember(Name = "expired", IsRequired = false, EmitDefaultValue = false)]
         public bool? Expired { get; set; }
 
+        /// <summary>
+        /// IDs of the guest [entrances](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "guest_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? GuestAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Number of issued cards associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "number_of_issued_cards", IsRequired = false, EmitDefaultValue = false)]
         public float? NumberOfIssuedCards { get; set; }
 
+        /// <summary>
+        /// Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overridden.
+        /// </summary>
         [DataMember(Name = "overridden", IsRequired = false, EmitDefaultValue = false)]
         public bool? Overridden { get; set; }
 
+        /// <summary>
+        /// Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is overwritten.
+        /// </summary>
         [DataMember(Name = "overwritten", IsRequired = false, EmitDefaultValue = false)]
         public bool? Overwritten { get; set; }
 
+        /// <summary>
+        /// Indicates whether the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is pending auto-update.
+        /// </summary>
         [DataMember(Name = "pending_auto_update", IsRequired = false, EmitDefaultValue = false)]
         public bool? PendingAutoUpdate { get; set; }
 
@@ -775,6 +901,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AccessMethodEnum
         {
@@ -794,6 +923,9 @@ namespace Seam.Model
             CloudKey = 4,
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -840,21 +972,39 @@ namespace Seam.Model
             KisiCredential = 13,
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "access_method", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeam.AccessMethodEnum AccessMethod { get; set; }
 
+        /// <summary>
+        /// ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the credential pool to which the credential belongs.
+        /// </summary>
         [DataMember(Name = "acs_credential_pool_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsCredentialPoolId { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_vostio_metadata",
             IsRequired = false,
@@ -862,30 +1012,57 @@ namespace Seam.Model
         )]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeamAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+        /// <summary>
+        /// Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_number", IsRequired = false, EmitDefaultValue = false)]
         public string? CardNumber { get; set; }
 
+        /// <summary>
+        /// Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptScanCredentialResultAcsCredentialOnSeamErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeam.ExternalTypeEnum? ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -893,9 +1070,15 @@ namespace Seam.Model
         )]
         public string? ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsIssued { get; set; }
 
+        /// <summary>
+        /// Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "is_latest_desired_state_synced_with_provider",
             IsRequired = false,
@@ -906,6 +1089,9 @@ namespace Seam.Model
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+        /// </summary>
         [DataMember(
             Name = "is_multi_phone_sync_credential",
             IsRequired = false,
@@ -913,12 +1099,21 @@ namespace Seam.Model
         )]
         public bool? IsMultiPhoneSyncCredential { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+        /// </summary>
         [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOneTimeUse { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+        /// </summary>
         [DataMember(Name = "issued_at", IsRequired = false, EmitDefaultValue = false)]
         public string? IssuedAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "latest_desired_state_synced_with_provider_at",
             IsRequired = false,
@@ -926,6 +1121,9 @@ namespace Seam.Model
         )]
         public string? LatestDesiredStateSyncedWithProviderAt { get; set; }
 
+        /// <summary>
+        /// ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "parent_acs_credential_id",
             IsRequired = false,
@@ -933,18 +1131,33 @@ namespace Seam.Model
         )]
         public string? ParentAcsCredentialId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeamVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptScanCredentialResultAcsCredentialOnSeamWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -993,21 +1206,39 @@ namespace Seam.Model
             OverrideGuestAcsEntranceIds = overrideGuestAcsEntranceIds;
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Names of the doors to which to grant access in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_names", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? DoorNames { get; set; }
 
+        /// <summary>
+        /// Endpoint ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "endpoint_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EndpointId { get; set; }
 
+        /// <summary>
+        /// Key ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyId { get; set; }
 
+        /// <summary>
+        /// Key issuing request ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_issuing_request_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyIssuingRequestId { get; set; }
 
+        /// <summary>
+        /// IDs of the guest entrances to override in the Vostio access system.
+        /// </summary>
         [DataMember(
             Name = "override_guest_acs_entrance_ids",
             IsRequired = false,
@@ -1054,6 +1285,9 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
@@ -1113,6 +1347,9 @@ namespace Seam.Model
             JoinerAcsCredentialIds = joinerAcsCredentialIds;
         }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CardFunctionTypeEnum
         {
@@ -1126,27 +1363,51 @@ namespace Seam.Model
             Staff = 2,
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_function_type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeamVisionlineMetadata.CardFunctionTypeEnum? CardFunctionType { get; set; }
 
+        /// <summary>
+        /// ID of the card in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CardId { get; set; }
 
+        /// <summary>
+        /// Common entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "common_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? CommonAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// ID of the credential in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CredentialId { get; set; }
 
+        /// <summary>
+        /// Guest entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "guest_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? GuestAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential is valid.
+        /// </summary>
         [DataMember(Name = "is_valid", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsValid { get; set; }
 
+        /// <summary>
+        /// IDs of the credentials to which you want to join.
+        /// </summary>
         [DataMember(
             Name = "joiner_acs_credential_ids",
             IsRequired = false,
@@ -1194,6 +1455,9 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum WarningCodeEnum
         {
@@ -1219,12 +1483,21 @@ namespace Seam.Model
             NeedsToBeReissued = 6,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultAcsCredentialOnSeamWarnings.WarningCodeEnum WarningCode { get; set; }
 
@@ -1263,6 +1536,9 @@ namespace Seam.Model
             WarningMessage = warningMessage;
         }
 
+        /// <summary>
+        /// Indicates a warning related to scanning a credential.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum WarningCodeEnum
         {
@@ -1276,9 +1552,15 @@ namespace Seam.Model
             AcsCredentialOnSeamNotFound = 2,
         }
 
+        /// <summary>
+        /// Indicates a warning related to scanning a credential.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanCredentialResultWarnings.WarningCodeEnum WarningCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "warning_message", IsRequired = false, EmitDefaultValue = false)]
         public string WarningMessage { get; set; }
 
@@ -1302,6 +1584,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Encoding credential data from the physical encoder onto a card is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptEncodeCredential_model")]
     public class ActionAttemptEncodeCredential : ActionAttempt
     {
@@ -1339,6 +1624,9 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
@@ -1348,6 +1636,9 @@ namespace Seam.Model
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialError Error { get; set; }
 
+        /// <summary>
+        /// Result of an encoding attempt. If the attempt was successful, includes the credential data that was encoded onto the card.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialResult Result { get; set; }
 
@@ -1389,6 +1680,9 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Error type to indicate that the credential was deleted and can no longer be encoded.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum TypeEnum
         {
@@ -1426,9 +1720,15 @@ namespace Seam.Model
             CredentialDeleted = 10,
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Error type to indicate that the credential was deleted and can no longer be encoded.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialError.TypeEnum Type { get; set; }
 
@@ -1520,6 +1820,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AccessMethodEnum
         {
@@ -1539,6 +1842,9 @@ namespace Seam.Model
             CloudKey = 4,
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -1585,21 +1891,39 @@ namespace Seam.Model
             KisiCredential = 13,
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "access_method", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialResult.AccessMethodEnum AccessMethod { get; set; }
 
+        /// <summary>
+        /// ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the credential pool to which the credential belongs.
+        /// </summary>
         [DataMember(Name = "acs_credential_pool_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsCredentialPoolId { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_vostio_metadata",
             IsRequired = false,
@@ -1607,30 +1931,57 @@ namespace Seam.Model
         )]
         public ActionAttemptEncodeCredentialResultAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+        /// <summary>
+        /// Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_number", IsRequired = false, EmitDefaultValue = false)]
         public string? CardNumber { get; set; }
 
+        /// <summary>
+        /// Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptEncodeCredentialResultErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialResult.ExternalTypeEnum? ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -1638,9 +1989,15 @@ namespace Seam.Model
         )]
         public string? ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsIssued { get; set; }
 
+        /// <summary>
+        /// Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "is_latest_desired_state_synced_with_provider",
             IsRequired = false,
@@ -1651,6 +2008,9 @@ namespace Seam.Model
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+        /// </summary>
         [DataMember(
             Name = "is_multi_phone_sync_credential",
             IsRequired = false,
@@ -1658,12 +2018,21 @@ namespace Seam.Model
         )]
         public bool? IsMultiPhoneSyncCredential { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+        /// </summary>
         [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOneTimeUse { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+        /// </summary>
         [DataMember(Name = "issued_at", IsRequired = false, EmitDefaultValue = false)]
         public string? IssuedAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "latest_desired_state_synced_with_provider_at",
             IsRequired = false,
@@ -1671,6 +2040,9 @@ namespace Seam.Model
         )]
         public string? LatestDesiredStateSyncedWithProviderAt { get; set; }
 
+        /// <summary>
+        /// ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "parent_acs_credential_id",
             IsRequired = false,
@@ -1678,18 +2050,33 @@ namespace Seam.Model
         )]
         public string? ParentAcsCredentialId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialResultVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptEncodeCredentialResultWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -1738,21 +2125,39 @@ namespace Seam.Model
             OverrideGuestAcsEntranceIds = overrideGuestAcsEntranceIds;
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Names of the doors to which to grant access in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_names", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? DoorNames { get; set; }
 
+        /// <summary>
+        /// Endpoint ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "endpoint_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EndpointId { get; set; }
 
+        /// <summary>
+        /// Key ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyId { get; set; }
 
+        /// <summary>
+        /// Key issuing request ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_issuing_request_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyIssuingRequestId { get; set; }
 
+        /// <summary>
+        /// IDs of the guest entrances to override in the Vostio access system.
+        /// </summary>
         [DataMember(
             Name = "override_guest_acs_entrance_ids",
             IsRequired = false,
@@ -1797,6 +2202,9 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
@@ -1854,6 +2262,9 @@ namespace Seam.Model
             JoinerAcsCredentialIds = joinerAcsCredentialIds;
         }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CardFunctionTypeEnum
         {
@@ -1867,27 +2278,51 @@ namespace Seam.Model
             Staff = 2,
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_function_type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialResultVisionlineMetadata.CardFunctionTypeEnum? CardFunctionType { get; set; }
 
+        /// <summary>
+        /// ID of the card in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CardId { get; set; }
 
+        /// <summary>
+        /// Common entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "common_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? CommonAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// ID of the credential in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CredentialId { get; set; }
 
+        /// <summary>
+        /// Guest entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "guest_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? GuestAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential is valid.
+        /// </summary>
         [DataMember(Name = "is_valid", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsValid { get; set; }
 
+        /// <summary>
+        /// IDs of the credentials to which you want to join.
+        /// </summary>
         [DataMember(
             Name = "joiner_acs_credential_ids",
             IsRequired = false,
@@ -1932,6 +2367,9 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum WarningCodeEnum
         {
@@ -1957,12 +2395,21 @@ namespace Seam.Model
             NeedsToBeReissued = 6,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptEncodeCredentialResultWarnings.WarningCodeEnum WarningCode { get; set; }
 
@@ -1986,6 +2433,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Scanning a physical card and assigning the credential is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptScanToAssignCredential_model")]
     public class ActionAttemptScanToAssignCredential : ActionAttempt
     {
@@ -2023,6 +2473,9 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
@@ -2032,6 +2485,9 @@ namespace Seam.Model
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialError Error { get; set; }
 
+        /// <summary>
+        /// Result of a scan to assign attempt. If the attempt was successful, includes the credential data that was scanned and assigned.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialResult Result { get; set; }
 
@@ -2073,6 +2529,9 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Error type to indicate that there is no credential on the encoder.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum TypeEnum
         {
@@ -2089,9 +2548,15 @@ namespace Seam.Model
             NoCredentialOnEncoder = 3,
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Error type to indicate that there is no credential on the encoder.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialError.TypeEnum Type { get; set; }
 
@@ -2184,6 +2649,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AccessMethodEnum
         {
@@ -2203,6 +2671,9 @@ namespace Seam.Model
             CloudKey = 4,
         }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ExternalTypeEnum
         {
@@ -2249,21 +2720,39 @@ namespace Seam.Model
             KisiCredential = 13,
         }
 
+        /// <summary>
+        /// Access method for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "access_method", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialResult.AccessMethodEnum AccessMethod { get; set; }
 
+        /// <summary>
+        /// ID of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the credential pool to which the credential belongs.
+        /// </summary>
         [DataMember(Name = "acs_credential_pool_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsCredentialPoolId { get; set; }
 
+        /// <summary>
+        /// ID of the [access control system](https://docs.seam.co/low-level-apis/access-systems) that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the [ACS user](https://docs.seam.co/low-level-apis/access-systems/user-management) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// Vostio-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_vostio_metadata",
             IsRequired = false,
@@ -2271,30 +2760,57 @@ namespace Seam.Model
         )]
         public ActionAttemptScanToAssignCredentialResultAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+        /// <summary>
+        /// Number of the card associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "card_number", IsRequired = false, EmitDefaultValue = false)]
         public string? CardNumber { get; set; }
 
+        /// <summary>
+        /// Access (PIN) code for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) to which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptScanToAssignCredentialResultErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.
+        /// </summary>
         [DataMember(Name = "external_type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialResult.ExternalTypeEnum? ExternalType { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) type.
+        /// </summary>
         [DataMember(
             Name = "external_type_display_name",
             IsRequired = false,
@@ -2302,9 +2818,15 @@ namespace Seam.Model
         )]
         public string? ExternalTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been encoded onto a card.
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsIssued { get; set; }
 
+        /// <summary>
+        /// Indicates whether the latest state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) has been synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "is_latest_desired_state_synced_with_provider",
             IsRequired = false,
@@ -2312,9 +2834,15 @@ namespace Seam.Model
         )]
         public bool? IsLatestDesiredStateSyncedWithProvider { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam manages the credential.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).
+        /// </summary>
         [DataMember(
             Name = "is_multi_phone_sync_credential",
             IsRequired = false,
@@ -2322,12 +2850,21 @@ namespace Seam.Model
         )]
         public bool? IsMultiPhoneSyncCredential { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.
+        /// </summary>
         [DataMember(Name = "is_one_time_use", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOneTimeUse { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was encoded onto a card.
+        /// </summary>
         [DataMember(Name = "issued_at", IsRequired = false, EmitDefaultValue = false)]
         public string? IssuedAt { get; set; }
 
+        /// <summary>
+        /// Date and time at which the state of the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was most recently synced from Seam to the provider.
+        /// </summary>
         [DataMember(
             Name = "latest_desired_state_synced_with_provider_at",
             IsRequired = false,
@@ -2335,6 +2872,9 @@ namespace Seam.Model
         )]
         public string? LatestDesiredStateSyncedWithProviderAt { get; set; }
 
+        /// <summary>
+        /// ID of the parent [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(
             Name = "parent_acs_credential_id",
             IsRequired = false,
@@ -2342,18 +2882,33 @@ namespace Seam.Model
         )]
         public string? ParentAcsCredentialId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) belongs.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Visionline-specific metadata for the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialResultVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptScanToAssignCredentialResultWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials).
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -2402,21 +2957,39 @@ namespace Seam.Model
             OverrideGuestAcsEntranceIds = overrideGuestAcsEntranceIds;
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Names of the doors to which to grant access in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "door_names", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? DoorNames { get; set; }
 
+        /// <summary>
+        /// Endpoint ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "endpoint_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EndpointId { get; set; }
 
+        /// <summary>
+        /// Key ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyId { get; set; }
 
+        /// <summary>
+        /// Key issuing request ID in the Vostio access system.
+        /// </summary>
         [DataMember(Name = "key_issuing_request_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyIssuingRequestId { get; set; }
 
+        /// <summary>
+        /// IDs of the guest entrances to override in the Vostio access system.
+        /// </summary>
         [DataMember(
             Name = "override_guest_acs_entrance_ids",
             IsRequired = false,
@@ -2461,6 +3034,9 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
@@ -2520,6 +3096,9 @@ namespace Seam.Model
             JoinerAcsCredentialIds = joinerAcsCredentialIds;
         }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CardFunctionTypeEnum
         {
@@ -2533,27 +3112,51 @@ namespace Seam.Model
             Staff = 2,
         }
 
+        /// <summary>
+        /// Indicates whether the credential should auto-join. For an auto-join credential, Seam automatically issues an override card if there are no other cards and a joiner card if there are existing cards on the doors.
+        /// </summary>
         [DataMember(Name = "auto_join", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoJoin { get; set; }
 
+        /// <summary>
+        /// Card function type in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_function_type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialResultVisionlineMetadata.CardFunctionTypeEnum? CardFunctionType { get; set; }
 
+        /// <summary>
+        /// ID of the card in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "card_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CardId { get; set; }
 
+        /// <summary>
+        /// Common entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "common_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? CommonAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// ID of the credential in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string? CredentialId { get; set; }
 
+        /// <summary>
+        /// Guest entrance IDs in the Visionline access system.
+        /// </summary>
         [DataMember(Name = "guest_acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? GuestAcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential is valid.
+        /// </summary>
         [DataMember(Name = "is_valid", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsValid { get; set; }
 
+        /// <summary>
+        /// IDs of the credentials to which you want to join.
+        /// </summary>
         [DataMember(
             Name = "joiner_acs_credential_ids",
             IsRequired = false,
@@ -2598,6 +3201,9 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum WarningCodeEnum
         {
@@ -2623,12 +3229,21 @@ namespace Seam.Model
             NeedsToBeReissued = 6,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptScanToAssignCredentialResultWarnings.WarningCodeEnum WarningCode { get; set; }
 
@@ -2652,6 +3267,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Assigning a credential to an access method is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptAssignCredential_model")]
     public class ActionAttemptAssignCredential : ActionAttempt
     {
@@ -2689,6 +3307,9 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
@@ -2698,6 +3319,9 @@ namespace Seam.Model
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialError Error { get; set; }
 
+        /// <summary>
+        /// Result of assigning a credential. If successful, includes the updated access method with the assigned credential.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResult Result { get; set; }
 
@@ -2739,6 +3363,9 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Error type to indicate that no matching credential was found.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum TypeEnum
         {
@@ -2755,9 +3382,15 @@ namespace Seam.Model
             CredentialNotFound = 3,
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Error type to indicate that no matching credential was found.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialError.TypeEnum Type { get; set; }
 
@@ -2828,6 +3461,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ModeEnum
         {
@@ -2847,18 +3483,33 @@ namespace Seam.Model
             CloudKey = 4,
         }
 
+        /// <summary>
+        /// ID of the access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Token of the client session associated with the access method.
+        /// </summary>
         [DataMember(Name = "client_session_token", IsRequired = false, EmitDefaultValue = false)]
         public string? ClientSessionToken { get; set; }
 
+        /// <summary>
+        /// The actual PIN code for code access methods.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access method was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the customization profile associated with the access method.
+        /// </summary>
         [DataMember(
             Name = "customization_profile_id",
             IsRequired = false,
@@ -2866,42 +3517,81 @@ namespace Seam.Model
         )]
         public string? CustomizationProfileId { get; set; }
 
+        /// <summary>
+        /// Display name of the access method.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptAssignCredentialResultErrors> Errors { get; set; }
 
+        /// <summary>
+        /// URL of the Instant Key for mobile key access methods.
+        /// </summary>
         [DataMember(Name = "instant_key_url", IsRequired = false, EmitDefaultValue = false)]
         public string? InstantKeyUrl { get; set; }
 
+        /// <summary>
+        /// Indicates whether an existing card credential must be assigned to this access method before it can be issued. Only applies to card-mode access methods on systems that support credential assignment.
+        /// </summary>
         [DataMember(Name = "is_assignment_required", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsAssignmentRequired { get; set; }
 
+        /// <summary>
+        /// Indicates whether encoding with an card encoder is required to issue or reissue the plastic card associated with the access method.
+        /// </summary>
         [DataMember(Name = "is_encoding_required", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsEncodingRequired { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access method has been issued.
+        /// </summary>
         [DataMember(Name = "is_issued", IsRequired = false, EmitDefaultValue = false)]
         public bool IsIssued { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access method is ready for card assignment. This is true when the access method is in card mode, has not yet been issued, and the system supports credential assignment.
+        /// </summary>
         [DataMember(Name = "is_ready_for_assignment", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsReadyForAssignment { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access method is ready to be encoded. This is true when the credential has been created and the card has not yet been issued.
+        /// </summary>
         [DataMember(Name = "is_ready_for_encoding", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsReadyForEncoding { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access method was issued.
+        /// </summary>
         [DataMember(Name = "issued_at", IsRequired = false, EmitDefaultValue = false)]
         public string? IssuedAt { get; set; }
 
+        /// <summary>
+        /// Access method mode. Supported values: `code`, `card`, `mobile_key`, `cloud_key`.
+        /// </summary>
         [DataMember(Name = "mode", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResult.ModeEnum Mode { get; set; }
 
+        /// <summary>
+        /// Pending mutations for the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant). Indicates operations that are in progress.
+        /// </summary>
         [DataMember(Name = "pending_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptAssignCredentialResultPendingMutations> PendingMutations { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access method](https://docs.seam.co/use-cases/granting-access/creating-an-access-grant).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<ActionAttemptAssignCredentialResultWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the Seam workspace associated with the access method.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -2942,6 +3632,9 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ErrorCodeEnum
         {
@@ -2952,12 +3645,21 @@ namespace Seam.Model
             FailedToIssue = 1,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResultErrors.ErrorCodeEnum ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -3003,6 +3705,9 @@ namespace Seam.Model
             To = to;
         }
 
+        /// <summary>
+        /// Mutation code to indicate that Seam is in the process of updating the access times for this access method.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum MutationCodeEnum
         {
@@ -3019,18 +3724,33 @@ namespace Seam.Model
             UpdatingAccessTimes = 3,
         }
 
+        /// <summary>
+        /// Date and time at which the mutation was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Previous access time configuration.
+        /// </summary>
         [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResultPendingMutationsFrom From { get; set; }
 
+        /// <summary>
+        /// Detailed description of the mutation.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Mutation code to indicate that Seam is in the process of updating the access times for this access method.
+        /// </summary>
         [DataMember(Name = "mutation_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResultPendingMutations.MutationCodeEnum MutationCode { get; set; }
 
+        /// <summary>
+        /// New access time configuration.
+        /// </summary>
         [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResultPendingMutationsTo To { get; set; }
 
@@ -3069,9 +3789,15 @@ namespace Seam.Model
             StartsAt = startsAt;
         }
 
+        /// <summary>
+        /// Previous end time for access.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Previous start time for access.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
@@ -3110,9 +3836,15 @@ namespace Seam.Model
             StartsAt = startsAt;
         }
 
+        /// <summary>
+        /// New end time for access.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// New start time for access.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
@@ -3155,6 +3887,9 @@ namespace Seam.Model
             OriginalAccessMethodId = originalAccessMethodId;
         }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum WarningCodeEnum
         {
@@ -3174,15 +3909,27 @@ namespace Seam.Model
             DelayInIssuing = 4,
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptAssignCredentialResultWarnings.WarningCodeEnum WarningCode { get; set; }
 
+        /// <summary>
+        /// ID of the original access method from which this backup access method was split, if applicable.
+        /// </summary>
         [DataMember(
             Name = "original_access_method_id",
             IsRequired = false,
@@ -3210,6 +3957,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Resetting a sandbox workspace is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptResetSandboxWorkspace_model")]
     public class ActionAttemptResetSandboxWorkspace : ActionAttempt
     {
@@ -3247,15 +3997,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "RESET_SANDBOX_WORKSPACE";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptResetSandboxWorkspaceError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptResetSandboxWorkspaceResult Result { get; set; }
 
@@ -3297,9 +4056,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -3349,6 +4114,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Setting the fan mode is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptSetFanMode_model")]
     public class ActionAttemptSetFanMode : ActionAttempt
     {
@@ -3386,15 +4154,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "SET_FAN_MODE";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSetFanModeError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSetFanModeResult Result { get; set; }
 
@@ -3433,9 +4210,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -3485,6 +4268,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Setting the HVAC mode is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptSetHvacMode_model")]
     public class ActionAttemptSetHvacMode : ActionAttempt
     {
@@ -3522,15 +4308,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "SET_HVAC_MODE";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSetHvacModeError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSetHvacModeResult Result { get; set; }
 
@@ -3569,9 +4364,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -3621,6 +4422,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Activating a climate preset is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptActivateClimatePreset_model")]
     public class ActionAttemptActivateClimatePreset : ActionAttempt
     {
@@ -3658,15 +4462,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "ACTIVATE_CLIMATE_PRESET";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptActivateClimatePresetError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptActivateClimatePresetResult Result { get; set; }
 
@@ -3708,9 +4521,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -3760,6 +4579,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Simulating a keypad code entry is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptSimulateKeypadCodeEntry_model")]
     public class ActionAttemptSimulateKeypadCodeEntry : ActionAttempt
     {
@@ -3797,15 +4619,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "SIMULATE_KEYPAD_CODE_ENTRY";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSimulateKeypadCodeEntryError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSimulateKeypadCodeEntryResult Result { get; set; }
 
@@ -3847,9 +4678,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -3899,6 +4736,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Simulating a manual lock action using a keypad is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptSimulateManualLockViaKeypad_model")]
     public class ActionAttemptSimulateManualLockViaKeypad : ActionAttempt
     {
@@ -3936,15 +4776,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "SIMULATE_MANUAL_LOCK_VIA_KEYPAD";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSimulateManualLockViaKeypadError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSimulateManualLockViaKeypadResult Result { get; set; }
 
@@ -3986,9 +4835,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4038,6 +4893,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Pushing thermostat weekly programs is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptPushThermostatPrograms_model")]
     public class ActionAttemptPushThermostatPrograms : ActionAttempt
     {
@@ -4075,15 +4933,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "PUSH_THERMOSTAT_PROGRAMS";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptPushThermostatProgramsError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptPushThermostatProgramsResult Result { get; set; }
 
@@ -4125,9 +4992,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4177,6 +5050,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Configuring the auto-lock is pending.
+    /// </summary>
     [DataContract(Name = "seamModel_actionAttemptConfigureAutoLock_model")]
     public class ActionAttemptConfigureAutoLock : ActionAttempt
     {
@@ -4214,15 +5090,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "CONFIGURE_AUTO_LOCK";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptConfigureAutoLockError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptConfigureAutoLockResult Result { get; set; }
 
@@ -4261,9 +5146,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4350,15 +5241,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "SYNC_ACCESS_CODES";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSyncAccessCodesError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptSyncAccessCodesResult Result { get; set; }
 
@@ -4397,9 +5297,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4486,15 +5392,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "CREATE_ACCESS_CODE";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptCreateAccessCodeError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptCreateAccessCodeResult Result { get; set; }
 
@@ -4533,9 +5448,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4622,15 +5543,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "DELETE_ACCESS_CODE";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptDeleteAccessCodeError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptDeleteAccessCodeResult Result { get; set; }
 
@@ -4669,9 +5599,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4758,15 +5694,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "UPDATE_ACCESS_CODE";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptUpdateAccessCodeError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptUpdateAccessCodeResult Result { get; set; }
 
@@ -4805,9 +5750,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -4894,15 +5845,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "CREATE_NOISE_THRESHOLD";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptCreateNoiseThresholdError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptCreateNoiseThresholdResult Result { get; set; }
 
@@ -4944,9 +5904,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -5033,15 +5999,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "DELETE_NOISE_THRESHOLD";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptDeleteNoiseThresholdError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptDeleteNoiseThresholdResult Result { get; set; }
 
@@ -5083,9 +6058,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -5172,15 +6153,24 @@ namespace Seam.Model
             Error = 3,
         }
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "UPDATE_NOISE_THRESHOLD";
 
+        /// <summary>
+        /// Error associated with the action.
+        /// </summary>
         [DataMember(Name = "error", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptUpdateNoiseThresholdError Error { get; set; }
 
+        /// <summary>
+        /// Result of the action.
+        /// </summary>
         [DataMember(Name = "result", IsRequired = false, EmitDefaultValue = false)]
         public ActionAttemptUpdateNoiseThresholdResult Result { get; set; }
 
@@ -5222,9 +6212,15 @@ namespace Seam.Model
             Type = type;
         }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Type of the error.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public string Type { get; set; }
 
@@ -5292,6 +6288,9 @@ namespace Seam.Model
         [DataMember(Name = "action_type", IsRequired = true, EmitDefaultValue = false)]
         public override string ActionType { get; } = "unrecognized";
 
+        /// <summary>
+        /// ID of the action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public override string ActionAttemptId { get; set; }
 

--- a/output/csharp/src/Seam/Model/Batch.cs
+++ b/output/csharp/src/Seam/Model/Batch.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// A batch of workspace resources.
+    /// </summary>
     [DataContract(Name = "seamModel_batch_model")]
     public class Batch
     {
@@ -67,60 +70,184 @@ namespace Seam.Model
             Workspaces = workspaces;
         }
 
+        /// <summary>
+        /// Represents a smart lock [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        ///
+        /// An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.
+        ///
+        /// Seam supports programming two types of access codes: [ongoing](https://docs.seam.co/low-level-apis/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/low-level-apis/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the `type` property of the access code. Ongoing codes display as `ongoing`, whereas time-bound codes are labeled `time_bound`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both `starts_at` and `ends_at` empty. A time-bound access code will be programmed at the `starts_at` time and removed at the `ends_at` time.
+        ///
+        /// In addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.
+        ///
+        /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach and work across both standalone smart locks and access systems. Use the lower-level Access Codes API directly only when you specifically need to manage individual PIN codes.
+        /// </summary>
         [DataMember(Name = "access_codes", IsRequired = false, EmitDefaultValue = false)]
         public object? AccessCodes { get; set; }
 
+        /// <summary>
+        /// Represents an Access Grant. Access Grants enable you to grant a user identity access to spaces, entrances, and devices through one or more access methods, such as mobile keys, plastic cards, and PIN codes. You can create an Access Grant for an existing user identity, or you can create a new user identity *while* creating the new Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grants", IsRequired = false, EmitDefaultValue = false)]
         public object? AccessGrants { get; set; }
 
+        /// <summary>
+        /// Represents an access method for an Access Grant. Access methods describe the modes of access, such as PIN codes, plastic cards, and mobile keys. For a mobile key, the access method also stores the URL for the associated Instant Key.
+        /// </summary>
         [DataMember(Name = "access_methods", IsRequired = false, EmitDefaultValue = false)]
         public object? AccessMethods { get; set; }
 
+        /// <summary>
+        /// Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.
+        ///
+        /// Some access control systems use [access group](https://docs.seam.co/low-level-apis/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
+        ///
+        /// To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+        /// </summary>
         [DataMember(Name = "acs_access_groups", IsRequired = false, EmitDefaultValue = false)]
         public object? AcsAccessGroups { get; set; }
 
+        /// <summary>
+        /// Means by which an [access control system user](https://docs.seam.co/low-level-apis/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// An access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.
+        ///
+        /// For each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.
+        ///
+        /// For granting a person access to a space, [Access Grants](https://docs.seam.co/use-cases/granting-access) are the default and recommended approach. Use the lower-level ACS credential API directly only when you specifically need to manage individual credentials.
+        /// </summary>
         [DataMember(Name = "acs_credentials", IsRequired = false, EmitDefaultValue = false)]
         public object? AcsCredentials { get; set; }
 
+        /// <summary>
+        /// Represents a hardware device that encodes [credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// Some access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:
+        ///
+        /// 1. Credential creation
+        ///    Configure the access parameters for the credential.
+        /// 2. Card encoding
+        ///    Write the credential data onto the card using a compatible card encoder.
+        ///
+        /// Separately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.
+        ///
+        /// See [Working with Card Encoders and Scanners](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners).
+        ///
+        /// To verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+        /// </summary>
         [DataMember(Name = "acs_encoders", IsRequired = false, EmitDefaultValue = false)]
         public object? AcsEncoders { get; set; }
 
+        /// <summary>
+        /// Represents an [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// In an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.
+        /// </summary>
         [DataMember(Name = "acs_entrances", IsRequired = false, EmitDefaultValue = false)]
         public object? AcsEntrances { get; set; }
 
+        /// <summary>
+        /// Represents an [access control system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// Within an `acs_system`, create [`acs_user`s](https://docs.seam.co/api/acs/users/object) and [`acs_credential`s](https://docs.seam.co/api/acs/credentials/object) to grant access to the `acs_user`s.
+        ///
+        /// For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
+        /// </summary>
         [DataMember(Name = "acs_systems", IsRequired = false, EmitDefaultValue = false)]
         public object? AcsSystems { get; set; }
 
+        /// <summary>
+        /// Represents a [user](https://docs.seam.co/low-level-apis/access-systems/user-management) in an [access system](https://docs.seam.co/low-level-apis/access-systems).
+        ///
+        /// An access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.
+        ///
+        /// For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
+        /// </summary>
         [DataMember(Name = "acs_users", IsRequired = false, EmitDefaultValue = false)]
         public object? AcsUsers { get; set; }
 
+        /// <summary>
+        /// Represents an action attempt that enables you to keep track of the progress of your action that affects a physical device or system.actions against a device. Action attempts are useful because the physical world is intrinsically asynchronous.
+        ///
+        /// When you request for a device to perform an action, the Seam API immediately returns an action attempt object. In the background, the Seam API performs the action.
+        ///
+        /// See also [Action Attempts](https://docs.seam.co/core-concepts/action-attempts).
+        /// </summary>
         [DataMember(Name = "action_attempts", IsRequired = false, EmitDefaultValue = false)]
         public object? ActionAttempts { get; set; }
 
+        /// <summary>
+        /// Represents a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens). If you want to restrict your users&apos; access to their own devices, use client sessions.
+        ///
+        /// You create each client session with a custom `user_identifier_key`. Normally, the `user_identifier_key` is a user ID that your application provides.
+        ///
+        /// When calling the Seam API from your backend using an API key, you can pass the `user_identifier_key` as a parameter to limit results to the associated client session. For example, `/devices/list?user_identifier_key=123` only returns devices associated with the client session created with the `user_identifier_key` `123`.
+        ///
+        /// A client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user&apos;s access to only the devices that they own.
+        ///
+        /// See also [Get Started with React](https://docs.seam.co/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).
+        /// </summary>
         [DataMember(Name = "client_sessions", IsRequired = false, EmitDefaultValue = false)]
         public object? ClientSessions { get; set; }
 
+        /// <summary>
+        /// Represents a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+        ///
+        /// Connect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.
+        ///
+        /// Connect Webviews perform credential validation, multifactor authentication (when applicable), and error handling for each brand that Seam supports. Further, Connect Webviews work across all modern browsers and platforms, including Chrome, Safari, and Firefox.
+        ///
+        /// To enable a user to connect their device or system account to Seam through your app, first create a `connect_webview`. Once created, this `connect_webview` includes a URL that you can use to open an [iframe](https://www.w3schools.com/html/html_iframe.asp) or new window containing the Connect Webview for your user.
+        ///
+        /// When you create a Connect Webview, specify the desired provider category key in the `provider_category` parameter. Alternately, to specify a list of providers explicitly, use the `accepted_providers` parameter with a list of device provider keys.
+        ///
+        /// To list all providers within a category, use `/devices/list_device_providers` with the desired `provider_category` filter. To list all provider keys, use `/devices/list_device_providers` with no filters.
+        /// </summary>
         [DataMember(Name = "connect_webviews", IsRequired = false, EmitDefaultValue = false)]
         public object? ConnectWebviews { get; set; }
 
+        /// <summary>
+        /// Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
+        /// </summary>
         [DataMember(Name = "connected_accounts", IsRequired = false, EmitDefaultValue = false)]
         public object? ConnectedAccounts { get; set; }
 
+        /// <summary>
+        /// Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.
+        /// </summary>
         [DataMember(Name = "devices", IsRequired = false, EmitDefaultValue = false)]
         public object? Devices { get; set; }
 
+        /// <summary>
+        /// Represents an event. Events let you know when something interesting happens in your workspace. For example, when a lock is unlocked, Seam creates a `lock.unlocked` event. When a device&apos;s battery level is low, Seam creates a `device.battery_low` event.
+        ///
+        /// As with other API resources, you can retrieve an individual event or a list of events. Seam also provides a separate webhook system for sending the event objects directly to an endpoint on your sever. Manage webhooks through [Seam Console](https://console.seam.co). You can also use the webhooks sandbox in Seam Console to see the different payloads for each event and test them against your own endpoints.
+        /// </summary>
         [DataMember(Name = "events", IsRequired = false, EmitDefaultValue = false)]
         public object? Events { get; set; }
 
+        /// <summary>
+        /// Represents a Seam Instant Key. For issuing Bluetooth mobile keys, Instant Keys are the fastest way to share access. With a single API call, you can create a mobile key and send it through text or email or embed it in your own app.
+        ///
+        /// There’s no app to install, nor account to create. Your user just taps a link and gets a lightweight, native-feeling experience using iOS App Clip or Instant Apps on Android. Further, Instant Keys work offline, so even in areas with poor cellular or Wi-Fi, like elevator banks or concrete-walled hallways, the Instant Keys still work.
+        /// </summary>
         [DataMember(Name = "instant_keys", IsRequired = false, EmitDefaultValue = false)]
         public object? InstantKeys { get; set; }
 
+        /// <summary>
+        /// Represents a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+        /// </summary>
         [DataMember(Name = "noise_thresholds", IsRequired = false, EmitDefaultValue = false)]
         public object? NoiseThresholds { get; set; }
 
+        /// <summary>
+        /// Represents a space that is a logical grouping of devices and entrances. You can assign access to an entire space, thereby making granting access more efficient.
+        /// </summary>
         [DataMember(Name = "spaces", IsRequired = false, EmitDefaultValue = false)]
         public object? Spaces { get; set; }
 
+        /// <summary>
+        /// Represents a thermostat daily program, consisting of a set of periods, each of which has a starting time and the key that identifies the climate preset to apply at the starting time.
+        /// </summary>
         [DataMember(
             Name = "thermostat_daily_programs",
             IsRequired = false,
@@ -128,18 +255,43 @@ namespace Seam.Model
         )]
         public object? ThermostatDailyPrograms { get; set; }
 
+        /// <summary>
+        /// Represents a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.
+        /// </summary>
         [DataMember(Name = "thermostat_schedules", IsRequired = false, EmitDefaultValue = false)]
         public object? ThermostatSchedules { get; set; }
 
+        /// <summary>
+        /// Represents an [unmanaged smart lock access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+        ///
+        /// An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.
+        ///
+        /// When you create an access code on a device in Seam, it is created as a managed access code. Access codes that exist on a device that were not created through Seam are considered unmanaged codes. We strictly limit the operations that can be performed on unmanaged codes.
+        ///
+        /// Prior to using Seam to manage your devices, you may have used another lock management system to manage the access codes on your devices. Where possible, we help you keep any existing access codes on devices and transition those codes to ones managed by your Seam workspace.
+        ///
+        /// Not all providers support unmanaged access codes. The following providers do not support unmanaged access codes:
+        ///
+        /// - [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)
+        /// </summary>
         [DataMember(Name = "unmanaged_access_codes", IsRequired = false, EmitDefaultValue = false)]
         public object? UnmanagedAccessCodes { get; set; }
 
+        /// <summary>
+        /// Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+        /// </summary>
         [DataMember(Name = "unmanaged_devices", IsRequired = false, EmitDefaultValue = false)]
         public object? UnmanagedDevices { get; set; }
 
+        /// <summary>
+        /// Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
+        /// </summary>
         [DataMember(Name = "user_identities", IsRequired = false, EmitDefaultValue = false)]
         public object? UserIdentities { get; set; }
 
+        /// <summary>
+        /// Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).
+        /// </summary>
         [DataMember(Name = "workspaces", IsRequired = false, EmitDefaultValue = false)]
         public object? Workspaces { get; set; }
 

--- a/output/csharp/src/Seam/Model/ClientSession.cs
+++ b/output/csharp/src/Seam/Model/ClientSession.cs
@@ -8,6 +8,17 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens). If you want to restrict your users&apos; access to their own devices, use client sessions.
+    ///
+    /// You create each client session with a custom `user_identifier_key`. Normally, the `user_identifier_key` is a user ID that your application provides.
+    ///
+    /// When calling the Seam API from your backend using an API key, you can pass the `user_identifier_key` as a parameter to limit results to the associated client session. For example, `/devices/list?user_identifier_key=123` only returns devices associated with the client session created with the `user_identifier_key` `123`.
+    ///
+    /// A client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user&apos;s access to only the devices that they own.
+    ///
+    /// See also [Get Started with React](https://docs.seam.co/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).
+    /// </summary>
     [DataContract(Name = "seamModel_clientSession_model")]
     public class ClientSession
     {
@@ -43,39 +54,76 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the client session.
+        /// </summary>
         [DataMember(Name = "client_session_id", IsRequired = false, EmitDefaultValue = false)]
         public string ClientSessionId { get; set; }
 
+        /// <summary>
+        /// IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         [DataMember(Name = "connect_webview_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> ConnectWebviewIds { get; set; }
 
+        /// <summary>
+        /// IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         [DataMember(Name = "connected_account_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> ConnectedAccountIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Customer key associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Number of devices associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         [DataMember(Name = "device_count", IsRequired = false, EmitDefaultValue = false)]
         public float DeviceCount { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) expires.
+        /// </summary>
         [DataMember(Name = "expires_at", IsRequired = false, EmitDefaultValue = false)]
         public string ExpiresAt { get; set; }
 
+        /// <summary>
+        /// Client session token associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         [DataMember(Name = "token", IsRequired = false, EmitDefaultValue = false)]
         public string Token { get; set; }
 
+        /// <summary>
+        /// Your user ID for the user associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).
+        /// </summary>
         [DataMember(Name = "user_identifier_key", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentifierKey { get; set; }
 
+        /// <summary>
+        /// ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.
+        /// </summary>
+        [Obsolete("Use `user_identity_id` instead.")]
         [DataMember(Name = "user_identity_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> UserIdentityIds { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the client session.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 

--- a/output/csharp/src/Seam/Model/ConnectWebview.cs
+++ b/output/csharp/src/Seam/Model/ConnectWebview.cs
@@ -8,6 +8,19 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
+    ///
+    /// Connect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.
+    ///
+    /// Connect Webviews perform credential validation, multifactor authentication (when applicable), and error handling for each brand that Seam supports. Further, Connect Webviews work across all modern browsers and platforms, including Chrome, Safari, and Firefox.
+    ///
+    /// To enable a user to connect their device or system account to Seam through your app, first create a `connect_webview`. Once created, this `connect_webview` includes a URL that you can use to open an [iframe](https://www.w3schools.com/html/html_iframe.asp) or new window containing the Connect Webview for your user.
+    ///
+    /// When you create a Connect Webview, specify the desired provider category key in the `provider_category` parameter. Alternately, to specify a list of providers explicitly, use the `accepted_providers` parameter with a list of device provider keys.
+    ///
+    /// To list all providers within a category, use `/devices/list_device_providers` with the desired `provider_category` filter. To list all provider keys, use `/devices/list_device_providers` with no filters.
+    /// </summary>
     [DataContract(Name = "seamModel_connectWebview_model")]
     public class ConnectWebview
     {
@@ -57,6 +70,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// High-level device capabilities that the Connect Webview can accept. When creating a Connect Webview, you can specify the types of devices that it can connect to Seam. If you do not set custom `accepted_capabilities`, Seam uses a default set of `accepted_capabilities` for each provider. For example, if you create a Connect Webview that accepts SmartThing devices, without specifying `accepted_capabilities`, Seam accepts only SmartThings locks. To connect SmartThings thermostats and locks to Seam, create a Connect Webview and include both `thermostat` and `lock` in the `accepted_capabilities`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AcceptedCapabilitiesEnum
         {
@@ -79,6 +95,9 @@ namespace Seam.Model
             Camera = 5,
         }
 
+        /// <summary>
+        /// Device selection mode of the Connect Webview. Supported values: `none`, `single`, `multiple`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DeviceSelectionModeEnum
         {
@@ -95,6 +114,9 @@ namespace Seam.Model
             Multiple = 3,
         }
 
+        /// <summary>
+        /// Status of the Connect Webview. `authorized` indicates that the user has successfully logged into their device or system account, thereby completing the Connect Webview.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum StatusEnum
         {
@@ -111,18 +133,33 @@ namespace Seam.Model
             Authorized = 3,
         }
 
+        /// <summary>
+        /// High-level device capabilities that the Connect Webview can accept. When creating a Connect Webview, you can specify the types of devices that it can connect to Seam. If you do not set custom `accepted_capabilities`, Seam uses a default set of `accepted_capabilities` for each provider. For example, if you create a Connect Webview that accepts SmartThing devices, without specifying `accepted_capabilities`, Seam accepts only SmartThings locks. To connect SmartThings thermostats and locks to Seam, create a Connect Webview and include both `thermostat` and `lock` in the `accepted_capabilities`.
+        /// </summary>
         [DataMember(Name = "accepted_capabilities", IsRequired = false, EmitDefaultValue = false)]
         public List<ConnectWebview.AcceptedCapabilitiesEnum> AcceptedCapabilities { get; set; }
 
+        /// <summary>
+        /// List of accepted [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+        /// </summary>
         [DataMember(Name = "accepted_providers", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AcceptedProviders { get; set; }
 
+        /// <summary>
+        /// Indicates whether any provider is allowed.
+        /// </summary>
         [DataMember(Name = "any_provider_allowed", IsRequired = false, EmitDefaultValue = false)]
         public bool AnyProviderAllowed { get; set; }
 
+        /// <summary>
+        /// Date and time at which the user authorized (through the Connect Webview) the management of their devices.
+        /// </summary>
         [DataMember(Name = "authorized_at", IsRequired = false, EmitDefaultValue = false)]
         public string? AuthorizedAt { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for use and management by the Seam API.
+        /// </summary>
         [DataMember(
             Name = "automatically_manage_new_devices",
             IsRequired = false,
@@ -130,18 +167,33 @@ namespace Seam.Model
         )]
         public bool AutomaticallyManageNewDevices { get; set; }
 
+        /// <summary>
+        /// ID of the Connect Webview.
+        /// </summary>
         [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectWebviewId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the Connect Webview.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the Connect Webview was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+        /// </summary>
         [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object CustomMetadata { get; set; }
 
+        /// <summary>
+        /// URL to which the Connect Webview should redirect when an unexpected error occurs.
+        /// </summary>
         [DataMember(
             Name = "custom_redirect_failure_url",
             IsRequired = false,
@@ -149,27 +201,51 @@ namespace Seam.Model
         )]
         public string? CustomRedirectFailureUrl { get; set; }
 
+        /// <summary>
+        /// URL to which the Connect Webview should redirect when the user successfully pairs a device or system. If you do not set the `custom_redirect_failure_url`, the Connect Webview redirects to the `custom_redirect_url` when an unexpected error occurs.
+        /// </summary>
         [DataMember(Name = "custom_redirect_url", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomRedirectUrl { get; set; }
 
+        /// <summary>
+        /// The customer key associated with this webview, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Device selection mode of the Connect Webview. Supported values: `none`, `single`, `multiple`.
+        /// </summary>
         [DataMember(Name = "device_selection_mode", IsRequired = false, EmitDefaultValue = false)]
         public ConnectWebview.DeviceSelectionModeEnum DeviceSelectionMode { get; set; }
 
+        /// <summary>
+        /// Indicates whether the user logged in successfully using the Connect Webview.
+        /// </summary>
         [DataMember(Name = "login_successful", IsRequired = false, EmitDefaultValue = false)]
         public bool LoginSuccessful { get; set; }
 
+        /// <summary>
+        /// Selected provider of the Connect Webview, one of the [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).
+        /// </summary>
         [DataMember(Name = "selected_provider", IsRequired = false, EmitDefaultValue = false)]
         public string? SelectedProvider { get; set; }
 
+        /// <summary>
+        /// Status of the Connect Webview. `authorized` indicates that the user has successfully logged into their device or system account, thereby completing the Connect Webview.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public ConnectWebview.StatusEnum Status { get; set; }
 
+        /// <summary>
+        /// URL for the Connect Webview. You use the URL to display the Connect Webview flow to your user.
+        /// </summary>
         [DataMember(Name = "url", IsRequired = false, EmitDefaultValue = false)]
         public string Url { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam should [finish syncing all devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#wait_for_device_creation) in a newly-connected account before completing the associated Connect Webview.
+        /// </summary>
         [DataMember(
             Name = "wait_for_device_creation",
             IsRequired = false,
@@ -177,6 +253,9 @@ namespace Seam.Model
         )]
         public bool WaitForDeviceCreation { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the Connect Webview.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 

--- a/output/csharp/src/Seam/Model/ConnectedAccount.cs
+++ b/output/csharp/src/Seam/Model/ConnectedAccount.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
+    /// </summary>
     [DataContract(Name = "seamModel_connectedAccount_model")]
     public class ConnectedAccount
     {
@@ -55,6 +58,9 @@ namespace Seam.Model
             Warnings = warnings;
         }
 
+        /// <summary>
+        /// List of capabilities that were accepted during the account connection process.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AcceptedCapabilitiesEnum
         {
@@ -131,15 +137,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "account_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public override bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -147,6 +162,9 @@ namespace Seam.Model
             )]
             public override bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -191,15 +209,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "bridge_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public override bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -207,6 +234,9 @@ namespace Seam.Model
             )]
             public override bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -256,15 +286,24 @@ namespace Seam.Model
                 SaltoKsMetadata = saltoKsMetadata;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public override bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -272,9 +311,15 @@ namespace Seam.Model
             )]
             public override bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// Salto KS metadata associated with the connected account that has an error.
+            /// </summary>
             [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ConnectedAccountErrorsSaltoKsSubscriptionLimitExceededSaltoKsMetadata SaltoKsMetadata { get; set; }
 
@@ -314,6 +359,9 @@ namespace Seam.Model
                 Sites = sites;
             }
 
+            /// <summary>
+            /// Salto sites associated with the connected account that has an error.
+            /// </summary>
             [DataMember(Name = "sites", IsRequired = false, EmitDefaultValue = false)]
             public List<ConnectedAccountErrorsSaltoKsSubscriptionLimitExceededSaltoKsMetadataSites>? Sites { get; set; }
 
@@ -359,12 +407,21 @@ namespace Seam.Model
                 SubscribedSiteUserCount = subscribedSiteUserCount;
             }
 
+            /// <summary>
+            /// ID of a Salto site associated with the connected account that has an error.
+            /// </summary>
             [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SiteId { get; set; }
 
+            /// <summary>
+            /// Name of a Salto site associated with the connected account that has an error.
+            /// </summary>
             [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
             public string? SiteName { get; set; }
 
+            /// <summary>
+            /// Subscription limit of site users for a Salto site associated with the connected account that has an error.
+            /// </summary>
             [DataMember(
                 Name = "site_user_subscription_limit",
                 IsRequired = false,
@@ -372,6 +429,9 @@ namespace Seam.Model
             )]
             public int? SiteUserSubscriptionLimit { get; set; }
 
+            /// <summary>
+            /// Count of subscribed site users for a Salto site associated with the connected account that has an error.
+            /// </summary>
             [DataMember(
                 Name = "subscribed_site_user_count",
                 IsRequired = false,
@@ -420,15 +480,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "dormakaba_sites_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public override bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -436,6 +505,9 @@ namespace Seam.Model
             )]
             public override bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -483,12 +555,21 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public override bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -496,6 +577,9 @@ namespace Seam.Model
             )]
             public override bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -575,9 +659,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -624,9 +714,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -676,12 +772,21 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// Salto KS metadata associated with the connected account that has a warning.
+            /// </summary>
             [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
             public ConnectedAccountWarningsSaltoKsSubscriptionLimitAlmostReachedSaltoKsMetadata SaltoKsMetadata { get; set; }
 
@@ -726,6 +831,9 @@ namespace Seam.Model
                 Sites = sites;
             }
 
+            /// <summary>
+            /// Salto sites associated with the connected account that has a warning.
+            /// </summary>
             [DataMember(Name = "sites", IsRequired = false, EmitDefaultValue = false)]
             public List<ConnectedAccountWarningsSaltoKsSubscriptionLimitAlmostReachedSaltoKsMetadataSites>? Sites { get; set; }
 
@@ -771,12 +879,21 @@ namespace Seam.Model
                 SubscribedSiteUserCount = subscribedSiteUserCount;
             }
 
+            /// <summary>
+            /// ID of a Salto site associated with the connected account that has a warning.
+            /// </summary>
             [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
             public string? SiteId { get; set; }
 
+            /// <summary>
+            /// Name of a Salto site associated with the connected account that has a warning.
+            /// </summary>
             [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
             public string? SiteName { get; set; }
 
+            /// <summary>
+            /// Subscription limit of site users for a Salto site associated with the connected account that has a warning.
+            /// </summary>
             [DataMember(
                 Name = "site_user_subscription_limit",
                 IsRequired = false,
@@ -784,6 +901,9 @@ namespace Seam.Model
             )]
             public int? SiteUserSubscriptionLimit { get; set; }
 
+            /// <summary>
+            /// Count of subscribed site users for a Salto site associated with the connected account that has a warning.
+            /// </summary>
             [DataMember(
                 Name = "subscribed_site_user_count",
                 IsRequired = false,
@@ -831,9 +951,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -877,9 +1003,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -923,9 +1055,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -969,9 +1107,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1015,9 +1159,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1064,9 +1214,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1090,12 +1246,21 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// List of capabilities that were accepted during the account connection process.
+        /// </summary>
         [DataMember(Name = "accepted_capabilities", IsRequired = false, EmitDefaultValue = false)]
         public List<ConnectedAccount.AcceptedCapabilitiesEnum> AcceptedCapabilities { get; set; }
 
+        /// <summary>
+        /// Type of connected account.
+        /// </summary>
         [DataMember(Name = "account_type", IsRequired = false, EmitDefaultValue = false)]
         public string? AccountType { get; set; }
 
+        /// <summary>
+        /// Display name for the connected account type.
+        /// </summary>
         [DataMember(
             Name = "account_type_display_name",
             IsRequired = false,
@@ -1103,6 +1268,9 @@ namespace Seam.Model
         )]
         public string AccountTypeDisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for management by the Seam API.
+        /// </summary>
         [DataMember(
             Name = "automatically_manage_new_devices",
             IsRequired = false,
@@ -1110,45 +1278,88 @@ namespace Seam.Model
         )]
         public bool AutomaticallyManageNewDevices { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the connected account was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string? CreatedAt { get; set; }
 
+        /// <summary>
+        /// Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+        /// </summary>
         [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object CustomMetadata { get; set; }
 
+        /// <summary>
+        /// Your unique key for the customer associated with this connected account.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Default reservation check-in time for this connected account, as `HH:mm` (24-hour). Sourced from the connector configuration — set during the connect_webview for providers like Lodgify whose API does not expose check-in times.
+        /// </summary>
         [DataMember(Name = "default_checkin_time", IsRequired = false, EmitDefaultValue = false)]
         public string? DefaultCheckinTime { get; set; }
 
+        /// <summary>
+        /// Default reservation check-out time for this connected account, as `HH:mm` (24-hour). Sourced from the connector configuration.
+        /// </summary>
         [DataMember(Name = "default_checkout_time", IsRequired = false, EmitDefaultValue = false)]
         public string? DefaultCheckoutTime { get; set; }
 
+        /// <summary>
+        /// Display name for the connected account.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<ConnectedAccountErrors> Errors { get; set; }
 
+        /// <summary>
+        /// For iCal connected accounts, the platform that produced the feed (for example, `airbnb`, `vrbo`, or `booking`), or `unknown` when it could not be determined. Intended for rendering the source platform&apos;s logo.
+        /// </summary>
         [DataMember(Name = "ical_feed_origin", IsRequired = false, EmitDefaultValue = false)]
         public string? IcalFeedOrigin { get; set; }
 
+        /// <summary>
+        /// For iCal connected accounts, the feed URL for the connection. Sourced from the connector configuration.
+        /// </summary>
         [DataMember(Name = "ical_url", IsRequired = false, EmitDefaultValue = false)]
         public string? IcalUrl { get; set; }
 
+        /// <summary>
+        /// Logo URL for the connected account provider.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// IANA time zone (e.g. America/Los_Angeles) for this connected account. Sourced from the connector configuration.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
+        /// <summary>
+        /// User identifier associated with the connected account.
+        /// </summary>
+        [Obsolete("Use `display_name` instead.")]
         [DataMember(Name = "user_identifier", IsRequired = false, EmitDefaultValue = false)]
         public ConnectedAccountUserIdentifier? UserIdentifier { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<ConnectedAccountWarnings> Warnings { get; set; }
 
@@ -1193,18 +1404,33 @@ namespace Seam.Model
             Username = username;
         }
 
+        /// <summary>
+        /// API URL for the user identifier associated with the connected account.
+        /// </summary>
         [DataMember(Name = "api_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ApiUrl { get; set; }
 
+        /// <summary>
+        /// Email address of the user identifier associated with the connected account.
+        /// </summary>
         [DataMember(Name = "email", IsRequired = false, EmitDefaultValue = false)]
         public string? Email { get; set; }
 
+        /// <summary>
+        /// Indicates whether the user identifier associated with the connected account is exclusive.
+        /// </summary>
         [DataMember(Name = "exclusive", IsRequired = false, EmitDefaultValue = false)]
         public bool? Exclusive { get; set; }
 
+        /// <summary>
+        /// Phone number of the user identifier associated with the connected account.
+        /// </summary>
         [DataMember(Name = "phone", IsRequired = false, EmitDefaultValue = false)]
         public string? Phone { get; set; }
 
+        /// <summary>
+        /// Username of the user identifier associated with the connected account.
+        /// </summary>
         [DataMember(Name = "username", IsRequired = false, EmitDefaultValue = false)]
         public string? Username { get; set; }
 

--- a/output/csharp/src/Seam/Model/CustomerPortal.cs
+++ b/output/csharp/src/Seam/Model/CustomerPortal.cs
@@ -8,6 +8,13 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a Customer Portal. Customer Portal is a hosted, customizable interface for managing device access. It enables you to embed secure, pre-authenticated access flows into your product—either by sharing a link with users or embedding a view in an iframe.
+    ///
+    /// With Customer Portal, you no longer need to build out frontend experiences for physical access, thermostats, and sensors. Instead, you can ship enterprise-grade access control experiences in a fraction of the time, while maintaining your product&apos;s branding and user experience.
+    ///
+    /// Seam hosts these flows, handling everything from account connection and device mapping to full-featured device control.
+    /// </summary>
     [DataContract(Name = "seamModel_customerPortal_model")]
     public class CustomerPortal
     {
@@ -29,18 +36,33 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Date and time at which the customer portal link was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Customer key for the customer portal.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string CustomerKey { get; set; }
 
+        /// <summary>
+        /// Date and time at which the customer portal link expires.
+        /// </summary>
         [DataMember(Name = "expires_at", IsRequired = false, EmitDefaultValue = false)]
         public string ExpiresAt { get; set; }
 
+        /// <summary>
+        /// URL for the customer portal.
+        /// </summary>
         [DataMember(Name = "url", IsRequired = false, EmitDefaultValue = false)]
         public string Url { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the customer portal.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 

--- a/output/csharp/src/Seam/Model/Device.cs
+++ b/output/csharp/src/Seam/Model/Device.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.
+    /// </summary>
     [DataContract(Name = "seamModel_device_model")]
     public class Device
     {
@@ -95,6 +98,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CapabilitiesSupportedEnum
         {
@@ -120,6 +126,9 @@ namespace Seam.Model
             Phone = 6,
         }
 
+        /// <summary>
+        /// Type of the device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DeviceTypeEnum
         {
@@ -318,12 +327,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "account_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -331,9 +346,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -378,12 +399,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -391,9 +418,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -438,12 +471,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "dormakaba_sites_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -451,9 +490,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -496,15 +541,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_offline";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -547,15 +601,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_removed";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -598,15 +661,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "hub_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -649,15 +721,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -700,15 +781,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "empty_backup_access_code_pool";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -751,15 +841,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "august_lock_not_authorized";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -802,15 +901,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "missing_device_credentials";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -853,15 +961,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "auxiliary_heat_running";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -904,15 +1021,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "subscription_required";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -957,15 +1083,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "bridge_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -973,6 +1108,9 @@ namespace Seam.Model
             )]
             public bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1016,9 +1154,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1166,9 +1310,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1212,9 +1362,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1258,9 +1414,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1304,9 +1466,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1351,9 +1519,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1397,9 +1571,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1443,9 +1623,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1489,9 +1675,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1535,9 +1727,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1581,9 +1779,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1627,9 +1831,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1673,9 +1883,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1719,9 +1935,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1765,9 +1987,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1812,9 +2040,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1859,9 +2093,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1905,9 +2145,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1951,9 +2197,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1997,9 +2249,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2043,9 +2301,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2089,9 +2353,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2135,9 +2405,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2182,9 +2458,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2228,9 +2510,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2274,9 +2562,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2320,9 +2614,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2370,6 +2670,9 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Number of active access codes on the device when the warning was set.
+            /// </summary>
             [DataMember(
                 Name = "active_access_code_count",
                 IsRequired = false,
@@ -2377,9 +2680,15 @@ namespace Seam.Model
             )]
             public int ActiveAccessCodeCount { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Maximum number of active access codes supported by the device.
+            /// </summary>
             [DataMember(
                 Name = "max_active_access_code_count",
                 IsRequired = false,
@@ -2387,6 +2696,9 @@ namespace Seam.Model
             )]
             public int MaxActiveAccessCodeCount { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2430,9 +2742,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2479,9 +2797,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2505,18 +2829,33 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Indicates whether the lock supports configuring automatic locking.
+        /// </summary>
         [DataMember(Name = "can_configure_auto_lock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanConfigureAutoLock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports cooling.
+        /// </summary>
         [DataMember(Name = "can_hvac_cool", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacCool { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports heating.
+        /// </summary>
         [DataMember(Name = "can_hvac_heat", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacHeat { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports simultaneous heating and cooling.
+        /// </summary>
         [DataMember(Name = "can_hvac_heat_cool", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacHeatCool { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports programming offline access codes.
+        /// </summary>
         [DataMember(
             Name = "can_program_offline_access_codes",
             IsRequired = false,
@@ -2524,6 +2863,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramOfflineAccessCodes { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports programming online access codes.
+        /// </summary>
         [DataMember(
             Name = "can_program_online_access_codes",
             IsRequired = false,
@@ -2531,6 +2873,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramOnlineAccessCodes { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports different climate programs for each day of the week.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_different_each_day",
             IsRequired = false,
@@ -2538,6 +2883,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsDifferentEachDay { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports a single climate program applied to every day.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_same_each_day",
             IsRequired = false,
@@ -2545,6 +2893,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsSameEachDay { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports weekday/weekend climate programs.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_weekday_weekend",
             IsRequired = false,
@@ -2552,12 +2903,21 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsWeekdayWeekend { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports remote locking.
+        /// </summary>
         [DataMember(Name = "can_remotely_lock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanRemotelyLock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports remote unlocking.
+        /// </summary>
         [DataMember(Name = "can_remotely_unlock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanRemotelyUnlock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports running climate programs.
+        /// </summary>
         [DataMember(
             Name = "can_run_thermostat_programs",
             IsRequired = false,
@@ -2565,9 +2925,15 @@ namespace Seam.Model
         )]
         public bool? CanRunThermostatPrograms { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating connection in a sandbox.
+        /// </summary>
         [DataMember(Name = "can_simulate_connection", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanSimulateConnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating disconnection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_disconnection",
             IsRequired = false,
@@ -2575,6 +2941,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateDisconnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the hub supports simulating connection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_hub_connection",
             IsRequired = false,
@@ -2582,6 +2951,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateHubConnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the hub supports simulating disconnection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_hub_disconnection",
             IsRequired = false,
@@ -2589,6 +2961,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateHubDisconnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating a paid subscription in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_paid_subscription",
             IsRequired = false,
@@ -2596,63 +2971,123 @@ namespace Seam.Model
         )]
         public bool? CanSimulatePaidSubscription { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating removal in a sandbox.
+        /// </summary>
         [DataMember(Name = "can_simulate_removal", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanSimulateRemoval { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat can be turned off.
+        /// </summary>
         [DataMember(Name = "can_turn_off_hvac", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanTurnOffHvac { get; set; }
 
+        /// <summary>
+        /// Indicates whether the lock supports unlocking with an access code.
+        /// </summary>
         [DataMember(Name = "can_unlock_with_code", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanUnlockWithCode { get; set; }
 
+        /// <summary>
+        /// Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
+        /// </summary>
         [DataMember(Name = "capabilities_supported", IsRequired = false, EmitDefaultValue = false)]
         public List<Device.CapabilitiesSupportedEnum> CapabilitiesSupported { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the account associated with the device.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the device object was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+        /// </summary>
         [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object CustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Manufacturer of the device. Represents the hardware brand, which may differ from the provider.
+        /// </summary>
         [DataMember(Name = "device_manufacturer", IsRequired = false, EmitDefaultValue = false)]
         public DeviceDeviceManufacturer? DeviceManufacturer { get; set; }
 
+        /// <summary>
+        /// Provider of the device. Represents the third-party service through which the device is controlled.
+        /// </summary>
         [DataMember(Name = "device_provider", IsRequired = false, EmitDefaultValue = false)]
         public DeviceDeviceProvider? DeviceProvider { get; set; }
 
+        /// <summary>
+        /// Type of the device.
+        /// </summary>
         [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
         public Device.DeviceTypeEnum DeviceType { get; set; }
 
+        /// <summary>
+        /// Display name of the device, defaults to nickname (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the device easily, especially when there are numerous devices.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Array of errors associated with the device. Each error object within the array contains two fields: `error_code` and `message`. `error_code` is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<DeviceErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Location information for the device.
+        /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
         public DeviceLocation? Location { get; set; }
 
+        /// <summary>
+        /// Optional nickname to describe the device, settable through Seam.
+        /// </summary>
         [DataMember(Name = "nickname", IsRequired = false, EmitDefaultValue = false)]
         public string? Nickname { get; set; }
 
+        /// <summary>
+        /// Properties of the device.
+        /// </summary>
         [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
         public DeviceProperties Properties { get; set; }
 
+        /// <summary>
+        /// IDs of the spaces the device is in.
+        /// </summary>
         [DataMember(Name = "space_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> SpaceIds { get; set; }
 
+        /// <summary>
+        /// Array of warnings associated with the device. Each warning object within the array contains two fields: `warning_code` and `message`. `warning_code` is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<DeviceWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the Seam workspace associated with the device.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -2693,12 +3128,21 @@ namespace Seam.Model
             Manufacturer = manufacturer;
         }
 
+        /// <summary>
+        /// Display name for the manufacturer, such as `August`, `Yale`, `Salto`, and so on.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Image URL for the manufacturer logo.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// Manufacturer identifier, such as `august`, `yale`, `salto`, and so on.
+        /// </summary>
         [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
         public string Manufacturer { get; set; }
 
@@ -2741,15 +3185,27 @@ namespace Seam.Model
             ProviderCategory = providerCategory;
         }
 
+        /// <summary>
+        /// Device provider name. Corresponds to the integration type, such as `august`, `schlage`, `yale_access`, and so on.
+        /// </summary>
         [DataMember(Name = "device_provider_name", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceProviderName { get; set; }
 
+        /// <summary>
+        /// Display name for the device provider type.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Image URL for the device provider.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// Provider category. Indicates the third-party provider type, such as `stable`, for stable integrations, or `internal`, for internal integrations.
+        /// </summary>
         [DataMember(Name = "provider_category", IsRequired = false, EmitDefaultValue = false)]
         public string ProviderCategory { get; set; }
 
@@ -2790,12 +3246,22 @@ namespace Seam.Model
             Timezone = timezone;
         }
 
+        /// <summary>
+        /// Name of the device location.
+        /// </summary>
         [DataMember(Name = "location_name", IsRequired = false, EmitDefaultValue = false)]
         public string? LocationName { get; set; }
 
+        /// <summary>
+        /// Time zone of the device location.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
+        /// <summary>
+        /// Time zone of the device location.
+        /// </summary>
+        [Obsolete("Use `time_zone` instead.")]
         [DataMember(Name = "timezone", IsRequired = false, EmitDefaultValue = false)]
         public string? Timezone { get; set; }
 
@@ -3042,6 +3508,9 @@ namespace Seam.Model
             ThermostatWeeklyProgram = thermostatWeeklyProgram;
         }
 
+        /// <summary>
+        /// Climate preset modes that the thermostat supports, such as &quot;home&quot;, &quot;away&quot;, &quot;wake&quot;, &quot;sleep&quot;, &quot;occupied&quot;, and &quot;unoccupied&quot;.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AvailableClimatePresetModesEnum
         {
@@ -3067,6 +3536,9 @@ namespace Seam.Model
             Unoccupied = 6,
         }
 
+        /// <summary>
+        /// Fan mode settings that the thermostat supports.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AvailableFanModeSettingsEnum
         {
@@ -3083,6 +3555,9 @@ namespace Seam.Model
             Circulate = 3,
         }
 
+        /// <summary>
+        /// HVAC mode settings that the thermostat supports.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum AvailableHvacModeSettingsEnum
         {
@@ -3121,18 +3596,33 @@ namespace Seam.Model
             Circulate = 3,
         }
 
+        /// <summary>
+        /// Accessory keypad properties and state.
+        /// </summary>
         [DataMember(Name = "accessory_keypad", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAccessoryKeypad? AccessoryKeypad { get; set; }
 
+        /// <summary>
+        /// Appearance-related properties, as reported by the device.
+        /// </summary>
         [DataMember(Name = "appearance", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAppearance Appearance { get; set; }
 
+        /// <summary>
+        /// Represents the current status of the battery charge level.
+        /// </summary>
         [DataMember(Name = "battery", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesBattery? Battery { get; set; }
 
+        /// <summary>
+        /// Indicates the battery level of the device as a decimal value between 0 and 1, inclusive.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public float? BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Array of noise threshold IDs that are currently triggering.
+        /// </summary>
         [DataMember(
             Name = "currently_triggering_noise_threshold_ids",
             IsRequired = false,
@@ -3140,27 +3630,53 @@ namespace Seam.Model
         )]
         public List<string>? CurrentlyTriggeringNoiseThresholdIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device has direct power.
+        /// </summary>
         [DataMember(Name = "has_direct_power", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasDirectPower { get; set; }
 
+        /// <summary>
+        /// Alt text for the device image.
+        /// </summary>
         [DataMember(Name = "image_alt_text", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageAltText { get; set; }
 
+        /// <summary>
+        /// Image URL for the device.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// Manufacturer of the device. When a device, such as a smart lock, is connected through a smart hub, the manufacturer of the device might be different from that of the smart hub.
+        /// </summary>
         [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
         public string? Manufacturer { get; set; }
 
+        /// <summary>
+        /// Device model-related properties.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesModel Model { get; set; }
 
+        /// <summary>
+        /// Name of the device.
+        /// </summary>
+        [Obsolete("use device.display_name instead")]
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Indicates current noise level in decibels, if the device supports noise detection.
+        /// </summary>
         [DataMember(Name = "noise_level_decibels", IsRequired = false, EmitDefaultValue = false)]
         public float? NoiseLevelDecibels { get; set; }
 
+        /// <summary>
+        /// Indicates whether it is currently possible to use offline access codes for the device.
+        /// </summary>
+        [Obsolete("use device.can_program_offline_access_codes")]
         [DataMember(
             Name = "offline_access_codes_enabled",
             IsRequired = false,
@@ -3168,9 +3684,16 @@ namespace Seam.Model
         )]
         public bool? OfflineAccessCodesEnabled { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device is online.
+        /// </summary>
         [DataMember(Name = "online", IsRequired = false, EmitDefaultValue = false)]
         public bool Online { get; set; }
 
+        /// <summary>
+        /// Indicates whether it is currently possible to use online access codes for the device.
+        /// </summary>
+        [Obsolete("use device.can_program_online_access_codes")]
         [DataMember(
             Name = "online_access_codes_enabled",
             IsRequired = false,
@@ -3178,9 +3701,13 @@ namespace Seam.Model
         )]
         public bool? OnlineAccessCodesEnabled { get; set; }
 
+        /// <summary>
+        /// Serial number of the device.
+        /// </summary>
         [DataMember(Name = "serial_number", IsRequired = false, EmitDefaultValue = false)]
         public string? SerialNumber { get; set; }
 
+        [Obsolete("use device.properties.model.can_connect_accessory_keypad")]
         [DataMember(
             Name = "supports_accessory_keypad",
             IsRequired = false,
@@ -3188,6 +3715,7 @@ namespace Seam.Model
         )]
         public bool? SupportsAccessoryKeypad { get; set; }
 
+        [Obsolete("use offline_access_codes_enabled")]
         [DataMember(
             Name = "supports_offline_access_codes",
             IsRequired = false,
@@ -3195,6 +3723,9 @@ namespace Seam.Model
         )]
         public bool? SupportsOfflineAccessCodes { get; set; }
 
+        /// <summary>
+        /// ASSA ABLOY Credential Service metadata for the phone.
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_credential_service_metadata",
             IsRequired = false,
@@ -3202,6 +3733,9 @@ namespace Seam.Model
         )]
         public DevicePropertiesAssaAbloyCredentialServiceMetadata? AssaAbloyCredentialServiceMetadata { get; set; }
 
+        /// <summary>
+        /// Salto Space credential service metadata for the phone.
+        /// </summary>
         [DataMember(
             Name = "salto_space_credential_service_metadata",
             IsRequired = false,
@@ -3209,9 +3743,15 @@ namespace Seam.Model
         )]
         public DevicePropertiesSaltoSpaceCredentialServiceMetadata? SaltoSpaceCredentialServiceMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an Akiles device.
+        /// </summary>
         [DataMember(Name = "akiles_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAkilesMetadata? AkilesMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an ASSA ABLOY Vostio system.
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_vostio_metadata",
             IsRequired = false,
@@ -3219,18 +3759,33 @@ namespace Seam.Model
         )]
         public DevicePropertiesAssaAbloyVostioMetadata? AssaAbloyVostioMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an August device.
+        /// </summary>
         [DataMember(Name = "august_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAugustMetadata? AugustMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "avigilon_alta_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAvigilonAltaMetadata? AvigilonAltaMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Brivo device.
+        /// </summary>
         [DataMember(Name = "brivo_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesBrivoMetadata? BrivoMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a ControlByWeb device.
+        /// </summary>
         [DataMember(Name = "controlbyweb_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesControlbywebMetadata? ControlbywebMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(
             Name = "dormakaba_oracode_metadata",
             IsRequired = false,
@@ -3238,15 +3793,27 @@ namespace Seam.Model
         )]
         public DevicePropertiesDormakabaOracodeMetadata? DormakabaOracodeMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an ecobee device.
+        /// </summary>
         [DataMember(Name = "ecobee_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesEcobeeMetadata? EcobeeMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a 4SUITES device.
+        /// </summary>
         [DataMember(Name = "four_suites_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesFourSuitesMetadata? FourSuitesMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Genie device.
+        /// </summary>
         [DataMember(Name = "genie_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesGenieMetadata? GenieMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Honeywell Resideo device.
+        /// </summary>
         [DataMember(
             Name = "honeywell_resideo_metadata",
             IsRequired = false,
@@ -3254,90 +3821,178 @@ namespace Seam.Model
         )]
         public DevicePropertiesHoneywellResideoMetadata? HoneywellResideoMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an igloo device.
+        /// </summary>
         [DataMember(Name = "igloo_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesIglooMetadata? IglooMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an igloohome device.
+        /// </summary>
         [DataMember(Name = "igloohome_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesIgloohomeMetadata? IgloohomeMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "keynest_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesKeynestMetadata? KeynestMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Kisi device.
+        /// </summary>
         [DataMember(Name = "kisi_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesKisiMetadata? KisiMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Korelock device.
+        /// </summary>
         [DataMember(Name = "korelock_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesKorelockMetadata? KorelockMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Kwikset device.
+        /// </summary>
         [DataMember(Name = "kwikset_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesKwiksetMetadata? KwiksetMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Lockly device.
+        /// </summary>
         [DataMember(Name = "lockly_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesLocklyMetadata? LocklyMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Minut device.
+        /// </summary>
         [DataMember(Name = "minut_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadata? MinutMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Google Nest device.
+        /// </summary>
         [DataMember(Name = "nest_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesNestMetadata? NestMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a NoiseAware device.
+        /// </summary>
         [DataMember(Name = "noiseaware_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesNoiseawareMetadata? NoiseawareMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Nuki device.
+        /// </summary>
         [DataMember(Name = "nuki_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesNukiMetadata? NukiMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an Omnitec device.
+        /// </summary>
         [DataMember(Name = "omnitec_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesOmnitecMetadata? OmnitecMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Ring device.
+        /// </summary>
         [DataMember(Name = "ring_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesRingMetadata? RingMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "salto_ks_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSaltoKsMetadata? SaltoKsMetadata { get; set; }
 
+        /// <summary>
+        /// Metada for a Salto device.
+        /// </summary>
+        [Obsolete("Use `salto_ks_metadata ` instead.")]
         [DataMember(Name = "salto_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSaltoMetadata? SaltoMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Schlage device.
+        /// </summary>
         [DataMember(Name = "schlage_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSchlageMetadata? SchlageMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for Seam Bridge.
+        /// </summary>
         [DataMember(Name = "seam_bridge_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSeamBridgeMetadata? SeamBridgeMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Sensi device.
+        /// </summary>
         [DataMember(Name = "sensi_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSensiMetadata? SensiMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a SmartThings device.
+        /// </summary>
         [DataMember(Name = "smartthings_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSmartthingsMetadata? SmartthingsMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a tado° device.
+        /// </summary>
         [DataMember(Name = "tado_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesTadoMetadata? TadoMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Tedee device.
+        /// </summary>
         [DataMember(Name = "tedee_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesTedeeMetadata? TedeeMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a TTLock device.
+        /// </summary>
         [DataMember(Name = "ttlock_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesTtlockMetadata? TtlockMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a 2N device.
+        /// </summary>
         [DataMember(Name = "two_n_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesTwoNMetadata? TwoNMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an Ultraloq device.
+        /// </summary>
         [DataMember(Name = "ultraloq_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesUltraloqMetadata? UltraloqMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for an ASSA ABLOY Visionline system.
+        /// </summary>
         [DataMember(Name = "visionline_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesVisionlineMetadata? VisionlineMetadata { get; set; }
 
+        /// <summary>
+        /// Metadata for a Wyze device.
+        /// </summary>
         [DataMember(Name = "wyze_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesWyzeMetadata? WyzeMetadata { get; set; }
 
+        /// <summary>
+        /// The delay in seconds before the lock automatically locks after being unlocked.
+        /// </summary>
         [DataMember(Name = "auto_lock_delay_seconds", IsRequired = false, EmitDefaultValue = false)]
         public float? AutoLockDelaySeconds { get; set; }
 
+        /// <summary>
+        /// Indicates whether automatic locking is enabled.
+        /// </summary>
         [DataMember(Name = "auto_lock_enabled", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoLockEnabled { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) is currently enabled for the device. To disable it, set this to `false` using [/devices/update](https://docs.seam.co/api/devices/update).
+        /// </summary>
         [DataMember(
             Name = "backup_access_code_pool_enabled",
             IsRequired = false,
@@ -3345,21 +4000,39 @@ namespace Seam.Model
         )]
         public bool? BackupAccessCodePoolEnabled { get; set; }
 
+        /// <summary>
+        /// Constraints on access codes for the device. Seam represents each constraint as an object with a `constraint_type` property. Depending on the constraint type, there may also be additional properties. Note that some constraints are manufacturer- or device-specific.
+        /// </summary>
         [DataMember(Name = "code_constraints", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesCodeConstraints>? CodeConstraints { get; set; }
 
+        /// <summary>
+        /// Indicates whether the door is open.
+        /// </summary>
         [DataMember(Name = "door_open", IsRequired = false, EmitDefaultValue = false)]
         public bool? DoorOpen { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports native entry events.
+        /// </summary>
         [DataMember(Name = "has_native_entry_events", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasNativeEntryEvents { get; set; }
 
+        /// <summary>
+        /// Keypad battery status.
+        /// </summary>
         [DataMember(Name = "keypad_battery", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesKeypadBattery? KeypadBattery { get; set; }
 
+        /// <summary>
+        /// Indicates whether the lock is locked.
+        /// </summary>
         [DataMember(Name = "locked", IsRequired = false, EmitDefaultValue = false)]
         public bool? Locked { get; set; }
 
+        /// <summary>
+        /// Maximum number of active access codes that the device supports.
+        /// </summary>
         [DataMember(
             Name = "max_active_codes_supported",
             IsRequired = false,
@@ -3367,6 +4040,9 @@ namespace Seam.Model
         )]
         public float? MaxActiveCodesSupported { get; set; }
 
+        /// <summary>
+        /// Time frames that may be requested when creating an offline access code, expressed as a list of options. The caller picks one option (by matching the requested duration when the options&apos; duration ranges do not overlap, or by `display_name` when they do) and satisfies that one option&apos;s rules. When `undefined`, any time frame works.
+        /// </summary>
         [DataMember(
             Name = "offline_time_frame_options",
             IsRequired = false,
@@ -3374,6 +4050,9 @@ namespace Seam.Model
         )]
         public List<DevicePropertiesOfflineTimeFrameOptions>? OfflineTimeFrameOptions { get; set; }
 
+        /// <summary>
+        /// Time frames that may be requested when creating an online access code, expressed as a list of options. The caller picks one option (by matching the requested duration when the options&apos; duration ranges do not overlap, or by `display_name` when they do) and satisfies that one option&apos;s rules. When `undefined`, any time frame works.
+        /// </summary>
         [DataMember(
             Name = "online_time_frame_options",
             IsRequired = false,
@@ -3381,9 +4060,15 @@ namespace Seam.Model
         )]
         public List<DevicePropertiesOnlineTimeFrameOptions>? OnlineTimeFrameOptions { get; set; }
 
+        /// <summary>
+        /// Supported code lengths for access codes.
+        /// </summary>
         [DataMember(Name = "supported_code_lengths", IsRequired = false, EmitDefaultValue = false)]
         public List<float>? SupportedCodeLengths { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports a [backup access code pool](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes).
+        /// </summary>
         [DataMember(
             Name = "supports_backup_access_code_pool",
             IsRequired = false,
@@ -3391,6 +4076,10 @@ namespace Seam.Model
         )]
         public bool? SupportsBackupAccessCodePool { get; set; }
 
+        /// <summary>
+        /// Active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
+        [Obsolete("Use `active_thermostat_schedule_id` with `/thermostats/schedules/get` instead.")]
         [DataMember(
             Name = "active_thermostat_schedule",
             IsRequired = false,
@@ -3398,6 +4087,9 @@ namespace Seam.Model
         )]
         public DevicePropertiesActiveThermostatSchedule? ActiveThermostatSchedule { get; set; }
 
+        /// <summary>
+        /// ID of the active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(
             Name = "active_thermostat_schedule_id",
             IsRequired = false,
@@ -3405,6 +4097,9 @@ namespace Seam.Model
         )]
         public string? ActiveThermostatScheduleId { get; set; }
 
+        /// <summary>
+        /// Climate preset modes that the thermostat supports, such as &quot;home&quot;, &quot;away&quot;, &quot;wake&quot;, &quot;sleep&quot;, &quot;occupied&quot;, and &quot;unoccupied&quot;.
+        /// </summary>
         [DataMember(
             Name = "available_climate_preset_modes",
             IsRequired = false,
@@ -3412,6 +4107,9 @@ namespace Seam.Model
         )]
         public List<DeviceProperties.AvailableClimatePresetModesEnum>? AvailableClimatePresetModes { get; set; }
 
+        /// <summary>
+        /// Available [climate presets](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.
+        /// </summary>
         [DataMember(
             Name = "available_climate_presets",
             IsRequired = false,
@@ -3419,6 +4117,9 @@ namespace Seam.Model
         )]
         public List<DevicePropertiesAvailableClimatePresets>? AvailableClimatePresets { get; set; }
 
+        /// <summary>
+        /// Fan mode settings that the thermostat supports.
+        /// </summary>
         [DataMember(
             Name = "available_fan_mode_settings",
             IsRequired = false,
@@ -3426,6 +4127,9 @@ namespace Seam.Model
         )]
         public List<DeviceProperties.AvailableFanModeSettingsEnum>? AvailableFanModeSettings { get; set; }
 
+        /// <summary>
+        /// HVAC mode settings that the thermostat supports.
+        /// </summary>
         [DataMember(
             Name = "available_hvac_mode_settings",
             IsRequired = false,
@@ -3433,12 +4137,19 @@ namespace Seam.Model
         )]
         public List<DeviceProperties.AvailableHvacModeSettingsEnum>? AvailableHvacModeSettings { get; set; }
 
+        /// <summary>
+        /// Current climate setting.
+        /// </summary>
         [DataMember(Name = "current_climate_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCurrentClimateSetting? CurrentClimateSetting { get; set; }
 
+        [Obsolete("use fallback_climate_preset_key to specify a fallback climate preset instead.")]
         [DataMember(Name = "default_climate_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDefaultClimateSetting? DefaultClimateSetting { get; set; }
 
+        /// <summary>
+        /// Key of the [fallback climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.
+        /// </summary>
         [DataMember(
             Name = "fallback_climate_preset_key",
             IsRequired = false,
@@ -3446,18 +4157,31 @@ namespace Seam.Model
         )]
         public string? FallbackClimatePresetKey { get; set; }
 
+        [Obsolete("Use `current_climate_setting.fan_mode_setting` instead.")]
         [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DeviceProperties.FanModeSettingEnum? FanModeSetting { get; set; }
 
+        /// <summary>
+        /// Indicates whether the connected HVAC system is currently cooling, as reported by the thermostat.
+        /// </summary>
         [DataMember(Name = "is_cooling", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsCooling { get; set; }
 
+        /// <summary>
+        /// Indicates whether the fan in the connected HVAC system is currently running, as reported by the thermostat.
+        /// </summary>
         [DataMember(Name = "is_fan_running", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsFanRunning { get; set; }
 
+        /// <summary>
+        /// Indicates whether the connected HVAC system is currently heating, as reported by the thermostat.
+        /// </summary>
         [DataMember(Name = "is_heating", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsHeating { get; set; }
 
+        /// <summary>
+        /// Indicates whether the current thermostat settings differ from the most recent active program or schedule that Seam activated. For this condition to occur, `current_climate_setting.manual_override_allowed` must also be `true`.
+        /// </summary>
         [DataMember(
             Name = "is_temporary_manual_override_active",
             IsRequired = false,
@@ -3465,6 +4189,9 @@ namespace Seam.Model
         )]
         public bool? IsTemporaryManualOverrideActive { get; set; }
 
+        /// <summary>
+        /// Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+        /// </summary>
         [DataMember(
             Name = "max_cooling_set_point_celsius",
             IsRequired = false,
@@ -3472,6 +4199,9 @@ namespace Seam.Model
         )]
         public float? MaxCoolingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+        /// </summary>
         [DataMember(
             Name = "max_cooling_set_point_fahrenheit",
             IsRequired = false,
@@ -3479,6 +4209,9 @@ namespace Seam.Model
         )]
         public float? MaxCoolingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+        /// </summary>
         [DataMember(
             Name = "max_heating_set_point_celsius",
             IsRequired = false,
@@ -3486,6 +4219,9 @@ namespace Seam.Model
         )]
         public float? MaxHeatingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+        /// </summary>
         [DataMember(
             Name = "max_heating_set_point_fahrenheit",
             IsRequired = false,
@@ -3493,6 +4229,9 @@ namespace Seam.Model
         )]
         public float? MaxHeatingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Maximum number of periods that the thermostat can support per day. For example, if the thermostat supports 4 periods per day, this value is 4.
+        /// </summary>
         [DataMember(
             Name = "max_thermostat_daily_program_periods_per_day",
             IsRequired = false,
@@ -3500,6 +4239,9 @@ namespace Seam.Model
         )]
         public float? MaxThermostatDailyProgramPeriodsPerDay { get; set; }
 
+        /// <summary>
+        /// Maximum number of climate presets that the thermostat can support for weekly programming.
+        /// </summary>
         [DataMember(
             Name = "max_unique_climate_presets_per_thermostat_weekly_program",
             IsRequired = false,
@@ -3507,6 +4249,9 @@ namespace Seam.Model
         )]
         public float? MaxUniqueClimatePresetsPerThermostatWeeklyProgram { get; set; }
 
+        /// <summary>
+        /// Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+        /// </summary>
         [DataMember(
             Name = "min_cooling_set_point_celsius",
             IsRequired = false,
@@ -3514,6 +4259,9 @@ namespace Seam.Model
         )]
         public float? MinCoolingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+        /// </summary>
         [DataMember(
             Name = "min_cooling_set_point_fahrenheit",
             IsRequired = false,
@@ -3521,6 +4269,9 @@ namespace Seam.Model
         )]
         public float? MinCoolingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.
+        /// </summary>
         [DataMember(
             Name = "min_heating_cooling_delta_celsius",
             IsRequired = false,
@@ -3528,6 +4279,9 @@ namespace Seam.Model
         )]
         public float? MinHeatingCoolingDeltaCelsius { get; set; }
 
+        /// <summary>
+        /// Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.
+        /// </summary>
         [DataMember(
             Name = "min_heating_cooling_delta_fahrenheit",
             IsRequired = false,
@@ -3535,6 +4289,9 @@ namespace Seam.Model
         )]
         public float? MinHeatingCoolingDeltaFahrenheit { get; set; }
 
+        /// <summary>
+        /// Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+        /// </summary>
         [DataMember(
             Name = "min_heating_set_point_celsius",
             IsRequired = false,
@@ -3542,6 +4299,9 @@ namespace Seam.Model
         )]
         public float? MinHeatingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+        /// </summary>
         [DataMember(
             Name = "min_heating_set_point_fahrenheit",
             IsRequired = false,
@@ -3549,18 +4309,33 @@ namespace Seam.Model
         )]
         public float? MinHeatingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Reported relative humidity, as a value between 0 and 1, inclusive.
+        /// </summary>
         [DataMember(Name = "relative_humidity", IsRequired = false, EmitDefaultValue = false)]
         public float? RelativeHumidity { get; set; }
 
+        /// <summary>
+        /// Reported temperature in °C.
+        /// </summary>
         [DataMember(Name = "temperature_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? TemperatureCelsius { get; set; }
 
+        /// <summary>
+        /// Reported temperature in °F.
+        /// </summary>
         [DataMember(Name = "temperature_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? TemperatureFahrenheit { get; set; }
 
+        /// <summary>
+        /// Current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_threshold", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesTemperatureThreshold? TemperatureThreshold { get; set; }
 
+        /// <summary>
+        /// Precision of the thermostat&apos;s period in minutes. For example, if the thermostat supports 15-minute periods, this value is 15. All values are relative to the top of the hour, so for 15 minutes, the periods would be 0, 15, 30, and 45 minutes past the hour.
+        /// </summary>
         [DataMember(
             Name = "thermostat_daily_program_period_precision_minutes",
             IsRequired = false,
@@ -3568,6 +4343,9 @@ namespace Seam.Model
         )]
         public float? ThermostatDailyProgramPeriodPrecisionMinutes { get; set; }
 
+        /// <summary>
+        /// Configured [daily programs](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+        /// </summary>
         [DataMember(
             Name = "thermostat_daily_programs",
             IsRequired = false,
@@ -3575,6 +4353,9 @@ namespace Seam.Model
         )]
         public List<DevicePropertiesThermostatDailyPrograms>? ThermostatDailyPrograms { get; set; }
 
+        /// <summary>
+        /// Current [weekly program](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+        /// </summary>
         [DataMember(
             Name = "thermostat_weekly_program",
             IsRequired = false,
@@ -3617,9 +4398,15 @@ namespace Seam.Model
             IsConnected = isConnected;
         }
 
+        /// <summary>
+        /// Keypad battery properties.
+        /// </summary>
         [DataMember(Name = "battery", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAccessoryKeypadBattery? Battery { get; set; }
 
+        /// <summary>
+        /// Indicates if an accessory keypad is connected to the device.
+        /// </summary>
         [DataMember(Name = "is_connected", IsRequired = false, EmitDefaultValue = false)]
         public bool IsConnected { get; set; }
 
@@ -3688,6 +4475,9 @@ namespace Seam.Model
             Name = name;
         }
 
+        /// <summary>
+        /// Name of the device as seen from the provider API and application, not settable through Seam.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
@@ -3726,6 +4516,9 @@ namespace Seam.Model
             Status = status;
         }
 
+        /// <summary>
+        /// Represents the current status of the battery charge level. Values are `critical`, which indicates an extremely low level, suggesting imminent shutdown or an urgent need for charging; `low`, which signifies that the battery is under the preferred threshold and should be charged soon; `good`, which denotes a satisfactory charge level, adequate for normal use without the immediate need for recharging; and `full`, which represents a battery that is fully charged, providing the maximum duration of usage.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum StatusEnum
         {
@@ -3745,9 +4538,15 @@ namespace Seam.Model
             Full = 4,
         }
 
+        /// <summary>
+        /// Battery charge level as a value between 0 and 1, inclusive.
+        /// </summary>
         [DataMember(Name = "level", IsRequired = false, EmitDefaultValue = false)]
         public float Level { get; set; }
 
+        /// <summary>
+        /// Represents the current status of the battery charge level. Values are `critical`, which indicates an extremely low level, suggesting imminent shutdown or an urgent need for charging; `low`, which signifies that the battery is under the preferred threshold and should be charged soon; `good`, which denotes a satisfactory charge level, adequate for normal use without the immediate need for recharging; and `full`, which represents a battery that is fully charged, providing the maximum duration of usage.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesBattery.StatusEnum Status { get; set; }
 
@@ -3796,6 +4595,7 @@ namespace Seam.Model
             OnlineAccessCodesSupported = onlineAccessCodesSupported;
         }
 
+        [Obsolete("use device.properties.model.can_connect_accessory_keypad")]
         [DataMember(
             Name = "accessory_keypad_supported",
             IsRequired = false,
@@ -3803,6 +4603,9 @@ namespace Seam.Model
         )]
         public bool? AccessoryKeypadSupported { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device can connect a accessory keypad.
+        /// </summary>
         [DataMember(
             Name = "can_connect_accessory_keypad",
             IsRequired = false,
@@ -3810,12 +4613,21 @@ namespace Seam.Model
         )]
         public bool? CanConnectAccessoryKeypad { get; set; }
 
+        /// <summary>
+        /// Display name of the device model.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device has a built in accessory keypad.
+        /// </summary>
         [DataMember(Name = "has_built_in_keypad", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasBuiltInKeypad { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the manufacturer-specific terminology for the device.
+        /// </summary>
         [DataMember(
             Name = "manufacturer_display_name",
             IsRequired = false,
@@ -3823,6 +4635,7 @@ namespace Seam.Model
         )]
         public string ManufacturerDisplayName { get; set; }
 
+        [Obsolete("use device.can_program_offline_access_codes.")]
         [DataMember(
             Name = "offline_access_codes_supported",
             IsRequired = false,
@@ -3830,6 +4643,7 @@ namespace Seam.Model
         )]
         public bool? OfflineAccessCodesSupported { get; set; }
 
+        [Obsolete("use device.can_program_online_access_codes.")]
         [DataMember(
             Name = "online_access_codes_supported",
             IsRequired = false,
@@ -3872,9 +4686,15 @@ namespace Seam.Model
             HasActiveEndpoint = hasActiveEndpoint;
         }
 
+        /// <summary>
+        /// Endpoints associated with the phone.
+        /// </summary>
         [DataMember(Name = "endpoints", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesAssaAbloyCredentialServiceMetadataEndpoints>? Endpoints { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential service has active endpoints associated with the phone.
+        /// </summary>
         [DataMember(Name = "has_active_endpoint", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasActiveEndpoint { get; set; }
 
@@ -3915,9 +4735,15 @@ namespace Seam.Model
             IsActive = isActive;
         }
 
+        /// <summary>
+        /// ID of the associated endpoint.
+        /// </summary>
         [DataMember(Name = "endpoint_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EndpointId { get; set; }
 
+        /// <summary>
+        /// Indicated whether the endpoint is active.
+        /// </summary>
         [DataMember(Name = "is_active", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsActive { get; set; }
 
@@ -3952,6 +4778,9 @@ namespace Seam.Model
             HasActivePhone = hasActivePhone;
         }
 
+        /// <summary>
+        /// Indicates whether the credential service has an active associated phone.
+        /// </summary>
         [DataMember(Name = "has_active_phone", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasActivePhone { get; set; }
 
@@ -3994,15 +4823,27 @@ namespace Seam.Model
             ProductName = productName;
         }
 
+        /// <summary>
+        /// Group ID to which to add users for an Akiles device.
+        /// </summary>
         [DataMember(Name = "member_group_id", IsRequired = false, EmitDefaultValue = false)]
         public string? MemberGroupId { get; set; }
 
+        /// <summary>
+        /// Gadget ID for an Akiles device.
+        /// </summary>
         [DataMember(Name = "gadget_id", IsRequired = false, EmitDefaultValue = false)]
         public string? GadgetId { get; set; }
 
+        /// <summary>
+        /// Gadget name for an Akiles device.
+        /// </summary>
         [DataMember(Name = "gadget_name", IsRequired = false, EmitDefaultValue = false)]
         public string? GadgetName { get; set; }
 
+        /// <summary>
+        /// Product name for an Akiles device.
+        /// </summary>
         [DataMember(Name = "product_name", IsRequired = false, EmitDefaultValue = false)]
         public string? ProductName { get; set; }
 
@@ -4037,6 +4878,9 @@ namespace Seam.Model
             EncoderName = encoderName;
         }
 
+        /// <summary>
+        /// Encoder name for an ASSA ABLOY Vostio system.
+        /// </summary>
         [DataMember(Name = "encoder_name", IsRequired = false, EmitDefaultValue = false)]
         public string? EncoderName { get; set; }
 
@@ -4085,24 +4929,45 @@ namespace Seam.Model
             Model = model;
         }
 
+        /// <summary>
+        /// Indicates whether an August device has a keypad.
+        /// </summary>
         [DataMember(Name = "has_keypad", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasKeypad { get; set; }
 
+        /// <summary>
+        /// House ID for an August device.
+        /// </summary>
         [DataMember(Name = "house_id", IsRequired = false, EmitDefaultValue = false)]
         public string? HouseId { get; set; }
 
+        /// <summary>
+        /// House name for an August device.
+        /// </summary>
         [DataMember(Name = "house_name", IsRequired = false, EmitDefaultValue = false)]
         public string? HouseName { get; set; }
 
+        /// <summary>
+        /// Keypad battery level for an August device.
+        /// </summary>
         [DataMember(Name = "keypad_battery_level", IsRequired = false, EmitDefaultValue = false)]
         public string? KeypadBatteryLevel { get; set; }
 
+        /// <summary>
+        /// Lock ID for an August device.
+        /// </summary>
         [DataMember(Name = "lock_id", IsRequired = false, EmitDefaultValue = false)]
         public string? LockId { get; set; }
 
+        /// <summary>
+        /// Lock name for an August device.
+        /// </summary>
         [DataMember(Name = "lock_name", IsRequired = false, EmitDefaultValue = false)]
         public string? LockName { get; set; }
 
+        /// <summary>
+        /// Model for an August device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
@@ -4151,9 +5016,15 @@ namespace Seam.Model
             ZoneName = zoneName;
         }
 
+        /// <summary>
+        /// Entry name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "entry_name", IsRequired = false, EmitDefaultValue = false)]
         public string? EntryName { get; set; }
 
+        /// <summary>
+        /// Total count of entry relays for an Avigilon Alta system.
+        /// </summary>
         [DataMember(
             Name = "entry_relays_total_count",
             IsRequired = false,
@@ -4161,18 +5032,33 @@ namespace Seam.Model
         )]
         public float? EntryRelaysTotalCount { get; set; }
 
+        /// <summary>
+        /// Organization name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "org_name", IsRequired = false, EmitDefaultValue = false)]
         public string? OrgName { get; set; }
 
+        /// <summary>
+        /// Site ID for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
         public float? SiteId { get; set; }
 
+        /// <summary>
+        /// Site name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
+        /// <summary>
+        /// Zone ID for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "zone_id", IsRequired = false, EmitDefaultValue = false)]
         public float? ZoneId { get; set; }
 
+        /// <summary>
+        /// Zone name for an Avigilon Alta system.
+        /// </summary>
         [DataMember(Name = "zone_name", IsRequired = false, EmitDefaultValue = false)]
         public string? ZoneName { get; set; }
 
@@ -4211,9 +5097,15 @@ namespace Seam.Model
             DeviceName = deviceName;
         }
 
+        /// <summary>
+        /// Indicates whether the Brivo access point has activation (remote unlock) enabled.
+        /// </summary>
         [DataMember(Name = "activation_enabled", IsRequired = false, EmitDefaultValue = false)]
         public bool? ActivationEnabled { get; set; }
 
+        /// <summary>
+        /// Device name for a Brivo device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
@@ -4254,12 +5146,21 @@ namespace Seam.Model
             RelayName = relayName;
         }
 
+        /// <summary>
+        /// Device ID for a ControlByWeb device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a ControlByWeb device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Relay name for a ControlByWeb device.
+        /// </summary>
         [DataMember(Name = "relay_name", IsRequired = false, EmitDefaultValue = false)]
         public string? RelayName { get; set; }
 
@@ -4311,27 +5212,52 @@ namespace Seam.Model
             SiteName = siteName;
         }
 
+        /// <summary>
+        /// Device ID for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDormakabaOracodeMetadataDeviceId? DeviceId { get; set; }
 
+        /// <summary>
+        /// Door ID for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "door_id", IsRequired = false, EmitDefaultValue = false)]
         public float? DoorId { get; set; }
 
+        /// <summary>
+        /// Indicates whether a door is wireless for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "door_is_wireless", IsRequired = false, EmitDefaultValue = false)]
         public bool? DoorIsWireless { get; set; }
 
+        /// <summary>
+        /// Door name for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
+        /// <summary>
+        /// IANA time zone for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "iana_timezone", IsRequired = false, EmitDefaultValue = false)]
         public string? IanaTimezone { get; set; }
 
+        /// <summary>
+        /// Predefined time slots for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "predefined_time_slots", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesDormakabaOracodeMetadataPredefinedTimeSlots>? PredefinedTimeSlots { get; set; }
 
+        /// <summary>
+        /// Site ID for a dormakaba Oracode device.
+        /// </summary>
+        [Obsolete("Previously marked as \"@DEPRECATED.\"")]
         [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
         public float? SiteId { get; set; }
 
+        /// <summary>
+        /// Site name for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
@@ -4414,12 +5340,21 @@ namespace Seam.Model
             Prefix = prefix;
         }
 
+        /// <summary>
+        /// Check in time for a time slot for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "check_in_time", IsRequired = false, EmitDefaultValue = false)]
         public string? CheckInTime { get; set; }
 
+        /// <summary>
+        /// Checkout time for a time slot for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "check_out_time", IsRequired = false, EmitDefaultValue = false)]
         public string? CheckOutTime { get; set; }
 
+        /// <summary>
+        /// ID of a user level for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(
             Name = "dormakaba_oracode_user_level_id",
             IsRequired = false,
@@ -4427,6 +5362,9 @@ namespace Seam.Model
         )]
         public string? DormakabaOracodeUserLevelId { get; set; }
 
+        /// <summary>
+        /// Prefix for a user level for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(
             Name = "dormakaba_oracode_user_level_prefix",
             IsRequired = false,
@@ -4434,21 +5372,39 @@ namespace Seam.Model
         )]
         public float? DormakabaOracodeUserLevelPrefix { get; set; }
 
+        /// <summary>
+        /// Indicates whether a time slot for a dormakaba Oracode device is a 24-hour time slot.
+        /// </summary>
         [DataMember(Name = "is_24_hour", IsRequired = false, EmitDefaultValue = false)]
         public bool? Is_24Hour { get; set; }
 
+        /// <summary>
+        /// Indicates whether a time slot for a dormakaba Oracode device is in biweekly mode.
+        /// </summary>
         [DataMember(Name = "is_biweekly_mode", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsBiweeklyMode { get; set; }
 
+        /// <summary>
+        /// Indicates whether a time slot for a dormakaba Oracode device is a master time slot.
+        /// </summary>
         [DataMember(Name = "is_master", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsMaster { get; set; }
 
+        /// <summary>
+        /// Indicates whether a time slot for a dormakaba Oracode device is a one-shot time slot.
+        /// </summary>
         [DataMember(Name = "is_one_shot", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOneShot { get; set; }
 
+        /// <summary>
+        /// Name of a time slot for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Prefix for a time slot for a dormakaba Oracode device.
+        /// </summary>
         [DataMember(Name = "prefix", IsRequired = false, EmitDefaultValue = false)]
         public float? Prefix { get; set; }
 
@@ -4487,9 +5443,15 @@ namespace Seam.Model
             EcobeeDeviceId = ecobeeDeviceId;
         }
 
+        /// <summary>
+        /// Device name for an ecobee device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Device ID for an ecobee device.
+        /// </summary>
         [DataMember(Name = "ecobee_device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EcobeeDeviceId { get; set; }
 
@@ -4530,12 +5492,21 @@ namespace Seam.Model
             RecloseDelayInSeconds = recloseDelayInSeconds;
         }
 
+        /// <summary>
+        /// Device ID for a 4SUITES device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public float? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a 4SUITES device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Reclose delay, in seconds, for a 4SUITES device.
+        /// </summary>
         [DataMember(
             Name = "reclose_delay_in_seconds",
             IsRequired = false,
@@ -4578,9 +5549,15 @@ namespace Seam.Model
             DoorName = doorName;
         }
 
+        /// <summary>
+        /// Lock name for a Genie device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Door name for a Genie device.
+        /// </summary>
         [DataMember(Name = "door_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DoorName { get; set; }
 
@@ -4619,9 +5596,15 @@ namespace Seam.Model
             HoneywellResideoDeviceId = honeywellResideoDeviceId;
         }
 
+        /// <summary>
+        /// Device name for a Honeywell Resideo device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Device ID for a Honeywell Resideo device.
+        /// </summary>
         [DataMember(
             Name = "honeywell_resideo_device_id",
             IsRequired = false,
@@ -4666,12 +5649,21 @@ namespace Seam.Model
             Model = model;
         }
 
+        /// <summary>
+        /// Bridge ID for an igloo device.
+        /// </summary>
         [DataMember(Name = "bridge_id", IsRequired = false, EmitDefaultValue = false)]
         public string? BridgeId { get; set; }
 
+        /// <summary>
+        /// Device ID for an igloo device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Model for an igloo device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
@@ -4718,18 +5710,33 @@ namespace Seam.Model
             KeypadId = keypadId;
         }
 
+        /// <summary>
+        /// Bridge ID for an igloohome device.
+        /// </summary>
         [DataMember(Name = "bridge_id", IsRequired = false, EmitDefaultValue = false)]
         public string? BridgeId { get; set; }
 
+        /// <summary>
+        /// Bridge name for an igloohome device.
+        /// </summary>
         [DataMember(Name = "bridge_name", IsRequired = false, EmitDefaultValue = false)]
         public string? BridgeName { get; set; }
 
+        /// <summary>
+        /// Device ID for an igloohome device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for an igloohome device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Indicates whether a keypad is linked to a bridge for an igloohome device.
+        /// </summary>
         [DataMember(
             Name = "is_accessory_keypad_linked_to_bridge",
             IsRequired = false,
@@ -4737,6 +5744,9 @@ namespace Seam.Model
         )]
         public bool? IsAccessoryKeypadLinkedToBridge { get; set; }
 
+        /// <summary>
+        /// Keypad ID for an igloohome device.
+        /// </summary>
         [DataMember(Name = "keypad_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeypadId { get; set; }
 
@@ -4813,9 +5823,15 @@ namespace Seam.Model
             SubscriptionPlan = subscriptionPlan;
         }
 
+        /// <summary>
+        /// Address for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
         public string? Address { get; set; }
 
+        /// <summary>
+        /// Current or last store ID for a KeyNest device.
+        /// </summary>
         [DataMember(
             Name = "current_or_last_store_id",
             IsRequired = false,
@@ -4823,18 +5839,33 @@ namespace Seam.Model
         )]
         public float? CurrentOrLastStoreId { get; set; }
 
+        /// <summary>
+        /// Current status for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "current_status", IsRequired = false, EmitDefaultValue = false)]
         public string? CurrentStatus { get; set; }
 
+        /// <summary>
+        /// Current user company for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "current_user_company", IsRequired = false, EmitDefaultValue = false)]
         public string? CurrentUserCompany { get; set; }
 
+        /// <summary>
+        /// Current user email for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "current_user_email", IsRequired = false, EmitDefaultValue = false)]
         public string? CurrentUserEmail { get; set; }
 
+        /// <summary>
+        /// Current user name for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "current_user_name", IsRequired = false, EmitDefaultValue = false)]
         public string? CurrentUserName { get; set; }
 
+        /// <summary>
+        /// Current user phone number for a KeyNest device.
+        /// </summary>
         [DataMember(
             Name = "current_user_phone_number",
             IsRequired = false,
@@ -4842,45 +5873,87 @@ namespace Seam.Model
         )]
         public string? CurrentUserPhoneNumber { get; set; }
 
+        /// <summary>
+        /// Default office ID for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "default_office_id", IsRequired = false, EmitDefaultValue = false)]
         public float? DefaultOfficeId { get; set; }
 
+        /// <summary>
+        /// Device name for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Fob ID for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "fob_id", IsRequired = false, EmitDefaultValue = false)]
         public float? FobId { get; set; }
 
+        /// <summary>
+        /// Handover method for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "handover_method", IsRequired = false, EmitDefaultValue = false)]
         public string? HandoverMethod { get; set; }
 
+        /// <summary>
+        /// Whether the KeyNest device has a photo.
+        /// </summary>
         [DataMember(Name = "has_photo", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasPhoto { get; set; }
 
+        /// <summary>
+        /// Whether the key is in a locker that does not support the access codes API.
+        /// </summary>
         [DataMember(Name = "is_quadient_locker", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsQuadientLocker { get; set; }
 
+        /// <summary>
+        /// Key ID for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "key_id", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyId { get; set; }
 
+        /// <summary>
+        /// Key notes for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "key_notes", IsRequired = false, EmitDefaultValue = false)]
         public string? KeyNotes { get; set; }
 
+        /// <summary>
+        /// KeyNest app user for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "keynest_app_user", IsRequired = false, EmitDefaultValue = false)]
         public string? KeynestAppUser { get; set; }
 
+        /// <summary>
+        /// Last movement timestamp for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "last_movement", IsRequired = false, EmitDefaultValue = false)]
         public string? LastMovement { get; set; }
 
+        /// <summary>
+        /// Property ID for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "property_id", IsRequired = false, EmitDefaultValue = false)]
         public string? PropertyId { get; set; }
 
+        /// <summary>
+        /// Property postcode for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "property_postcode", IsRequired = false, EmitDefaultValue = false)]
         public string? PropertyPostcode { get; set; }
 
+        /// <summary>
+        /// Status type for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "status_type", IsRequired = false, EmitDefaultValue = false)]
         public string? StatusType { get; set; }
 
+        /// <summary>
+        /// Subscription plan for a KeyNest device.
+        /// </summary>
         [DataMember(Name = "subscription_plan", IsRequired = false, EmitDefaultValue = false)]
         public string? SubscriptionPlan { get; set; }
 
@@ -4923,15 +5996,27 @@ namespace Seam.Model
             PlaceName = placeName;
         }
 
+        /// <summary>
+        /// Description for a Kisi device.
+        /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
         public string? Description { get; set; }
 
+        /// <summary>
+        /// Lock ID for a Kisi device.
+        /// </summary>
         [DataMember(Name = "lock_id", IsRequired = false, EmitDefaultValue = false)]
         public float? LockId { get; set; }
 
+        /// <summary>
+        /// Lock name for a Kisi device.
+        /// </summary>
         [DataMember(Name = "lock_name", IsRequired = false, EmitDefaultValue = false)]
         public string? LockName { get; set; }
 
+        /// <summary>
+        /// Place name for a Kisi device.
+        /// </summary>
         [DataMember(Name = "place_name", IsRequired = false, EmitDefaultValue = false)]
         public string? PlaceName { get; set; }
 
@@ -4980,24 +6065,45 @@ namespace Seam.Model
             WifiSignalStrength = wifiSignalStrength;
         }
 
+        /// <summary>
+        /// Device ID for a Korelock device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Korelock device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Firmware version for a Korelock device.
+        /// </summary>
         [DataMember(Name = "firmware_version", IsRequired = false, EmitDefaultValue = false)]
         public string? FirmwareVersion { get; set; }
 
+        /// <summary>
+        /// Location ID for a Korelock device. Required for timebound access codes.
+        /// </summary>
         [DataMember(Name = "location_id", IsRequired = false, EmitDefaultValue = false)]
         public string? LocationId { get; set; }
 
+        /// <summary>
+        /// Model code for a Korelock device.
+        /// </summary>
         [DataMember(Name = "model_code", IsRequired = false, EmitDefaultValue = false)]
         public string? ModelCode { get; set; }
 
+        /// <summary>
+        /// Serial number for a Korelock device.
+        /// </summary>
         [DataMember(Name = "serial_number", IsRequired = false, EmitDefaultValue = false)]
         public string? SerialNumber { get; set; }
 
+        /// <summary>
+        /// WiFi signal strength (0-1) for a Korelock device.
+        /// </summary>
         [DataMember(Name = "wifi_signal_strength", IsRequired = false, EmitDefaultValue = false)]
         public float? WifiSignalStrength { get; set; }
 
@@ -5038,12 +6144,21 @@ namespace Seam.Model
             ModelNumber = modelNumber;
         }
 
+        /// <summary>
+        /// Device ID for a Kwikset device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Kwikset device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Model number for a Kwikset device.
+        /// </summary>
         [DataMember(Name = "model_number", IsRequired = false, EmitDefaultValue = false)]
         public string? ModelNumber { get; set; }
 
@@ -5084,12 +6199,21 @@ namespace Seam.Model
             Model = model;
         }
 
+        /// <summary>
+        /// Device ID for a Lockly device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Lockly device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Model for a Lockly device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
@@ -5130,12 +6254,21 @@ namespace Seam.Model
             LatestSensorValues = latestSensorValues;
         }
 
+        /// <summary>
+        /// Device ID for a Minut device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Minut device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Latest sensor values for a Minut device.
+        /// </summary>
         [DataMember(Name = "latest_sensor_values", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadataLatestSensorValues? LatestSensorValues { get; set; }
 
@@ -5180,18 +6313,33 @@ namespace Seam.Model
             Temperature = temperature;
         }
 
+        /// <summary>
+        /// Latest accelerometer Z-axis reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "accelerometer_z", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadataLatestSensorValuesAccelerometerZ? AccelerometerZ { get; set; }
 
+        /// <summary>
+        /// Latest humidity reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "humidity", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadataLatestSensorValuesHumidity? Humidity { get; set; }
 
+        /// <summary>
+        /// Latest pressure reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "pressure", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadataLatestSensorValuesPressure? Pressure { get; set; }
 
+        /// <summary>
+        /// Latest sound reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "sound", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadataLatestSensorValuesSound? Sound { get; set; }
 
+        /// <summary>
+        /// Latest temperature reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "temperature", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesMinutMetadataLatestSensorValuesTemperature? Temperature { get; set; }
 
@@ -5232,9 +6380,15 @@ namespace Seam.Model
             Value = value;
         }
 
+        /// <summary>
+        /// Time of latest accelerometer Z-axis reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "time", IsRequired = false, EmitDefaultValue = false)]
         public string? Time { get; set; }
 
+        /// <summary>
+        /// Value of latest accelerometer Z-axis reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "value", IsRequired = false, EmitDefaultValue = false)]
         public float? Value { get; set; }
 
@@ -5273,9 +6427,15 @@ namespace Seam.Model
             Value = value;
         }
 
+        /// <summary>
+        /// Time of latest humidity reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "time", IsRequired = false, EmitDefaultValue = false)]
         public string? Time { get; set; }
 
+        /// <summary>
+        /// Value of latest humidity reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "value", IsRequired = false, EmitDefaultValue = false)]
         public float? Value { get; set; }
 
@@ -5314,9 +6474,15 @@ namespace Seam.Model
             Value = value;
         }
 
+        /// <summary>
+        /// Time of latest pressure reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "time", IsRequired = false, EmitDefaultValue = false)]
         public string? Time { get; set; }
 
+        /// <summary>
+        /// Value of latest pressure reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "value", IsRequired = false, EmitDefaultValue = false)]
         public float? Value { get; set; }
 
@@ -5355,9 +6521,15 @@ namespace Seam.Model
             Value = value;
         }
 
+        /// <summary>
+        /// Time of latest sound reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "time", IsRequired = false, EmitDefaultValue = false)]
         public string? Time { get; set; }
 
+        /// <summary>
+        /// Value of latest sound reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "value", IsRequired = false, EmitDefaultValue = false)]
         public float? Value { get; set; }
 
@@ -5398,9 +6570,15 @@ namespace Seam.Model
             Value = value;
         }
 
+        /// <summary>
+        /// Time of latest temperature reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "time", IsRequired = false, EmitDefaultValue = false)]
         public string? Time { get; set; }
 
+        /// <summary>
+        /// Value of latest temperature reading for a Minut device.
+        /// </summary>
         [DataMember(Name = "value", IsRequired = false, EmitDefaultValue = false)]
         public float? Value { get; set; }
 
@@ -5443,15 +6621,27 @@ namespace Seam.Model
             NestDeviceId = nestDeviceId;
         }
 
+        /// <summary>
+        /// Custom device name for a Google Nest device. The device owner sets this value.
+        /// </summary>
         [DataMember(Name = "device_custom_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceCustomName { get; set; }
 
+        /// <summary>
+        /// Device name for a Google Nest device. Google sets this value.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Display name for a Google Nest device.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DisplayName { get; set; }
 
+        /// <summary>
+        /// Device ID for a Google Nest device.
+        /// </summary>
         [DataMember(Name = "nest_device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? NestDeviceId { get; set; }
 
@@ -5496,6 +6686,9 @@ namespace Seam.Model
             NoiseLevelNrs = noiseLevelNrs;
         }
 
+        /// <summary>
+        /// Device model for a NoiseAware device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DeviceModelEnum
         {
@@ -5509,18 +6702,33 @@ namespace Seam.Model
             Outdoor = 2,
         }
 
+        /// <summary>
+        /// Device ID for a NoiseAware device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device model for a NoiseAware device.
+        /// </summary>
         [DataMember(Name = "device_model", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesNoiseawareMetadata.DeviceModelEnum? DeviceModel { get; set; }
 
+        /// <summary>
+        /// Device name for a NoiseAware device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Noise level, in decibels, for a NoiseAware device.
+        /// </summary>
         [DataMember(Name = "noise_level_decibel", IsRequired = false, EmitDefaultValue = false)]
         public float? NoiseLevelDecibel { get; set; }
 
+        /// <summary>
+        /// Noise level, expressed as a Noise Risk Score (NRS), for a NoiseAware device.
+        /// </summary>
         [DataMember(Name = "noise_level_nrs", IsRequired = false, EmitDefaultValue = false)]
         public float? NoiseLevelNrs { get; set; }
 
@@ -5565,18 +6773,33 @@ namespace Seam.Model
             KeypadPaired = keypadPaired;
         }
 
+        /// <summary>
+        /// Device ID for a Nuki device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Nuki device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Indicates whether keypad 2 is paired for a Nuki device.
+        /// </summary>
         [DataMember(Name = "keypad_2_paired", IsRequired = false, EmitDefaultValue = false)]
         public bool? Keypad_2Paired { get; set; }
 
+        /// <summary>
+        /// Indicates whether the keypad battery is in a critical state for a Nuki device.
+        /// </summary>
         [DataMember(Name = "keypad_battery_critical", IsRequired = false, EmitDefaultValue = false)]
         public bool? KeypadBatteryCritical { get; set; }
 
+        /// <summary>
+        /// Indicates whether the keypad is paired for a Nuki device.
+        /// </summary>
         [DataMember(Name = "keypad_paired", IsRequired = false, EmitDefaultValue = false)]
         public bool? KeypadPaired { get; set; }
 
@@ -5625,24 +6848,45 @@ namespace Seam.Model
             TimezoneRawOffsetMs = timezoneRawOffsetMs;
         }
 
+        /// <summary>
+        /// Whether the Omnitec lock has a connected gateway for remote operations.
+        /// </summary>
         [DataMember(Name = "has_gateway", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasGateway { get; set; }
 
+        /// <summary>
+        /// Operator-assigned alias for an Omnitec device.
+        /// </summary>
         [DataMember(Name = "lock_alias", IsRequired = false, EmitDefaultValue = false)]
         public string? LockAlias { get; set; }
 
+        /// <summary>
+        /// Lock ID for an Omnitec device.
+        /// </summary>
         [DataMember(Name = "lock_id", IsRequired = false, EmitDefaultValue = false)]
         public float? LockId { get; set; }
 
+        /// <summary>
+        /// Bluetooth MAC address for an Omnitec device.
+        /// </summary>
         [DataMember(Name = "lock_mac", IsRequired = false, EmitDefaultValue = false)]
         public string? LockMac { get; set; }
 
+        /// <summary>
+        /// Lock name for an Omnitec device.
+        /// </summary>
         [DataMember(Name = "lock_name", IsRequired = false, EmitDefaultValue = false)]
         public string? LockName { get; set; }
 
+        /// <summary>
+        /// IANA time zone for the Omnitec device, used to schedule time-bound access codes at the correct local time (accounting for DST).
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
+        /// <summary>
+        /// Static UTC offset of the Omnitec lock in milliseconds. Does not account for DST.
+        /// </summary>
         [DataMember(Name = "timezone_raw_offset_ms", IsRequired = false, EmitDefaultValue = false)]
         public float? TimezoneRawOffsetMs { get; set; }
 
@@ -5681,9 +6925,15 @@ namespace Seam.Model
             DeviceName = deviceName;
         }
 
+        /// <summary>
+        /// Device ID for a Ring device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Ring device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
@@ -5736,12 +6986,21 @@ namespace Seam.Model
             SiteName = siteName;
         }
 
+        /// <summary>
+        /// Battery level for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public string? BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Customer reference for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "customer_reference", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerReference { get; set; }
 
+        /// <summary>
+        /// Indicates whether the site has a Salto KS subscription that supports custom PINs.
+        /// </summary>
         [DataMember(
             Name = "has_custom_pin_subscription",
             IsRequired = false,
@@ -5749,21 +7008,39 @@ namespace Seam.Model
         )]
         public bool? HasCustomPinSubscription { get; set; }
 
+        /// <summary>
+        /// Lock ID for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "lock_id", IsRequired = false, EmitDefaultValue = false)]
         public string? LockId { get; set; }
 
+        /// <summary>
+        /// Lock type for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "lock_type", IsRequired = false, EmitDefaultValue = false)]
         public string? LockType { get; set; }
 
+        /// <summary>
+        /// Locked state for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "locked_state", IsRequired = false, EmitDefaultValue = false)]
         public string? LockedState { get; set; }
 
+        /// <summary>
+        /// Model for a Salto KS device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
+        /// <summary>
+        /// Site ID for the Salto KS site to which the device belongs.
+        /// </summary>
         [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteId { get; set; }
 
+        /// <summary>
+        /// Site name for the Salto KS site to which the device belongs.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
@@ -5814,27 +7091,51 @@ namespace Seam.Model
             SiteName = siteName;
         }
 
+        /// <summary>
+        /// Battery level for a Salto device.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public string? BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Customer reference for a Salto device.
+        /// </summary>
         [DataMember(Name = "customer_reference", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerReference { get; set; }
 
+        /// <summary>
+        /// Lock ID for a Salto device.
+        /// </summary>
         [DataMember(Name = "lock_id", IsRequired = false, EmitDefaultValue = false)]
         public string? LockId { get; set; }
 
+        /// <summary>
+        /// Lock type for a Salto device.
+        /// </summary>
         [DataMember(Name = "lock_type", IsRequired = false, EmitDefaultValue = false)]
         public string? LockType { get; set; }
 
+        /// <summary>
+        /// Locked state for a Salto device.
+        /// </summary>
         [DataMember(Name = "locked_state", IsRequired = false, EmitDefaultValue = false)]
         public string? LockedState { get; set; }
 
+        /// <summary>
+        /// Model for a Salto device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
+        /// <summary>
+        /// Site ID for the Salto KS site to which the device belongs.
+        /// </summary>
         [DataMember(Name = "site_id", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteId { get; set; }
 
+        /// <summary>
+        /// Site name for the Salto KS site to which the device belongs.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
@@ -5875,12 +7176,21 @@ namespace Seam.Model
             Model = model;
         }
 
+        /// <summary>
+        /// Device ID for a Schlage device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Schlage device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Model for a Schlage device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
@@ -5921,6 +7231,9 @@ namespace Seam.Model
             UnlockMethod = unlockMethod;
         }
 
+        /// <summary>
+        /// Unlock method for Seam Bridge.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum UnlockMethodEnum
         {
@@ -5934,12 +7247,21 @@ namespace Seam.Model
             Doorking = 2,
         }
 
+        /// <summary>
+        /// Device number for Seam Bridge.
+        /// </summary>
         [DataMember(Name = "device_num", IsRequired = false, EmitDefaultValue = false)]
         public float? DeviceNum { get; set; }
 
+        /// <summary>
+        /// Name for Seam Bridge.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Unlock method for Seam Bridge.
+        /// </summary>
         [DataMember(Name = "unlock_method", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesSeamBridgeMetadata.UnlockMethodEnum? UnlockMethod { get; set; }
 
@@ -5982,12 +7304,21 @@ namespace Seam.Model
             ProductType = productType;
         }
 
+        /// <summary>
+        /// Device ID for a Sensi device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a Sensi device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Set to true when the device does not support the /dual-setpoints API endpoint.
+        /// </summary>
         [DataMember(
             Name = "dual_setpoints_not_supported",
             IsRequired = false,
@@ -5995,6 +7326,9 @@ namespace Seam.Model
         )]
         public bool? DualSetpointsNotSupported { get; set; }
 
+        /// <summary>
+        /// Product type for a Sensi device.
+        /// </summary>
         [DataMember(Name = "product_type", IsRequired = false, EmitDefaultValue = false)]
         public string? ProductType { get; set; }
 
@@ -6037,15 +7371,27 @@ namespace Seam.Model
             Model = model;
         }
 
+        /// <summary>
+        /// Device ID for a SmartThings device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a SmartThings device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Location ID for a SmartThings device.
+        /// </summary>
         [DataMember(Name = "location_id", IsRequired = false, EmitDefaultValue = false)]
         public string? LocationId { get; set; }
 
+        /// <summary>
+        /// Model for a SmartThings device.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public string? Model { get; set; }
 
@@ -6084,9 +7430,15 @@ namespace Seam.Model
             SerialNo = serialNo;
         }
 
+        /// <summary>
+        /// Device type for a tado° device.
+        /// </summary>
         [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceType { get; set; }
 
+        /// <summary>
+        /// Serial number for a tado° device.
+        /// </summary>
         [DataMember(Name = "serial_no", IsRequired = false, EmitDefaultValue = false)]
         public string? SerialNo { get; set; }
 
@@ -6135,24 +7487,45 @@ namespace Seam.Model
             SerialNumber = serialNumber;
         }
 
+        /// <summary>
+        /// Bridge ID for a Tedee device.
+        /// </summary>
         [DataMember(Name = "bridge_id", IsRequired = false, EmitDefaultValue = false)]
         public float? BridgeId { get; set; }
 
+        /// <summary>
+        /// Bridge name for a Tedee device.
+        /// </summary>
         [DataMember(Name = "bridge_name", IsRequired = false, EmitDefaultValue = false)]
         public string? BridgeName { get; set; }
 
+        /// <summary>
+        /// Device ID for a Tedee device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public float? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device model for a Tedee device.
+        /// </summary>
         [DataMember(Name = "device_model", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceModel { get; set; }
 
+        /// <summary>
+        /// Device name for a Tedee device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Keypad ID for a Tedee device.
+        /// </summary>
         [DataMember(Name = "keypad_id", IsRequired = false, EmitDefaultValue = false)]
         public float? KeypadId { get; set; }
 
+        /// <summary>
+        /// Serial number for a Tedee device.
+        /// </summary>
         [DataMember(Name = "serial_number", IsRequired = false, EmitDefaultValue = false)]
         public string? SerialNumber { get; set; }
 
@@ -6201,24 +7574,45 @@ namespace Seam.Model
             WirelessKeypads = wirelessKeypads;
         }
 
+        /// <summary>
+        /// Feature value for a TTLock device.
+        /// </summary>
         [DataMember(Name = "feature_value", IsRequired = false, EmitDefaultValue = false)]
         public string? FeatureValue { get; set; }
 
+        /// <summary>
+        /// Features for a TTLock device.
+        /// </summary>
         [DataMember(Name = "features", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesTtlockMetadataFeatures? Features { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device has a gateway.
+        /// </summary>
         [DataMember(Name = "has_gateway", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasGateway { get; set; }
 
+        /// <summary>
+        /// Lock alias for a TTLock device.
+        /// </summary>
         [DataMember(Name = "lock_alias", IsRequired = false, EmitDefaultValue = false)]
         public string? LockAlias { get; set; }
 
+        /// <summary>
+        /// Lock ID for a TTLock device.
+        /// </summary>
         [DataMember(Name = "lock_id", IsRequired = false, EmitDefaultValue = false)]
         public float? LockId { get; set; }
 
+        /// <summary>
+        /// Lock-side timezone offset in milliseconds east of UTC, as configured in the TTLock app. Source of truth for the lock&apos;s wall-clock interpretation of access code start/end times — a misconfigured value here is the typical cause of customer &quot;codes offset by N hours&quot; reports. Diagnostic only; Seam does not convert times based on this value.
+        /// </summary>
         [DataMember(Name = "timezone_raw_offset_ms", IsRequired = false, EmitDefaultValue = false)]
         public float? TimezoneRawOffsetMs { get; set; }
 
+        /// <summary>
+        /// Wireless keypads for a TTLock device.
+        /// </summary>
         [DataMember(Name = "wireless_keypads", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesTtlockMetadataWirelessKeypads>? WirelessKeypads { get; set; }
 
@@ -6267,9 +7661,15 @@ namespace Seam.Model
             Wifi = wifi;
         }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports auto-lock time configuration.
+        /// </summary>
         [DataMember(Name = "auto_lock_time_config", IsRequired = false, EmitDefaultValue = false)]
         public bool? AutoLockTimeConfig { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports an incomplete keyboard passcode.
+        /// </summary>
         [DataMember(
             Name = "incomplete_keyboard_passcode",
             IsRequired = false,
@@ -6277,18 +7677,33 @@ namespace Seam.Model
         )]
         public bool? IncompleteKeyboardPasscode { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports the lock command.
+        /// </summary>
         [DataMember(Name = "lock_command", IsRequired = false, EmitDefaultValue = false)]
         public bool? LockCommand { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports a passcode.
+        /// </summary>
         [DataMember(Name = "passcode", IsRequired = false, EmitDefaultValue = false)]
         public bool? Passcode { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports passcode management.
+        /// </summary>
         [DataMember(Name = "passcode_management", IsRequired = false, EmitDefaultValue = false)]
         public bool? PasscodeManagement { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports unlock via gateway.
+        /// </summary>
         [DataMember(Name = "unlock_via_gateway", IsRequired = false, EmitDefaultValue = false)]
         public bool? UnlockViaGateway { get; set; }
 
+        /// <summary>
+        /// Indicates whether a TTLock device supports Wi-Fi.
+        /// </summary>
         [DataMember(Name = "wifi", IsRequired = false, EmitDefaultValue = false)]
         public bool? Wifi { get; set; }
 
@@ -6327,9 +7742,15 @@ namespace Seam.Model
             WirelessKeypadName = wirelessKeypadName;
         }
 
+        /// <summary>
+        /// ID for a wireless keypad for a TTLock device.
+        /// </summary>
         [DataMember(Name = "wireless_keypad_id", IsRequired = false, EmitDefaultValue = false)]
         public float? WirelessKeypadId { get; set; }
 
+        /// <summary>
+        /// Name for a wireless keypad for a TTLock device.
+        /// </summary>
         [DataMember(Name = "wireless_keypad_name", IsRequired = false, EmitDefaultValue = false)]
         public string? WirelessKeypadName { get; set; }
 
@@ -6365,9 +7786,15 @@ namespace Seam.Model
             DeviceName = deviceName;
         }
 
+        /// <summary>
+        /// Device ID for a 2N device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public float? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for a 2N device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
@@ -6410,15 +7837,27 @@ namespace Seam.Model
             TimeZone = timeZone;
         }
 
+        /// <summary>
+        /// Device ID for an Ultraloq device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device name for an Ultraloq device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Device type for an Ultraloq device.
+        /// </summary>
         [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceType { get; set; }
 
+        /// <summary>
+        /// IANA timezone for the Ultraloq device.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
@@ -6453,6 +7892,9 @@ namespace Seam.Model
             EncoderId = encoderId;
         }
 
+        /// <summary>
+        /// Encoder ID for an ASSA ABLOY Visionline system.
+        /// </summary>
         [DataMember(Name = "encoder_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EncoderId { get; set; }
 
@@ -6503,27 +7945,51 @@ namespace Seam.Model
             ProductType = productType;
         }
 
+        /// <summary>
+        /// Device ID for a Wyze device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Device information model for a Wyze device.
+        /// </summary>
         [DataMember(Name = "device_info_model", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceInfoModel { get; set; }
 
+        /// <summary>
+        /// Device name for a Wyze device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Keypad UUID for a Wyze device.
+        /// </summary>
         [DataMember(Name = "keypad_uuid", IsRequired = false, EmitDefaultValue = false)]
         public string? KeypadUuid { get; set; }
 
+        /// <summary>
+        /// Locker status (hardlock) for a Wyze device.
+        /// </summary>
         [DataMember(Name = "locker_status_hardlock", IsRequired = false, EmitDefaultValue = false)]
         public float? LockerStatusHardlock { get; set; }
 
+        /// <summary>
+        /// Product model for a Wyze device.
+        /// </summary>
         [DataMember(Name = "product_model", IsRequired = false, EmitDefaultValue = false)]
         public string? ProductModel { get; set; }
 
+        /// <summary>
+        /// Product name for a Wyze device.
+        /// </summary>
         [DataMember(Name = "product_name", IsRequired = false, EmitDefaultValue = false)]
         public string? ProductName { get; set; }
 
+        /// <summary>
+        /// Product type for a Wyze device.
+        /// </summary>
         [DataMember(Name = "product_type", IsRequired = false, EmitDefaultValue = false)]
         public string? ProductType { get; set; }
 
@@ -6616,9 +8082,15 @@ namespace Seam.Model
         [DataMember(Name = "constraint_type", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCodeConstraints.ConstraintTypeEnum ConstraintType { get; set; }
 
+        /// <summary>
+        /// Maximum name length constraint for access codes.
+        /// </summary>
         [DataMember(Name = "max_length", IsRequired = false, EmitDefaultValue = false)]
         public float? MaxLength { get; set; }
 
+        /// <summary>
+        /// Minimum name length constraint for access codes.
+        /// </summary>
         [DataMember(Name = "min_length", IsRequired = false, EmitDefaultValue = false)]
         public float? MinLength { get; set; }
 
@@ -6653,6 +8125,9 @@ namespace Seam.Model
             Level = level;
         }
 
+        /// <summary>
+        /// Keypad battery charge level.
+        /// </summary>
         [DataMember(Name = "level", IsRequired = false, EmitDefaultValue = false)]
         public float Level { get; set; }
 
@@ -6703,9 +8178,15 @@ namespace Seam.Model
             TimeZone = timeZone;
         }
 
+        /// <summary>
+        /// Label for this option. For a single-option device, the product name (for example, `algoPIN` or `SmartPIN`); for a multi-option device, a label that distinguishes it (for example, `Hourly` or `Fixed start times`).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// iCalendar recurrence rule (RRULE) that the end date must fall on. Constrains which calendar dates are selectable, independent of the time-of-day rules.
+        /// </summary>
         [DataMember(
             Name = "end_date_recurrence_rule",
             IsRequired = false,
@@ -6713,15 +8194,27 @@ namespace Seam.Model
         )]
         public string? EndDateRecurrenceRule { get; set; }
 
+        /// <summary>
+        /// When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
+        /// </summary>
         [DataMember(Name = "matching_start_end_time", IsRequired = false, EmitDefaultValue = false)]
         public bool? MatchingStartEndTime { get; set; }
 
+        /// <summary>
+        /// Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
+        /// </summary>
         [DataMember(Name = "max_duration", IsRequired = false, EmitDefaultValue = false)]
         public string? MaxDuration { get; set; }
 
+        /// <summary>
+        /// Minimum duration this option covers, as an ISO 8601 duration (for example, `PT1H` or `P29D`). Omitted when there is no minimum.
+        /// </summary>
         [DataMember(Name = "min_duration", IsRequired = false, EmitDefaultValue = false)]
         public string? MinDuration { get; set; }
 
+        /// <summary>
+        /// iCalendar recurrence rule (RRULE) that the start date must fall on (for example, `FREQ=MONTHLY;BYDAY=1MO,3MO`). Constrains which calendar dates are selectable, independent of the time-of-day rules.
+        /// </summary>
         [DataMember(
             Name = "start_date_recurrence_rule",
             IsRequired = false,
@@ -6729,9 +8222,15 @@ namespace Seam.Model
         )]
         public string? StartDateRecurrenceRule { get; set; }
 
+        /// <summary>
+        /// Fixed start/end time pairings the caller chooses from. Mutually exclusive with `matching_start_end_time`.
+        /// </summary>
         [DataMember(Name = "time_pairs", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesOfflineTimeFrameOptionsTimePairs>? TimePairs { get; set; }
 
+        /// <summary>
+        /// IANA time zone for interpreting `time_pairs` and the date recurrence rules. Present only when the option fixes times or dates.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
@@ -6772,12 +8271,21 @@ namespace Seam.Model
             StartTime = startTime;
         }
 
+        /// <summary>
+        /// Label for the start/end time pairing.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// End time of day as a 24-hour `HH:MM` value, interpreted in the option&apos;s `time_zone`. An `end_time` earlier on the clock than `start_time` means the end falls on a later date.
+        /// </summary>
         [DataMember(Name = "end_time", IsRequired = false, EmitDefaultValue = false)]
         public string EndTime { get; set; }
 
+        /// <summary>
+        /// Start time of day as a 24-hour `HH:MM` value, interpreted in the option&apos;s `time_zone`.
+        /// </summary>
         [DataMember(Name = "start_time", IsRequired = false, EmitDefaultValue = false)]
         public string StartTime { get; set; }
 
@@ -6828,9 +8336,15 @@ namespace Seam.Model
             TimeZone = timeZone;
         }
 
+        /// <summary>
+        /// Label for this option. For a single-option device, the product name (for example, `algoPIN` or `SmartPIN`); for a multi-option device, a label that distinguishes it (for example, `Hourly` or `Fixed start times`).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// iCalendar recurrence rule (RRULE) that the end date must fall on. Constrains which calendar dates are selectable, independent of the time-of-day rules.
+        /// </summary>
         [DataMember(
             Name = "end_date_recurrence_rule",
             IsRequired = false,
@@ -6838,15 +8352,27 @@ namespace Seam.Model
         )]
         public string? EndDateRecurrenceRule { get; set; }
 
+        /// <summary>
+        /// When `true`, the start and end must fall at the same time of day (the caller picks which). Mutually exclusive with `time_pairs`.
+        /// </summary>
         [DataMember(Name = "matching_start_end_time", IsRequired = false, EmitDefaultValue = false)]
         public bool? MatchingStartEndTime { get; set; }
 
+        /// <summary>
+        /// Maximum duration this option covers, as an ISO 8601 duration (for example, `PT672H` or `P367D`). Omitted when there is no maximum.
+        /// </summary>
         [DataMember(Name = "max_duration", IsRequired = false, EmitDefaultValue = false)]
         public string? MaxDuration { get; set; }
 
+        /// <summary>
+        /// Minimum duration this option covers, as an ISO 8601 duration (for example, `PT1H` or `P29D`). Omitted when there is no minimum.
+        /// </summary>
         [DataMember(Name = "min_duration", IsRequired = false, EmitDefaultValue = false)]
         public string? MinDuration { get; set; }
 
+        /// <summary>
+        /// iCalendar recurrence rule (RRULE) that the start date must fall on (for example, `FREQ=MONTHLY;BYDAY=1MO,3MO`). Constrains which calendar dates are selectable, independent of the time-of-day rules.
+        /// </summary>
         [DataMember(
             Name = "start_date_recurrence_rule",
             IsRequired = false,
@@ -6854,9 +8380,15 @@ namespace Seam.Model
         )]
         public string? StartDateRecurrenceRule { get; set; }
 
+        /// <summary>
+        /// Fixed start/end time pairings the caller chooses from. Mutually exclusive with `matching_start_end_time`.
+        /// </summary>
         [DataMember(Name = "time_pairs", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesOnlineTimeFrameOptionsTimePairs>? TimePairs { get; set; }
 
+        /// <summary>
+        /// IANA time zone for interpreting `time_pairs` and the date recurrence rules. Present only when the option fixes times or dates.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
@@ -6897,12 +8429,21 @@ namespace Seam.Model
             StartTime = startTime;
         }
 
+        /// <summary>
+        /// Label for the start/end time pairing.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// End time of day as a 24-hour `HH:MM` value, interpreted in the option&apos;s `time_zone`. An `end_time` earlier on the clock than `start_time` means the end falls on a later date.
+        /// </summary>
         [DataMember(Name = "end_time", IsRequired = false, EmitDefaultValue = false)]
         public string EndTime { get; set; }
 
+        /// <summary>
+        /// Start time of day as a 24-hour `HH:MM` value, interpreted in the option&apos;s `time_zone`.
+        /// </summary>
         [DataMember(Name = "start_time", IsRequired = false, EmitDefaultValue = false)]
         public string StartTime { get; set; }
 
@@ -6959,24 +8500,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesActiveThermostatScheduleErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Indicates whether a person at the thermostat can change the thermostat&apos;s settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.
+        /// </summary>
         [DataMember(Name = "is_override_allowed", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOverrideAllowed { get; set; }
 
+        /// <summary>
+        /// Number of minutes for which a person at the thermostat can change the thermostat&apos;s settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+        /// </summary>
         [DataMember(
             Name = "max_override_period_minutes",
             IsRequired = false,
@@ -6984,15 +8546,27 @@ namespace Seam.Model
         )]
         public int? MaxOverridePeriodMinutes { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "thermostat_schedule_id", IsRequired = false, EmitDefaultValue = false)]
         public string ThermostatScheduleId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the thermostat schedule.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -7033,12 +8607,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -7104,6 +8687,9 @@ namespace Seam.Model
             Name = name;
         }
 
+        /// <summary>
+        /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ClimatePresetModeEnum
         {
@@ -7129,6 +8715,9 @@ namespace Seam.Model
             Unoccupied = 6,
         }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum FanModeSettingEnum
         {
@@ -7145,6 +8734,9 @@ namespace Seam.Model
             Circulate = 3,
         }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum HvacModeSettingEnum
         {
@@ -7167,12 +8759,21 @@ namespace Seam.Model
             Eco = 5,
         }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+        /// </summary>
         [DataMember(Name = "can_delete", IsRequired = false, EmitDefaultValue = false)]
         public bool CanDelete { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+        /// </summary>
         [DataMember(Name = "can_edit", IsRequired = false, EmitDefaultValue = false)]
         public bool CanEdit { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+        /// </summary>
         [DataMember(
             Name = "can_use_with_thermostat_daily_programs",
             IsRequired = false,
@@ -7180,12 +8781,21 @@ namespace Seam.Model
         )]
         public bool CanUseWithThermostatDailyPrograms { get; set; }
 
+        /// <summary>
+        /// Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+        /// </summary>
         [DataMember(Name = "climate_preset_mode", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAvailableClimatePresets.ClimatePresetModeEnum? ClimatePresetMode { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_celsius",
             IsRequired = false,
@@ -7193,6 +8803,9 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_fahrenheit",
             IsRequired = false,
@@ -7200,15 +8813,27 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Metadata specific to the Ecobee climate, if applicable.
+        /// </summary>
         [DataMember(Name = "ecobee_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAvailableClimatePresetsEcobeeMetadata? EcobeeMetadata { get; set; }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAvailableClimatePresets.FanModeSettingEnum? FanModeSetting { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_celsius",
             IsRequired = false,
@@ -7216,6 +8841,9 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_fahrenheit",
             IsRequired = false,
@@ -7223,12 +8851,22 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [DataMember(Name = "hvac_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAvailableClimatePresets.HvacModeSettingEnum? HvacModeSetting { get; set; }
 
+        /// <summary>
+        /// Indicates whether a person at the thermostat can change the thermostat&apos;s settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+        /// </summary>
+        [Obsolete("Use 'thermostat_schedule.is_override_allowed'")]
         [DataMember(Name = "manual_override_allowed", IsRequired = false, EmitDefaultValue = false)]
         public bool ManualOverrideAllowed { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
@@ -7269,6 +8907,9 @@ namespace Seam.Model
             Owner = owner;
         }
 
+        /// <summary>
+        /// Indicates whether the climate preset is owned by the user or the system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum OwnerEnum
         {
@@ -7282,12 +8923,21 @@ namespace Seam.Model
             System = 2,
         }
 
+        /// <summary>
+        /// Reference to the Ecobee climate, if applicable.
+        /// </summary>
         [DataMember(Name = "climate_ref", IsRequired = false, EmitDefaultValue = false)]
         public string? ClimateRef { get; set; }
 
+        /// <summary>
+        /// Indicates if the climate preset is optimized by Ecobee.
+        /// </summary>
         [DataMember(Name = "is_optimized", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOptimized { get; set; }
 
+        /// <summary>
+        /// Indicates whether the climate preset is owned by the user or the system.
+        /// </summary>
         [DataMember(Name = "owner", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesAvailableClimatePresetsEcobeeMetadata.OwnerEnum? Owner { get; set; }
 
@@ -7353,6 +9003,9 @@ namespace Seam.Model
             Name = name;
         }
 
+        /// <summary>
+        /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ClimatePresetModeEnum
         {
@@ -7378,6 +9031,9 @@ namespace Seam.Model
             Unoccupied = 6,
         }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum FanModeSettingEnum
         {
@@ -7394,6 +9050,9 @@ namespace Seam.Model
             Circulate = 3,
         }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum HvacModeSettingEnum
         {
@@ -7416,12 +9075,21 @@ namespace Seam.Model
             Eco = 5,
         }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+        /// </summary>
         [DataMember(Name = "can_delete", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanDelete { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+        /// </summary>
         [DataMember(Name = "can_edit", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanEdit { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+        /// </summary>
         [DataMember(
             Name = "can_use_with_thermostat_daily_programs",
             IsRequired = false,
@@ -7429,12 +9097,21 @@ namespace Seam.Model
         )]
         public bool? CanUseWithThermostatDailyPrograms { get; set; }
 
+        /// <summary>
+        /// Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string? ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+        /// </summary>
         [DataMember(Name = "climate_preset_mode", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCurrentClimateSetting.ClimatePresetModeEnum? ClimatePresetMode { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_celsius",
             IsRequired = false,
@@ -7442,6 +9119,9 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_fahrenheit",
             IsRequired = false,
@@ -7449,15 +9129,27 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DisplayName { get; set; }
 
+        /// <summary>
+        /// Metadata specific to the Ecobee climate, if applicable.
+        /// </summary>
         [DataMember(Name = "ecobee_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCurrentClimateSettingEcobeeMetadata? EcobeeMetadata { get; set; }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCurrentClimateSetting.FanModeSettingEnum? FanModeSetting { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_celsius",
             IsRequired = false,
@@ -7465,6 +9157,9 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_fahrenheit",
             IsRequired = false,
@@ -7472,12 +9167,22 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [DataMember(Name = "hvac_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCurrentClimateSetting.HvacModeSettingEnum? HvacModeSetting { get; set; }
 
+        /// <summary>
+        /// Indicates whether a person at the thermostat can change the thermostat&apos;s settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+        /// </summary>
+        [Obsolete("Use 'thermostat_schedule.is_override_allowed'")]
         [DataMember(Name = "manual_override_allowed", IsRequired = false, EmitDefaultValue = false)]
         public bool? ManualOverrideAllowed { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
@@ -7518,6 +9223,9 @@ namespace Seam.Model
             Owner = owner;
         }
 
+        /// <summary>
+        /// Indicates whether the climate preset is owned by the user or the system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum OwnerEnum
         {
@@ -7531,12 +9239,21 @@ namespace Seam.Model
             System = 2,
         }
 
+        /// <summary>
+        /// Reference to the Ecobee climate, if applicable.
+        /// </summary>
         [DataMember(Name = "climate_ref", IsRequired = false, EmitDefaultValue = false)]
         public string? ClimateRef { get; set; }
 
+        /// <summary>
+        /// Indicates if the climate preset is optimized by Ecobee.
+        /// </summary>
         [DataMember(Name = "is_optimized", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOptimized { get; set; }
 
+        /// <summary>
+        /// Indicates whether the climate preset is owned by the user or the system.
+        /// </summary>
         [DataMember(Name = "owner", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesCurrentClimateSettingEcobeeMetadata.OwnerEnum? Owner { get; set; }
 
@@ -7602,6 +9319,9 @@ namespace Seam.Model
             Name = name;
         }
 
+        /// <summary>
+        /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ClimatePresetModeEnum
         {
@@ -7627,6 +9347,9 @@ namespace Seam.Model
             Unoccupied = 6,
         }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum FanModeSettingEnum
         {
@@ -7643,6 +9366,9 @@ namespace Seam.Model
             Circulate = 3,
         }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum HvacModeSettingEnum
         {
@@ -7665,12 +9391,21 @@ namespace Seam.Model
             Eco = 5,
         }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.
+        /// </summary>
         [DataMember(Name = "can_delete", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanDelete { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.
+        /// </summary>
         [DataMember(Name = "can_edit", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanEdit { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.
+        /// </summary>
         [DataMember(
             Name = "can_use_with_thermostat_daily_programs",
             IsRequired = false,
@@ -7678,12 +9413,21 @@ namespace Seam.Model
         )]
         public bool? CanUseWithThermostatDailyPrograms { get; set; }
 
+        /// <summary>
+        /// Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string? ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
+        /// </summary>
         [DataMember(Name = "climate_preset_mode", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDefaultClimateSetting.ClimatePresetModeEnum? ClimatePresetMode { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_celsius",
             IsRequired = false,
@@ -7691,6 +9435,9 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_fahrenheit",
             IsRequired = false,
@@ -7698,15 +9445,27 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DisplayName { get; set; }
 
+        /// <summary>
+        /// Metadata specific to the Ecobee climate, if applicable.
+        /// </summary>
         [DataMember(Name = "ecobee_metadata", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDefaultClimateSettingEcobeeMetadata? EcobeeMetadata { get; set; }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDefaultClimateSetting.FanModeSettingEnum? FanModeSetting { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_celsius",
             IsRequired = false,
@@ -7714,6 +9473,9 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_fahrenheit",
             IsRequired = false,
@@ -7721,12 +9483,22 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [DataMember(Name = "hvac_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDefaultClimateSetting.HvacModeSettingEnum? HvacModeSetting { get; set; }
 
+        /// <summary>
+        /// Indicates whether a person at the thermostat can change the thermostat&apos;s settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+        /// </summary>
+        [Obsolete("Use 'thermostat_schedule.is_override_allowed'")]
         [DataMember(Name = "manual_override_allowed", IsRequired = false, EmitDefaultValue = false)]
         public bool? ManualOverrideAllowed { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
@@ -7767,6 +9539,9 @@ namespace Seam.Model
             Owner = owner;
         }
 
+        /// <summary>
+        /// Indicates whether the climate preset is owned by the user or the system.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum OwnerEnum
         {
@@ -7780,12 +9555,21 @@ namespace Seam.Model
             System = 2,
         }
 
+        /// <summary>
+        /// Reference to the Ecobee climate, if applicable.
+        /// </summary>
         [DataMember(Name = "climate_ref", IsRequired = false, EmitDefaultValue = false)]
         public string? ClimateRef { get; set; }
 
+        /// <summary>
+        /// Indicates if the climate preset is optimized by Ecobee.
+        /// </summary>
         [DataMember(Name = "is_optimized", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOptimized { get; set; }
 
+        /// <summary>
+        /// Indicates whether the climate preset is owned by the user or the system.
+        /// </summary>
         [DataMember(Name = "owner", IsRequired = false, EmitDefaultValue = false)]
         public DevicePropertiesDefaultClimateSettingEcobeeMetadata.OwnerEnum? Owner { get; set; }
 
@@ -7828,15 +9612,27 @@ namespace Seam.Model
             UpperLimitFahrenheit = upperLimitFahrenheit;
         }
 
+        /// <summary>
+        /// Lower limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+        /// </summary>
         [DataMember(Name = "lower_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? LowerLimitCelsius { get; set; }
 
+        /// <summary>
+        /// Lower limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+        /// </summary>
         [DataMember(Name = "lower_limit_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? LowerLimitFahrenheit { get; set; }
 
+        /// <summary>
+        /// Upper limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+        /// </summary>
         [DataMember(Name = "upper_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? UpperLimitCelsius { get; set; }
 
+        /// <summary>
+        /// Upper limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+        /// </summary>
         [DataMember(Name = "upper_limit_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? UpperLimitFahrenheit { get; set; }
 
@@ -7883,18 +9679,33 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Date and time at which the thermostat daily program was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat device on which the thermostat daily program is configured.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the thermostat daily program.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Array of thermostat daily program periods.
+        /// </summary>
         [DataMember(Name = "periods", IsRequired = false, EmitDefaultValue = false)]
         public List<DevicePropertiesThermostatDailyProgramsPeriods> Periods { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program.
+        /// </summary>
         [DataMember(
             Name = "thermostat_daily_program_id",
             IsRequired = false,
@@ -7902,6 +9713,9 @@ namespace Seam.Model
         )]
         public string ThermostatDailyProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the thermostat daily program.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -7940,9 +9754,15 @@ namespace Seam.Model
             StartsAtTime = startsAtTime;
         }
 
+        /// <summary>
+        /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at_time", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAtTime { get; set; }
 
@@ -7993,27 +9813,51 @@ namespace Seam.Model
             WednesdayProgramId = wednesdayProgramId;
         }
 
+        /// <summary>
+        /// Date and time at which the thermostat weekly program was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Fridays.
+        /// </summary>
         [DataMember(Name = "friday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? FridayProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Mondays.
+        /// </summary>
         [DataMember(Name = "monday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? MondayProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Saturdays.
+        /// </summary>
         [DataMember(Name = "saturday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? SaturdayProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Sundays.
+        /// </summary>
         [DataMember(Name = "sunday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? SundayProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Thursdays.
+        /// </summary>
         [DataMember(Name = "thursday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ThursdayProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Tuesdays.
+        /// </summary>
         [DataMember(Name = "tuesday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? TuesdayProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program to run on Wednesdays.
+        /// </summary>
         [DataMember(Name = "wednesday_program_id", IsRequired = false, EmitDefaultValue = false)]
         public string? WednesdayProgramId { get; set; }
 

--- a/output/csharp/src/Seam/Model/DeviceProvider.cs
+++ b/output/csharp/src/Seam/Model/DeviceProvider.cs
@@ -69,6 +69,9 @@ namespace Seam.Model
             ProviderCategories = providerCategories;
         }
 
+        /// <summary>
+        /// Name of the device provider.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DeviceProviderNameEnum
         {
@@ -262,6 +265,9 @@ namespace Seam.Model
             Kisi = 62,
         }
 
+        /// <summary>
+        /// List of provider categories to which the device provider belongs, such as `stable`, `consumer_smartlocks`, `thermostats`, and so on.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ProviderCategoriesEnum
         {
@@ -293,18 +299,33 @@ namespace Seam.Model
             Connectors = 8,
         }
 
+        /// <summary>
+        /// Indicates whether the lock supports configuring automatic locking.
+        /// </summary>
         [DataMember(Name = "can_configure_auto_lock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanConfigureAutoLock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports cooling.
+        /// </summary>
         [DataMember(Name = "can_hvac_cool", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacCool { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports heating.
+        /// </summary>
         [DataMember(Name = "can_hvac_heat", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacHeat { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports simultaneous heating and cooling.
+        /// </summary>
         [DataMember(Name = "can_hvac_heat_cool", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacHeatCool { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports programming offline access codes.
+        /// </summary>
         [DataMember(
             Name = "can_program_offline_access_codes",
             IsRequired = false,
@@ -312,6 +333,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramOfflineAccessCodes { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports programming online access codes.
+        /// </summary>
         [DataMember(
             Name = "can_program_online_access_codes",
             IsRequired = false,
@@ -319,6 +343,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramOnlineAccessCodes { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports different climate programs for each day of the week.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_different_each_day",
             IsRequired = false,
@@ -326,6 +353,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsDifferentEachDay { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports a single climate program applied to every day.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_same_each_day",
             IsRequired = false,
@@ -333,6 +363,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsSameEachDay { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports weekday/weekend climate programs.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_weekday_weekend",
             IsRequired = false,
@@ -340,12 +373,21 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsWeekdayWeekend { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports remote locking.
+        /// </summary>
         [DataMember(Name = "can_remotely_lock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanRemotelyLock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports remote unlocking.
+        /// </summary>
         [DataMember(Name = "can_remotely_unlock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanRemotelyUnlock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports running climate programs.
+        /// </summary>
         [DataMember(
             Name = "can_run_thermostat_programs",
             IsRequired = false,
@@ -353,9 +395,15 @@ namespace Seam.Model
         )]
         public bool? CanRunThermostatPrograms { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating connection in a sandbox.
+        /// </summary>
         [DataMember(Name = "can_simulate_connection", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanSimulateConnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating disconnection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_disconnection",
             IsRequired = false,
@@ -363,6 +411,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateDisconnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the hub supports simulating connection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_hub_connection",
             IsRequired = false,
@@ -370,6 +421,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateHubConnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the hub supports simulating disconnection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_hub_disconnection",
             IsRequired = false,
@@ -377,6 +431,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateHubDisconnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating a paid subscription in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_paid_subscription",
             IsRequired = false,
@@ -384,24 +441,45 @@ namespace Seam.Model
         )]
         public bool? CanSimulatePaidSubscription { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating removal in a sandbox.
+        /// </summary>
         [DataMember(Name = "can_simulate_removal", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanSimulateRemoval { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat can be turned off.
+        /// </summary>
         [DataMember(Name = "can_turn_off_hvac", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanTurnOffHvac { get; set; }
 
+        /// <summary>
+        /// Indicates whether the lock supports unlocking with an access code.
+        /// </summary>
         [DataMember(Name = "can_unlock_with_code", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanUnlockWithCode { get; set; }
 
+        /// <summary>
+        /// Name of the device provider.
+        /// </summary>
         [DataMember(Name = "device_provider_name", IsRequired = false, EmitDefaultValue = false)]
         public DeviceProvider.DeviceProviderNameEnum DeviceProviderName { get; set; }
 
+        /// <summary>
+        /// Display name for the device provider.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Image URL for the device provider.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string ImageUrl { get; set; }
 
+        /// <summary>
+        /// List of provider categories to which the device provider belongs, such as `stable`, `consumer_smartlocks`, `thermostats`, and so on.
+        /// </summary>
         [DataMember(Name = "provider_categories", IsRequired = false, EmitDefaultValue = false)]
         public List<DeviceProvider.ProviderCategoriesEnum> ProviderCategories { get; set; }
 

--- a/output/csharp/src/Seam/Model/Event.cs
+++ b/output/csharp/src/Seam/Model/Event.cs
@@ -318,6 +318,9 @@ namespace Seam.Model
         public abstract override string ToString();
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was created.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeCreated_model")]
     public class EventAccessCodeCreated : Event
     {
@@ -351,9 +354,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -361,30 +370,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -408,6 +441,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeChanged_model")]
     public class EventAccessCodeChanged : Event
     {
@@ -445,15 +481,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Human-readable reason for the change (e.g. `ongoing code auto-renewed`).
+        /// </summary>
         [DataMember(Name = "change_reason", IsRequired = false, EmitDefaultValue = false)]
         public string? ChangeReason { get; set; }
 
+        /// <summary>
+        /// List of properties that changed on the access code.
+        /// </summary>
         [DataMember(Name = "changed_properties", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeChangedChangedProperties>? ChangedProperties { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -461,30 +509,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.changed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -525,12 +597,21 @@ namespace Seam.Model
             To = to;
         }
 
+        /// <summary>
+        /// Previous value of the property, or null if not set.
+        /// </summary>
         [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
         public string? From { get; set; }
 
+        /// <summary>
+        /// Name of the property that changed (e.g. `code`).
+        /// </summary>
         [DataMember(Name = "property", IsRequired = false, EmitDefaultValue = false)]
         public string Property { get; set; }
 
+        /// <summary>
+        /// New value of the property, or null if cleared.
+        /// </summary>
         [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
         public string? To { get; set; }
 
@@ -554,6 +635,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The name of an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed on the device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeNameChanged_model")]
     public class EventAccessCodeNameChanged : Event
     {
@@ -593,9 +677,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -603,39 +693,72 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the change and its source.
+        /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
         public string Description { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.name_changed";
 
+        /// <summary>
+        /// Previous access code name configuration.
+        /// </summary>
         [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeNameChangedFrom From { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// New access code name configuration.
+        /// </summary>
         [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeNameChangedTo To { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -670,6 +793,9 @@ namespace Seam.Model
             Name = name;
         }
 
+        /// <summary>
+        /// Previous name of the access code.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
@@ -704,6 +830,9 @@ namespace Seam.Model
             Name = name;
         }
 
+        /// <summary>
+        /// New name of the access code.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
@@ -727,6 +856,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The pin code of an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed on the device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeCodeChanged_model")]
     public class EventAccessCodeCodeChanged : Event
     {
@@ -766,9 +898,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -776,39 +914,72 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the change and its source.
+        /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
         public string Description { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.code_changed";
 
+        /// <summary>
+        /// Previous pin code configuration.
+        /// </summary>
         [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeCodeChangedFrom From { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// New pin code configuration.
+        /// </summary>
         [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeCodeChangedTo To { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -843,6 +1014,9 @@ namespace Seam.Model
             Code = code;
         }
 
+        /// <summary>
+        /// Previous pin code.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
@@ -877,6 +1051,9 @@ namespace Seam.Model
             Code = code;
         }
 
+        /// <summary>
+        /// New pin code.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
@@ -900,6 +1077,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The time frame of an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was changed on the device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeTimeFrameChanged_model")]
     public class EventAccessCodeTimeFrameChanged : Event
     {
@@ -939,9 +1119,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -949,39 +1135,72 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the change and its source.
+        /// </summary>
         [DataMember(Name = "description", IsRequired = false, EmitDefaultValue = false)]
         public string Description { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.time_frame_changed";
 
+        /// <summary>
+        /// Previous time frame configuration.
+        /// </summary>
         [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeTimeFrameChangedFrom From { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// New time frame configuration.
+        /// </summary>
         [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeTimeFrameChangedTo To { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -1020,9 +1239,15 @@ namespace Seam.Model
             StartsAt = startsAt;
         }
 
+        /// <summary>
+        /// Previous end time.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Previous start time.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
@@ -1061,9 +1286,15 @@ namespace Seam.Model
             StartsAt = startsAt;
         }
 
+        /// <summary>
+        /// New end time.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// New start time.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
@@ -1087,6 +1318,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Mutations were requested on an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes). This event fires at request time, before the change is confirmed on the device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeMutationsRequested_model")]
     public class EventAccessCodeMutationsRequested : Event
     {
@@ -1122,9 +1356,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -1132,33 +1372,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.mutations_requested";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Array of mutations requested on the access code, each containing the mutation type and from/to values.
+        /// </summary>
         [DataMember(Name = "requested_mutations", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeMutationsRequestedRequestedMutations> RequestedMutations { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -1200,6 +1467,9 @@ namespace Seam.Model
             To = to;
         }
 
+        /// <summary>
+        /// Code identifying the type of mutation requested, such as `updating_name`, `updating_code`, `updating_time_frame`, or `deleting`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum MutationCodeEnum
         {
@@ -1225,12 +1495,21 @@ namespace Seam.Model
             DeferringCreation = 6,
         }
 
+        /// <summary>
+        /// Previous property values before the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+        /// </summary>
         [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
         public object? From { get; set; }
 
+        /// <summary>
+        /// Code identifying the type of mutation requested, such as `updating_name`, `updating_code`, `updating_time_frame`, or `deleting`.
+        /// </summary>
         [DataMember(Name = "mutation_code", IsRequired = false, EmitDefaultValue = false)]
         public EventAccessCodeMutationsRequestedRequestedMutations.MutationCodeEnum MutationCode { get; set; }
 
+        /// <summary>
+        /// New property values after the requested change. Keys depend on the mutation type. Absent for non-property mutations like `deleting`.
+        /// </summary>
         [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
         public object? To { get; set; }
 
@@ -1254,6 +1533,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was [scheduled natively](https://docs.seam.co/low-level-apis/smart-locks/access-codes#native-scheduling) on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeScheduledOnDevice_model")]
     public class EventAccessCodeScheduledOnDevice : Event
     {
@@ -1289,12 +1571,21 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Code for the affected access code.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string Code { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -1302,30 +1593,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.scheduled_on_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -1349,6 +1664,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was set on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeSetOnDevice_model")]
     public class EventAccessCodeSetOnDevice : Event
     {
@@ -1384,12 +1702,21 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Code for the affected access code.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string Code { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -1397,30 +1724,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.set_on_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -1444,6 +1795,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was removed from a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeRemovedFromDevice_model")]
     public class EventAccessCodeRemovedFromDevice : Event
     {
@@ -1477,9 +1831,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -1487,30 +1847,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.removed_from_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -1534,6 +1918,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// There was an unusually long delay in setting an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeDelayInSettingOnDevice_model")]
     public class EventAccessCodeDelayInSettingOnDevice : Event
     {
@@ -1582,15 +1969,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Errors associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInSettingOnDeviceAccessCodeErrors> AccessCodeErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInSettingOnDeviceAccessCodeWarnings> AccessCodeWarnings { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -1598,6 +1997,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -1605,9 +2007,15 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeDelayInSettingOnDeviceConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -1615,33 +2023,60 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeDelayInSettingOnDeviceConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInSettingOnDeviceDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInSettingOnDeviceDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.delay_in_setting_on_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -1682,12 +2117,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -1728,12 +2172,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -1776,12 +2229,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -1824,12 +2286,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -1870,12 +2341,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -1916,12 +2396,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -1945,6 +2434,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) failed to be set on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeFailedToSetOnDevice_model")]
     public class EventAccessCodeFailedToSetOnDevice : Event
     {
@@ -1992,15 +2484,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Errors associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToSetOnDeviceAccessCodeErrors> AccessCodeErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToSetOnDeviceAccessCodeWarnings> AccessCodeWarnings { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -2008,6 +2512,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -2015,9 +2522,15 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeFailedToSetOnDeviceConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -2025,33 +2538,60 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeFailedToSetOnDeviceConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToSetOnDeviceDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToSetOnDeviceDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.failed_to_set_on_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -2092,12 +2632,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -2138,12 +2687,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -2186,12 +2744,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -2234,12 +2801,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -2280,12 +2856,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -2326,12 +2911,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -2355,6 +2949,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeDeleted_model")]
     public class EventAccessCodeDeleted : Event
     {
@@ -2390,12 +2987,21 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Code for the affected access code.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -2403,30 +3009,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -2450,6 +3080,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// There was an unusually long delay in removing an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) from a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeDelayInRemovingFromDevice_model")]
     public class EventAccessCodeDelayInRemovingFromDevice : Event
     {
@@ -2499,15 +3132,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Errors associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInRemovingFromDeviceAccessCodeErrors> AccessCodeErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInRemovingFromDeviceAccessCodeWarnings> AccessCodeWarnings { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -2515,6 +3160,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -2522,9 +3170,15 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeDelayInRemovingFromDeviceConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -2532,33 +3186,60 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeDelayInRemovingFromDeviceConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInRemovingFromDeviceDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeDelayInRemovingFromDeviceDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.delay_in_removing_from_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -2601,12 +3282,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -2649,12 +3339,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -2697,12 +3396,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -2745,12 +3453,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -2791,12 +3508,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -2837,12 +3563,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -2866,6 +3601,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) failed to be removed from a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeFailedToRemoveFromDevice_model")]
     public class EventAccessCodeFailedToRemoveFromDevice : Event
     {
@@ -2915,15 +3653,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Errors associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToRemoveFromDeviceAccessCodeErrors> AccessCodeErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToRemoveFromDeviceAccessCodeWarnings> AccessCodeWarnings { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -2931,6 +3681,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -2938,9 +3691,15 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeFailedToRemoveFromDeviceConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -2948,33 +3707,60 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeFailedToRemoveFromDeviceConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToRemoveFromDeviceDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeFailedToRemoveFromDeviceDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.failed_to_remove_from_device";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -3015,12 +3801,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -3063,12 +3858,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -3111,12 +3915,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -3159,12 +3972,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -3205,12 +4027,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -3251,12 +4082,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -3280,6 +4120,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was modified outside of Seam.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeModifiedExternalToSeam_model")]
     public class EventAccessCodeModifiedExternalToSeam : Event
     {
@@ -3313,9 +4156,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -3323,30 +4172,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.modified_external_to_seam";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -3370,6 +4243,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was deleted outside of Seam.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeDeletedExternalToSeam_model")]
     public class EventAccessCodeDeletedExternalToSeam : Event
     {
@@ -3403,9 +4279,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -3413,30 +4295,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.deleted_external_to_seam";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -3460,6 +4366,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [backup access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/backup-access-codes) was pulled from the backup access code pool and set on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeBackupAccessCodePulled_model")]
     public class EventAccessCodeBackupAccessCodePulled : Event
     {
@@ -3495,12 +4404,21 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// ID of the backup access code that was pulled from the pool.
+        /// </summary>
         [DataMember(Name = "backup_access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string BackupAccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -3508,30 +4426,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.backup_access_code_pulled";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -3555,6 +4497,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) was converted successfully to a managed access code.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeUnmanagedConvertedToManaged_model")]
     public class EventAccessCodeUnmanagedConvertedToManaged : Event
     {
@@ -3588,9 +4533,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -3598,30 +4549,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.unmanaged.converted_to_managed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -3645,6 +4620,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) failed to be converted to a managed access code.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeUnmanagedFailedToConvertToManaged_model")]
     public class EventAccessCodeUnmanagedFailedToConvertToManaged : Event
     {
@@ -3696,15 +4674,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Errors associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeUnmanagedFailedToConvertToManagedAccessCodeErrors> AccessCodeErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the access code.
+        /// </summary>
         [DataMember(Name = "access_code_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeUnmanagedFailedToConvertToManagedAccessCodeWarnings> AccessCodeWarnings { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -3712,6 +4702,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -3719,9 +4712,15 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeUnmanagedFailedToConvertToManagedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -3729,24 +4728,45 @@ namespace Seam.Model
         )]
         public List<EventAccessCodeUnmanagedFailedToConvertToManagedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeUnmanagedFailedToConvertToManagedDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAccessCodeUnmanagedFailedToConvertToManagedDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -3754,9 +4774,15 @@ namespace Seam.Model
         public override string EventType { get; } =
             "access_code.unmanaged.failed_to_convert_to_managed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -3799,12 +4825,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -3847,12 +4882,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -3895,12 +4939,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -3943,12 +4996,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -3991,12 +5053,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -4039,12 +5110,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -4068,6 +5148,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) was created on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeUnmanagedCreated_model")]
     public class EventAccessCodeUnmanagedCreated : Event
     {
@@ -4101,9 +5184,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -4111,30 +5200,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.unmanaged.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4158,6 +5271,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [unmanaged access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) was removed from a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessCodeUnmanagedRemoved_model")]
     public class EventAccessCodeUnmanagedRemoved : Event
     {
@@ -4191,9 +5307,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -4201,30 +5323,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the affected access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_code.unmanaged.removed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4248,6 +5394,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An Access Grant was created.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantCreated_model")]
     public class EventAccessGrantCreated : Event
     {
@@ -4273,24 +5422,42 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_grant.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4314,6 +5481,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An Access Grant was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantDeleted_model")]
     public class EventAccessGrantDeleted : Event
     {
@@ -4339,24 +5509,42 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_grant.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4380,6 +5568,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// All access requested for an Access Grant was successfully granted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantAccessGrantedToAllDoors_model")]
     public class EventAccessGrantAccessGrantedToAllDoors : Event
     {
@@ -4405,24 +5596,42 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_grant.access_granted_to_all_doors";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4446,6 +5655,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Access requested as part of an Access Grant to a particular door was successfully granted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantAccessGrantedToDoor_model")]
     public class EventAccessGrantAccessGrantedToDoor : Event
     {
@@ -4473,27 +5685,48 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// ID of the affected [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_grant.access_granted_to_door";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4517,6 +5750,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Access to a particular door that was requested as part of an Access Grant was lost.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantAccessToDoorLost_model")]
     public class EventAccessGrantAccessToDoorLost : Event
     {
@@ -4544,27 +5780,48 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// ID of the affected [entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details).
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_grant.access_to_door_lost";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4588,6 +5845,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An Access Grant&apos;s start or end time was changed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantAccessTimesChanged_model")]
     public class EventAccessGrantAccessTimesChanged : Event
     {
@@ -4619,33 +5879,60 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// Key of the affected Access Grant (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_key", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessGrantKey { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The new end time for the access grant.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_grant.access_times_changed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// The new start time for the access grant.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4669,6 +5956,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// One or more requested access methods could not be created for an Access Grant.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessGrantCouldNotCreateRequestedAccessMethods_model")]
     public class EventAccessGrantCouldNotCreateRequestedAccessMethods : Event
     {
@@ -4698,18 +5988,33 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Access Grant.
+        /// </summary>
         [DataMember(Name = "access_grant_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessGrantId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Description of why the access methods could not be created.
+        /// </summary>
         [DataMember(Name = "error_message", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorMessage { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -4717,12 +6022,21 @@ namespace Seam.Model
         public override string EventType { get; } =
             "access_grant.could_not_create_requested_access_methods";
 
+        /// <summary>
+        /// IDs of the devices that did not receive a requested access method. Use these to identify which specific devices failed without having to fetch the Access Grant.
+        /// </summary>
         [DataMember(Name = "missing_device_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? MissingDeviceIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4746,6 +6060,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An access method was issued.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodIssued_model")]
     public class EventAccessMethodIssued : Event
     {
@@ -4779,36 +6096,66 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// The actual PIN code for code access methods (only present when mode is &apos;code&apos;).
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.issued";
 
+        /// <summary>
+        /// Indicates whether the code is a backup code (only present when mode is &apos;code&apos; and a backup code was used).
+        /// </summary>
         [DataMember(Name = "is_backup_code", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsBackupCode { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4832,6 +6179,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An access method was revoked.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodRevoked_model")]
     public class EventAccessMethodRevoked : Event
     {
@@ -4861,30 +6211,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.revoked";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4908,6 +6282,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An access method representing a physical card requires encoding.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodCardEncodingRequired_model")]
     public class EventAccessMethodCardEncodingRequired : Event
     {
@@ -4937,30 +6314,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.card_encoding_required";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -4984,6 +6385,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An access method was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodDeleted_model")]
     public class EventAccessMethodDeleted : Event
     {
@@ -5013,30 +6417,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5060,6 +6488,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An access method was reissued.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodReissued_model")]
     public class EventAccessMethodReissued : Event
     {
@@ -5093,36 +6524,66 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// The actual PIN code for code access methods (only present when mode is &apos;code&apos;).
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.reissued";
 
+        /// <summary>
+        /// Indicates whether the code is a backup code (only present when mode is &apos;code&apos; and a backup code was used).
+        /// </summary>
         [DataMember(Name = "is_backup_code", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsBackupCode { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5146,6 +6607,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An access method was created.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodCreated_model")]
     public class EventAccessMethodCreated : Event
     {
@@ -5175,30 +6639,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5222,6 +6710,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Seam has not yet issued this access method, even though its access grant is about to begin, so access may not be ready when the recipient arrives. Seam is still attempting to issue it, and the accompanying `delay_in_issuing` warning clears automatically once issuance succeeds.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodDelayInIssuing_model")]
     public class EventAccessMethodDelayInIssuing : Event
     {
@@ -5251,30 +6742,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.delay_in_issuing";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5298,6 +6813,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Seam was unable to issue this access method before its access grant started, so the recipient may be unable to access the space. This usually points to a problem that needs attention, such as an offline or disconnected device. Seam keeps retrying, and the accompanying `failed_to_issue` error clears automatically if the access method is eventually issued.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAccessMethodFailedToIssue_model")]
     public class EventAccessMethodFailedToIssue : Event
     {
@@ -5327,30 +6845,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of the access grants associated with this access method.
+        /// </summary>
         [DataMember(Name = "access_grant_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AccessGrantIds { get; set; }
 
+        /// <summary>
+        /// Keys of the access grants associated with this access method (if present).
+        /// </summary>
         [DataMember(Name = "access_grant_keys", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? AccessGrantKeys { get; set; }
 
+        /// <summary>
+        /// ID of the affected access method.
+        /// </summary>
         [DataMember(Name = "access_method_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessMethodId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "access_method.failed_to_issue";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5374,6 +6916,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system](https://docs.seam.co/low-level-apis/access-systems) was connected.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsSystemConnected_model")]
     public class EventAcsSystemConnected : Event
     {
@@ -5401,27 +6946,48 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_system.connected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5445,6 +7011,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system](https://docs.seam.co/low-level-apis/access-systems) was added.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsSystemAdded_model")]
     public class EventAcsSystemAdded : Event
     {
@@ -5472,27 +7041,48 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_system.added";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5516,6 +7106,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system](https://docs.seam.co/low-level-apis/access-systems) was disconnected.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsSystemDisconnected_model")]
     public class EventAcsSystemDisconnected : Event
     {
@@ -5552,15 +7145,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Errors associated with the access control system.
+        /// </summary>
         [DataMember(Name = "acs_system_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAcsSystemDisconnectedAcsSystemErrors> AcsSystemErrors { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the access control system.
+        /// </summary>
         [DataMember(Name = "acs_system_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventAcsSystemDisconnectedAcsSystemWarnings> AcsSystemWarnings { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -5568,9 +7173,15 @@ namespace Seam.Model
         )]
         public List<EventAcsSystemDisconnectedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -5578,21 +7189,36 @@ namespace Seam.Model
         )]
         public List<EventAcsSystemDisconnectedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_system.disconnected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5633,12 +7259,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -5679,12 +7314,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -5725,12 +7369,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -5771,12 +7424,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -5800,6 +7462,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsCredentialDeleted_model")]
     public class EventAcsCredentialDeleted : Event
     {
@@ -5829,30 +7494,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected credential.
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_credential.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5876,6 +7565,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was issued.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsCredentialIssued_model")]
     public class EventAcsCredentialIssued : Event
     {
@@ -5905,30 +7597,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected credential.
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_credential.issued";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -5952,6 +7668,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was reissued.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsCredentialReissued_model")]
     public class EventAcsCredentialReissued : Event
     {
@@ -5981,30 +7700,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected credential.
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_credential.reissued";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6028,6 +7771,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system credential](https://docs.seam.co/low-level-apis/access-systems/managing-credentials) was invalidated. That is, the credential cannot be used anymore.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsCredentialInvalidated_model")]
     public class EventAcsCredentialInvalidated : Event
     {
@@ -6057,30 +7803,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected credential.
+        /// </summary>
         [DataMember(Name = "acs_credential_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsCredentialId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_credential.invalidated";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6104,6 +7874,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was created.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsUserCreated_model")]
     public class EventAcsUserCreated : Event
     {
@@ -6133,30 +7906,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the affected access system user.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsUserId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_user.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6180,6 +7977,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system user](https://docs.seam.co/low-level-apis/access-systems/user-management) was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsUserDeleted_model")]
     public class EventAcsUserDeleted : Event
     {
@@ -6209,30 +8009,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the affected access system user.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsUserId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_user.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6256,6 +8080,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) was added.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsEncoderAdded_model")]
     public class EventAcsEncoderAdded : Event
     {
@@ -6285,30 +8112,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected encoder.
+        /// </summary>
         [DataMember(Name = "acs_encoder_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEncoderId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_encoder.added";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6332,6 +8183,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system encoder](https://docs.seam.co/low-level-apis/access-systems/working-with-card-encoders-and-scanners) was removed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsEncoderRemoved_model")]
     public class EventAcsEncoderRemoved : Event
     {
@@ -6361,30 +8215,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected encoder.
+        /// </summary>
         [DataMember(Name = "acs_encoder_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEncoderId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_encoder.removed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6408,6 +8286,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An ACS access group was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsAccessGroupDeleted_model")]
     public class EventAcsAccessGroupDeleted : Event
     {
@@ -6437,30 +8318,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected access group.
+        /// </summary>
         [DataMember(Name = "acs_access_group_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsAccessGroupId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_access_group.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6484,6 +8389,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was added.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsEntranceAdded_model")]
     public class EventAcsEntranceAdded : Event
     {
@@ -6513,30 +8421,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected entrance.
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_entrance.added";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6560,6 +8492,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [access system entrance](https://docs.seam.co/low-level-apis/access-systems/retrieving-entrance-details) was removed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventAcsEntranceRemoved_model")]
     public class EventAcsEntranceRemoved : Event
     {
@@ -6589,30 +8524,54 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected entrance.
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// ID of the access system.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string AcsSystemId { get; set; }
 
+        /// <summary>
+        /// ID of the connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "acs_entrance.removed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6636,6 +8595,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A client session was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventClientSessionDeleted_model")]
     public class EventClientSessionDeleted : Event
     {
@@ -6661,24 +8623,42 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected client session.
+        /// </summary>
         [DataMember(Name = "client_session_id", IsRequired = false, EmitDefaultValue = false)]
         public string ClientSessionId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "client_session.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6702,6 +8682,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account was connected for the first time or was reconnected after being disconnected.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectedAccountConnected_model")]
     public class EventConnectedAccountConnected : Event
     {
@@ -6733,9 +8716,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the Connect Webview associated with the event.
+        /// </summary>
         [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectWebviewId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -6743,27 +8732,48 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with this connected account, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.connected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6787,6 +8797,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account was created.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectedAccountCreated_model")]
     public class EventConnectedAccountCreated : Event
     {
@@ -6816,9 +8829,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the Connect Webview associated with the event.
+        /// </summary>
         [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectWebviewId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -6826,24 +8845,42 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6867,6 +8904,10 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account had a successful login using a Connect Webview.
+    /// </summary>
+    [Obsolete("Use `connect_webview.login_succeeded`.")]
     [DataContract(Name = "seamModel_eventConnectedAccountSuccessfulLogin_model")]
     public class EventConnectedAccountSuccessfulLogin : Event
     {
@@ -6896,9 +8937,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the Connect Webview associated with the event.
+        /// </summary>
         [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectWebviewId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -6906,24 +8953,42 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.successful_login";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -6947,6 +9012,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account was disconnected.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectedAccountDisconnected_model")]
     public class EventConnectedAccountDisconnected : Event
     {
@@ -6980,6 +9048,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -6987,6 +9058,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -6994,9 +9068,15 @@ namespace Seam.Model
         )]
         public List<EventConnectedAccountDisconnectedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -7004,21 +9084,36 @@ namespace Seam.Model
         )]
         public List<EventConnectedAccountDisconnectedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.disconnected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7059,12 +9154,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -7107,12 +9211,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -7136,6 +9249,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account completed the first sync with Seam, and the corresponding devices or systems are now available.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectedAccountCompletedFirstSync_model")]
     public class EventConnectedAccountCompletedFirstSync : Event
     {
@@ -7163,6 +9279,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -7170,24 +9289,42 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.completed_first_sync";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7211,6 +9348,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectedAccountDeleted_model")]
     public class EventConnectedAccountDeleted : Event
     {
@@ -7242,6 +9382,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -7249,30 +9392,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        /// </summary>
         [DataMember(Name = "connected_account_type", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountType { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with this connected account, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7296,6 +9463,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account completed the first sync after reconnection with Seam, and the corresponding devices or systems are now available.
+    /// </summary>
     [DataContract(
         Name = "seamModel_eventConnectedAccountCompletedFirstSyncAfterReconnection_model"
     )]
@@ -7325,6 +9495,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -7332,15 +9505,27 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -7348,9 +9533,15 @@ namespace Seam.Model
         public override string EventType { get; } =
             "connected_account.completed_first_sync_after_reconnection";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7374,6 +9565,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A connected account requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectedAccountReauthorizationRequested_model")]
     public class EventConnectedAccountReauthorizationRequested : Event
     {
@@ -7407,6 +9601,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -7414,6 +9611,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -7421,9 +9621,15 @@ namespace Seam.Model
         )]
         public List<EventConnectedAccountReauthorizationRequestedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected connected account.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -7431,21 +9637,36 @@ namespace Seam.Model
         )]
         public List<EventConnectedAccountReauthorizationRequestedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connected_account.reauthorization_requested";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7488,12 +9709,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -7536,12 +9766,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -7565,6 +9804,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A lock door action attempt succeeded.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptLockDoorSucceeded_model")]
     public class EventActionAttemptLockDoorSucceeded : Event
     {
@@ -7598,36 +9840,66 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "action_attempt.lock_door.succeeded";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7651,6 +9923,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A lock door action attempt failed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptLockDoorFailed_model")]
     public class EventActionAttemptLockDoorFailed : Event
     {
@@ -7684,36 +9959,66 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "action_attempt.lock_door.failed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7737,6 +10042,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An unlock door action attempt succeeded.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptUnlockDoorSucceeded_model")]
     public class EventActionAttemptUnlockDoorSucceeded : Event
     {
@@ -7770,36 +10078,66 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "action_attempt.unlock_door.succeeded";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7823,6 +10161,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An unlock door action attempt failed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptUnlockDoorFailed_model")]
     public class EventActionAttemptUnlockDoorFailed : Event
     {
@@ -7856,36 +10197,66 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "action_attempt.unlock_door.failed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7909,6 +10280,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A simulate keypad code entry action attempt succeeded.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptSimulateKeypadCodeEntrySucceeded_model")]
     public class EventActionAttemptSimulateKeypadCodeEntrySucceeded : Event
     {
@@ -7942,24 +10316,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -7967,12 +10362,21 @@ namespace Seam.Model
         public override string EventType { get; } =
             "action_attempt.simulate_keypad_code_entry.succeeded";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -7996,6 +10400,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A simulate keypad code entry action attempt failed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptSimulateKeypadCodeEntryFailed_model")]
     public class EventActionAttemptSimulateKeypadCodeEntryFailed : Event
     {
@@ -8029,24 +10436,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -8054,12 +10482,21 @@ namespace Seam.Model
         public override string EventType { get; } =
             "action_attempt.simulate_keypad_code_entry.failed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8083,6 +10520,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A simulate manual lock via keypad action attempt succeeded.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptSimulateManualLockViaKeypadSucceeded_model")]
     public class EventActionAttemptSimulateManualLockViaKeypadSucceeded : Event
     {
@@ -8116,24 +10556,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -8141,12 +10602,21 @@ namespace Seam.Model
         public override string EventType { get; } =
             "action_attempt.simulate_manual_lock_via_keypad.succeeded";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8170,6 +10640,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A simulate manual lock via keypad action attempt failed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventActionAttemptSimulateManualLockViaKeypadFailed_model")]
     public class EventActionAttemptSimulateManualLockViaKeypadFailed : Event
     {
@@ -8203,24 +10676,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected action attempt.
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Type of the action.
+        /// </summary>
         [DataMember(Name = "action_type", IsRequired = false, EmitDefaultValue = false)]
         public string ActionType { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the device associated with the action attempt, if applicable.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -8228,12 +10722,21 @@ namespace Seam.Model
         public override string EventType { get; } =
             "action_attempt.simulate_manual_lock_via_keypad.failed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Status of the action.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public string Status { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8257,6 +10760,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A Connect Webview login succeeded.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectWebviewLoginSucceeded_model")]
     public class EventConnectWebviewLoginSucceeded : Event
     {
@@ -8288,9 +10794,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Connect Webview.
+        /// </summary>
         [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectWebviewId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account; present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8298,27 +10810,48 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with this connect webview, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connect_webview.login_succeeded";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8342,6 +10875,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A Connect Webview login failed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventConnectWebviewLoginFailed_model")]
     public class EventConnectWebviewLoginFailed : Event
     {
@@ -8367,24 +10903,42 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the affected Connect Webview.
+        /// </summary>
         [DataMember(Name = "connect_webview_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectWebviewId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "connect_webview.login_failed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8408,6 +10962,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The status of a device changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`. Note that some devices operate entirely in offline mode, so Seam never emits a `device.connected` event for these devices.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceConnected_model")]
     public class EventDeviceConnected : Event
     {
@@ -8441,6 +10998,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8448,33 +11008,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.connected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8498,6 +11085,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device was added to Seam or was re-added to Seam after having been removed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceAdded_model")]
     public class EventDeviceAdded : Event
     {
@@ -8531,6 +11121,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8538,33 +11131,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.added";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8588,6 +11208,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A managed device was successfully converted to an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceConvertedToUnmanaged_model")]
     public class EventDeviceConvertedToUnmanaged : Event
     {
@@ -8621,6 +11244,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8628,33 +11254,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.converted_to_unmanaged";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8678,6 +11331,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) was successfully converted to a managed device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceUnmanagedConvertedToManaged_model")]
     public class EventDeviceUnmanagedConvertedToManaged : Event
     {
@@ -8711,6 +11367,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8718,33 +11377,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.unmanaged.converted_to_managed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8768,6 +11454,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceUnmanagedConnected_model")]
     public class EventDeviceUnmanagedConnected : Event
     {
@@ -8801,6 +11490,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8808,33 +11500,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.unmanaged.connected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -8858,6 +11577,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The status of a device changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceDisconnected_model")]
     public class EventDeviceDisconnected : Event
     {
@@ -8902,6 +11624,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Error code associated with the disconnection event, if any.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ErrorCodeEnum
         {
@@ -8918,6 +11643,9 @@ namespace Seam.Model
             DeviceDisconnected = 3,
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -8925,6 +11653,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -8932,9 +11663,15 @@ namespace Seam.Model
         )]
         public List<EventDeviceDisconnectedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -8942,39 +11679,72 @@ namespace Seam.Model
         )]
         public List<EventDeviceDisconnectedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceDisconnectedDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceDisconnectedDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Error code associated with the disconnection event, if any.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public EventDeviceDisconnected.ErrorCodeEnum ErrorCode { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.disconnected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9015,12 +11785,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -9061,12 +11840,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -9107,12 +11895,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -9153,12 +11950,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -9182,6 +11988,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceUnmanagedDisconnected_model")]
     public class EventDeviceUnmanagedDisconnected : Event
     {
@@ -9227,6 +12036,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Error code associated with the disconnection event, if any.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ErrorCodeEnum
         {
@@ -9243,6 +12055,9 @@ namespace Seam.Model
             DeviceDisconnected = 3,
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -9250,6 +12065,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -9257,9 +12075,15 @@ namespace Seam.Model
         )]
         public List<EventDeviceUnmanagedDisconnectedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -9267,39 +12091,72 @@ namespace Seam.Model
         )]
         public List<EventDeviceUnmanagedDisconnectedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceUnmanagedDisconnectedDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceUnmanagedDisconnectedDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Error code associated with the disconnection event, if any.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public EventDeviceUnmanagedDisconnected.ErrorCodeEnum ErrorCode { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.unmanaged.disconnected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9340,12 +12197,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -9388,12 +12254,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -9434,12 +12309,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -9480,12 +12364,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -9509,6 +12402,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device detected that it was tampered with, for example, opened or moved.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceTampered_model")]
     public class EventDeviceTampered : Event
     {
@@ -9542,6 +12438,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -9549,33 +12448,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.tampered";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9599,6 +12525,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device battery level dropped below the low threshold.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceLowBattery_model")]
     public class EventDeviceLowBattery : Event
     {
@@ -9634,9 +12563,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Number in the range 0 to 1.0 indicating the amount of battery in the affected device, as reported by the device.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public float BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -9644,33 +12579,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.low_battery";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9694,6 +12656,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device battery status changed since the last `battery_status_changed` event.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceBatteryStatusChanged_model")]
     public class EventDeviceBatteryStatusChanged : Event
     {
@@ -9731,6 +12696,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Battery status of the affected device, calculated from the numeric `battery_level` value.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum BatteryStatusEnum
         {
@@ -9750,12 +12718,21 @@ namespace Seam.Model
             Full = 4,
         }
 
+        /// <summary>
+        /// Number in the range 0 to 1.0 indicating the amount of battery in the affected device, as reported by the device.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public float BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Battery status of the affected device, calculated from the numeric `battery_level` value.
+        /// </summary>
         [DataMember(Name = "battery_status", IsRequired = false, EmitDefaultValue = false)]
         public EventDeviceBatteryStatusChanged.BatteryStatusEnum BatteryStatus { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -9763,33 +12740,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.battery_status_changed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9813,6 +12817,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device was removed externally from the connected account.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceRemoved_model")]
     public class EventDeviceRemoved : Event
     {
@@ -9846,6 +12853,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -9853,33 +12863,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.removed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9903,6 +12940,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceDeleted_model")]
     public class EventDeviceDeleted : Event
     {
@@ -9938,6 +12978,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -9945,36 +12988,66 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Name of the deleted device, captured at deletion time. The device record no longer exists when this event fires, so the name is preserved here. Null when the device had no resolvable name.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceName { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -9998,6 +13071,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Seam detected that a device is using a third-party integration that will interfere with Seam device management.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceThirdPartyIntegrationDetected_model")]
     public class EventDeviceThirdPartyIntegrationDetected : Event
     {
@@ -10031,6 +13107,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10038,33 +13117,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.third_party_integration_detected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10088,6 +13194,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Seam detected that a device is no longer using a third-party integration that was interfering with Seam device management.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceThirdPartyIntegrationNoLongerDetected_model")]
     public class EventDeviceThirdPartyIntegrationNoLongerDetected : Event
     {
@@ -10121,6 +13230,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10128,24 +13240,45 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -10153,9 +13286,15 @@ namespace Seam.Model
         public override string EventType { get; } =
             "device.third_party_integration_no_longer_detected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10179,6 +13318,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) activated privacy mode.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceSaltoPrivacyModeActivated_model")]
     public class EventDeviceSaltoPrivacyModeActivated : Event
     {
@@ -10212,6 +13354,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10219,33 +13364,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.salto.privacy_mode_activated";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10269,6 +13441,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) deactivated privacy mode.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceSaltoPrivacyModeDeactivated_model")]
     public class EventDeviceSaltoPrivacyModeDeactivated : Event
     {
@@ -10302,6 +13477,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10309,33 +13487,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.salto.privacy_mode_deactivated";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10359,6 +13564,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Seam detected a flaky device connection.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceConnectionBecameFlaky_model")]
     public class EventDeviceConnectionBecameFlaky : Event
     {
@@ -10402,6 +13610,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10409,6 +13620,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -10416,9 +13630,15 @@ namespace Seam.Model
         )]
         public List<EventDeviceConnectionBecameFlakyConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -10426,36 +13646,66 @@ namespace Seam.Model
         )]
         public List<EventDeviceConnectionBecameFlakyConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceConnectionBecameFlakyDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceConnectionBecameFlakyDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.connection_became_flaky";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10496,12 +13746,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -10544,12 +13803,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -10590,12 +13858,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -10636,12 +13913,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -10665,6 +13951,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Seam detected that a previously-flaky device connection stabilized.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceConnectionStabilized_model")]
     public class EventDeviceConnectionStabilized : Event
     {
@@ -10698,6 +13987,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10705,33 +13997,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.connection_stabilized";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10755,6 +14074,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A third-party subscription is required to use all device features.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceErrorSubscriptionRequired_model")]
     public class EventDeviceErrorSubscriptionRequired : Event
     {
@@ -10798,6 +14120,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -10805,6 +14130,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -10812,9 +14140,15 @@ namespace Seam.Model
         )]
         public List<EventDeviceErrorSubscriptionRequiredConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -10822,36 +14156,66 @@ namespace Seam.Model
         )]
         public List<EventDeviceErrorSubscriptionRequiredConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceErrorSubscriptionRequiredDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceErrorSubscriptionRequiredDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.error.subscription_required";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -10894,12 +14258,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -10942,12 +14315,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -10988,12 +14370,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -11034,12 +14425,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -11063,6 +14463,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A third-party subscription is active or no longer required to use all device features.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceErrorSubscriptionRequiredResolved_model")]
     public class EventDeviceErrorSubscriptionRequiredResolved : Event
     {
@@ -11096,6 +14499,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -11103,33 +14509,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.error.subscription_required.resolved";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -11153,6 +14586,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An accessory keypad was connected to a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceAccessoryKeypadConnected_model")]
     public class EventDeviceAccessoryKeypadConnected : Event
     {
@@ -11186,6 +14622,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -11193,33 +14632,60 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.accessory_keypad_connected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -11243,6 +14709,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// An accessory keypad was disconnected from a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceAccessoryKeypadDisconnected_model")]
     public class EventDeviceAccessoryKeypadDisconnected : Event
     {
@@ -11286,6 +14755,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -11293,6 +14765,9 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_errors",
             IsRequired = false,
@@ -11300,9 +14775,15 @@ namespace Seam.Model
         )]
         public List<EventDeviceAccessoryKeypadDisconnectedConnectedAccountErrors> ConnectedAccountErrors { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the connected account.
+        /// </summary>
         [DataMember(
             Name = "connected_account_warnings",
             IsRequired = false,
@@ -11310,36 +14791,66 @@ namespace Seam.Model
         )]
         public List<EventDeviceAccessoryKeypadDisconnectedConnectedAccountWarnings> ConnectedAccountWarnings { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// Errors associated with the device.
+        /// </summary>
         [DataMember(Name = "device_errors", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceAccessoryKeypadDisconnectedDeviceErrors> DeviceErrors { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the device.
+        /// </summary>
         [DataMember(Name = "device_warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<EventDeviceAccessoryKeypadDisconnectedDeviceWarnings> DeviceWarnings { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.accessory_keypad_disconnected";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -11382,12 +14893,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -11430,12 +14950,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -11476,12 +15005,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -11522,12 +15060,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 
@@ -11551,6 +15098,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// Extended periods of noise or noise exceeding a [threshold](https://docs.seam.co/capability-guides/noise-sensors#what-is-a-threshold) were detected.
+    /// </summary>
     [DataContract(Name = "seamModel_eventNoiseSensorNoiseThresholdTriggered_model")]
     public class EventNoiseSensorNoiseThresholdTriggered : Event
     {
@@ -11596,6 +15146,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -11603,51 +15156,96 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "noise_sensor.noise_threshold_triggered";
 
+        /// <summary>
+        /// Metadata from Minut.
+        /// </summary>
         [DataMember(Name = "minut_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? MinutMetadata { get; set; }
 
+        /// <summary>
+        /// Detected noise level in decibels.
+        /// </summary>
         [DataMember(Name = "noise_level_decibels", IsRequired = false, EmitDefaultValue = false)]
         public float? NoiseLevelDecibels { get; set; }
 
+        /// <summary>
+        /// Detected noise level in Noiseaware Noise Risk Score (NRS).
+        /// </summary>
         [DataMember(Name = "noise_level_nrs", IsRequired = false, EmitDefaultValue = false)]
         public float? NoiseLevelNrs { get; set; }
 
+        /// <summary>
+        /// ID of the noise threshold that was triggered.
+        /// </summary>
         [DataMember(Name = "noise_threshold_id", IsRequired = false, EmitDefaultValue = false)]
         public string? NoiseThresholdId { get; set; }
 
+        /// <summary>
+        /// Name of the noise threshold that was triggered.
+        /// </summary>
         [DataMember(Name = "noise_threshold_name", IsRequired = false, EmitDefaultValue = false)]
         public string? NoiseThresholdName { get; set; }
 
+        /// <summary>
+        /// Metadata from Noiseaware.
+        /// </summary>
         [DataMember(Name = "noiseaware_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? NoiseawareMetadata { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -11671,6 +15269,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [lock](https://docs.seam.co/low-level-apis/smart-locks) was locked.
+    /// </summary>
     [DataContract(Name = "seamModel_eventLockLocked_model")]
     public class EventLockLocked : Event
     {
@@ -11726,6 +15327,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Method by which the lock was locked. `keycode`: an access code was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or button press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by an auto-relock timer. `unknown`: could not be determined.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum MethodEnum
         {
@@ -11751,27 +15355,57 @@ namespace Seam.Model
             Card = 6,
         }
 
+        /// <summary>
+        /// ID of the access code that was used to lock the device.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
+        /// </summary>
         [DataMember(Name = "access_code_is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool? AccessCodeIsManaged { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS entrance associated with the lock event.
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS system associated with the lock event.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsSystemId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS user associated with the lock event.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// ID of the Seam action attempt that triggered this lock. Present only when the lock was initiated through Seam (via a `LOCK_DOOR` action attempt).
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Code (PIN) that was used to lock the device, if known. Taken from the matched managed or unmanaged access code, or from the code reported by the provider when no access code matched.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -11779,45 +15413,86 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "lock.locked";
 
+        /// <summary>
+        /// Whether the lock action was performed over Bluetooth by a remote client (such as the provider&apos;s mobile app), rather than a direct physical interaction or a Seam-initiated remote action.
+        /// </summary>
         [DataMember(Name = "is_via_bluetooth", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsViaBluetooth { get; set; }
 
+        /// <summary>
+        /// Whether the lock action was performed by an NFC credential tap (such as an Apple Home Key or an NFC key fob) presented to the lock, rather than a direct physical interaction or a Seam-initiated remote action.
+        /// </summary>
         [DataMember(Name = "is_via_nfc", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsViaNfc { get; set; }
 
+        /// <summary>
+        /// Method by which the lock was locked. `keycode`: an access code was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or button press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by an auto-relock timer. `unknown`: could not be determined.
+        /// </summary>
         [DataMember(Name = "method", IsRequired = false, EmitDefaultValue = false)]
         public EventLockLocked.MethodEnum Method { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the user identity associated with the lock event.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -11841,6 +15516,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [lock](https://docs.seam.co/low-level-apis/smart-locks) was unlocked.
+    /// </summary>
     [DataContract(Name = "seamModel_eventLockUnlocked_model")]
     public class EventLockUnlocked : Event
     {
@@ -11896,6 +15574,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum MethodEnum
         {
@@ -11921,27 +15602,57 @@ namespace Seam.Model
             Card = 6,
         }
 
+        /// <summary>
+        /// ID of the access code that was used to unlock the affected device.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Whether the access code is managed by Seam (true) or unmanaged (false). Only present when access_code_id is set.
+        /// </summary>
         [DataMember(Name = "access_code_is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool? AccessCodeIsManaged { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS entrance associated with the unlock event.
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS system associated with the unlock event.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsSystemId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS user associated with the unlock event.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// ID of the Seam action attempt that triggered this unlock. Present only when the unlock was initiated through Seam (via an `UNLOCK_DOOR` action attempt).
+        /// </summary>
         [DataMember(Name = "action_attempt_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ActionAttemptId { get; set; }
 
+        /// <summary>
+        /// Code (PIN) that was used to unlock the affected device, if known. Taken from the matched managed or unmanaged access code, or from the code reported by the provider when no access code matched.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -11949,45 +15660,86 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "lock.unlocked";
 
+        /// <summary>
+        /// Whether the unlock action was performed over Bluetooth by a remote client (such as the provider&apos;s mobile app), rather than a direct physical interaction or a Seam-initiated remote action.
+        /// </summary>
         [DataMember(Name = "is_via_bluetooth", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsViaBluetooth { get; set; }
 
+        /// <summary>
+        /// Whether the unlock action was performed by an NFC credential tap (such as an Apple Home Key or an NFC key fob) presented to the lock, rather than a direct physical interaction or a Seam-initiated remote action.
+        /// </summary>
         [DataMember(Name = "is_via_nfc", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsViaNfc { get; set; }
 
+        /// <summary>
+        /// Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.
+        /// </summary>
         [DataMember(Name = "method", IsRequired = false, EmitDefaultValue = false)]
         public EventLockUnlocked.MethodEnum Method { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the user identity associated with the unlock event.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12011,6 +15763,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The [lock](https://docs.seam.co/low-level-apis/smart-locks) denied access to a user after one or more consecutive invalid attempts to unlock the device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventLockAccessDenied_model")]
     public class EventLockAccessDenied : Event
     {
@@ -12056,18 +15811,39 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the access code that was used in the unlock attempts.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AccessCodeId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS entrance associated with the access-denied event.
+        /// </summary>
         [DataMember(Name = "acs_entrance_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsEntranceId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS system associated with the access-denied event.
+        /// </summary>
         [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsSystemId { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the ACS user associated with the access-denied event.
+        /// </summary>
         [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
         public string? AcsUserId { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12075,39 +15851,74 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string? DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "lock.access_denied";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Why access was denied, when the provider reports a determinable cause. Omitted when unknown.
+        /// </summary>
         [DataMember(Name = "reason", IsRequired = false, EmitDefaultValue = false)]
         public EventLockAccessDeniedReason? Reason { get; set; }
 
+        /// <summary>
+        /// undocumented: Unreleased.
+        ///       ---
+        ///       ID of the user identity associated with the access-denied event.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12146,6 +15957,9 @@ namespace Seam.Model
             ReasonCode = reasonCode;
         }
 
+        /// <summary>
+        /// Normalized reason a lock denied access. Provider-agnostic; not all providers report every value.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ReasonCodeEnum
         {
@@ -12171,9 +15985,15 @@ namespace Seam.Model
             CredentialError = 6,
         }
 
+        /// <summary>
+        /// Human-readable explanation of why access was denied.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Normalized reason a lock denied access. Provider-agnostic; not all providers report every value.
+        /// </summary>
         [DataMember(Name = "reason_code", IsRequired = false, EmitDefaultValue = false)]
         public EventLockAccessDeniedReason.ReasonCodeEnum ReasonCode { get; set; }
 
@@ -12197,6 +16017,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A thermostat [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) was activated.
+    /// </summary>
     [DataContract(Name = "seamModel_eventThermostatClimatePresetActivated_model")]
     public class EventThermostatClimatePresetActivated : Event
     {
@@ -12236,9 +16059,15 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Key of the climate preset that was activated.
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12246,30 +16075,54 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "thermostat.climate_preset_activated";
 
+        /// <summary>
+        /// Indicates whether the climate preset that was activated is the fallback climate preset for the thermostat.
+        /// </summary>
         [DataMember(
             Name = "is_fallback_climate_preset",
             IsRequired = false,
@@ -12277,12 +16130,21 @@ namespace Seam.Model
         )]
         public bool IsFallbackClimatePreset { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat schedule that prompted the affected climate preset to be activated.
+        /// </summary>
         [DataMember(Name = "thermostat_schedule_id", IsRequired = false, EmitDefaultValue = false)]
         public string? ThermostatScheduleId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12306,6 +16168,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [thermostat](https://docs.seam.co/capability-guides/thermostats) was adjusted manually.
+    /// </summary>
     [DataContract(Name = "seamModel_eventThermostatManuallyAdjusted_model")]
     public class EventThermostatManuallyAdjusted : Event
     {
@@ -12353,6 +16218,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum FanModeSettingEnum
         {
@@ -12369,6 +16237,9 @@ namespace Seam.Model
             Circulate = 3,
         }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum HvacModeSettingEnum
         {
@@ -12391,6 +16262,9 @@ namespace Seam.Model
             Eco = 5,
         }
 
+        /// <summary>
+        /// Method used to adjust the affected thermostat manually. `seam` indicates that the Seam API, Seam CLI, or Seam Console was used to adjust the thermostat.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum MethodEnum
         {
@@ -12404,6 +16278,9 @@ namespace Seam.Model
             External = 2,
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12411,9 +16288,15 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_celsius",
             IsRequired = false,
@@ -12421,6 +16304,9 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "cooling_set_point_fahrenheit",
             IsRequired = false,
@@ -12428,30 +16314,54 @@ namespace Seam.Model
         )]
         public float? CoolingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "thermostat.manually_adjusted";
 
+        /// <summary>
+        /// Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.
+        /// </summary>
         [DataMember(Name = "fan_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public EventThermostatManuallyAdjusted.FanModeSettingEnum? FanModeSetting { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_celsius",
             IsRequired = false,
@@ -12459,6 +16369,9 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+        /// </summary>
         [DataMember(
             Name = "heating_set_point_fahrenheit",
             IsRequired = false,
@@ -12466,15 +16379,27 @@ namespace Seam.Model
         )]
         public float? HeatingSetPointFahrenheit { get; set; }
 
+        /// <summary>
+        /// Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.
+        /// </summary>
         [DataMember(Name = "hvac_mode_setting", IsRequired = false, EmitDefaultValue = false)]
         public EventThermostatManuallyAdjusted.HvacModeSettingEnum? HvacModeSetting { get; set; }
 
+        /// <summary>
+        /// Method used to adjust the affected thermostat manually. `seam` indicates that the Seam API, Seam CLI, or Seam Console was used to adjust the thermostat.
+        /// </summary>
         [DataMember(Name = "method", IsRequired = false, EmitDefaultValue = false)]
         public EventThermostatManuallyAdjusted.MethodEnum Method { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12498,6 +16423,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [thermostat&apos;s](https://docs.seam.co/capability-guides/thermostats) temperature reading exceeded the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
+    /// </summary>
     [DataContract(Name = "seamModel_eventThermostatTemperatureThresholdExceeded_model")]
     public class EventThermostatTemperatureThresholdExceeded : Event
     {
@@ -12543,6 +16471,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12550,51 +16481,96 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "thermostat.temperature_threshold_exceeded";
 
+        /// <summary>
+        /// Lower temperature limit, in °C, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "lower_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? LowerLimitCelsius { get; set; }
 
+        /// <summary>
+        /// Lower temperature limit, in °F, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "lower_limit_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? LowerLimitFahrenheit { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Temperature, in °C, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature, in °F, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureFahrenheit { get; set; }
 
+        /// <summary>
+        /// Upper temperature limit, in °C, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "upper_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? UpperLimitCelsius { get; set; }
 
+        /// <summary>
+        /// Upper temperature limit, in °F, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "upper_limit_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? UpperLimitFahrenheit { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12618,6 +16594,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [thermostat&apos;s](https://docs.seam.co/capability-guides/thermostats) temperature reading no longer exceeds the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
+    /// </summary>
     [DataContract(Name = "seamModel_eventThermostatTemperatureThresholdNoLongerExceeded_model")]
     public class EventThermostatTemperatureThresholdNoLongerExceeded : Event
     {
@@ -12663,6 +16642,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12670,24 +16652,45 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
@@ -12695,27 +16698,51 @@ namespace Seam.Model
         public override string EventType { get; } =
             "thermostat.temperature_threshold_no_longer_exceeded";
 
+        /// <summary>
+        /// Lower temperature limit, in °C, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "lower_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? LowerLimitCelsius { get; set; }
 
+        /// <summary>
+        /// Lower temperature limit, in °F, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "lower_limit_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? LowerLimitFahrenheit { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Temperature, in °C, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature, in °F, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureFahrenheit { get; set; }
 
+        /// <summary>
+        /// Upper temperature limit, in °C, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "upper_limit_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float? UpperLimitCelsius { get; set; }
 
+        /// <summary>
+        /// Upper temperature limit, in °F, defined by the set threshold.
+        /// </summary>
         [DataMember(Name = "upper_limit_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float? UpperLimitFahrenheit { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12739,6 +16766,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [thermostat&apos;s](https://docs.seam.co/capability-guides/thermostats) temperature reading is within 1 °C of the configured cooling or heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+    /// </summary>
     [DataContract(Name = "seamModel_eventThermostatTemperatureReachedSetPoint_model")]
     public class EventThermostatTemperatureReachedSetPoint : Event
     {
@@ -12780,6 +16810,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12787,15 +16820,27 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Desired temperature, in °C, defined by the affected thermostat&apos;s cooling or heating set point.
+        /// </summary>
         [DataMember(
             Name = "desired_temperature_celsius",
             IsRequired = false,
@@ -12803,6 +16848,9 @@ namespace Seam.Model
         )]
         public float? DesiredTemperatureCelsius { get; set; }
 
+        /// <summary>
+        /// Desired temperature, in °F, defined by the affected thermostat&apos;s cooling or heating set point.
+        /// </summary>
         [DataMember(
             Name = "desired_temperature_fahrenheit",
             IsRequired = false,
@@ -12810,30 +16858,54 @@ namespace Seam.Model
         )]
         public float? DesiredTemperatureFahrenheit { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "thermostat.temperature_reached_set_point";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Temperature, in °C, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature, in °F, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureFahrenheit { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12857,6 +16929,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A [thermostat&apos;s](https://docs.seam.co/capability-guides/thermostats) reported temperature changed by at least 1 °C.
+    /// </summary>
     [DataContract(Name = "seamModel_eventThermostatTemperatureChanged_model")]
     public class EventThermostatTemperatureChanged : Event
     {
@@ -12894,6 +16969,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12901,39 +16979,72 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "thermostat.temperature_changed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// Temperature, in °C, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_celsius", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureCelsius { get; set; }
 
+        /// <summary>
+        /// Temperature, in °F, reported by the affected thermostat.
+        /// </summary>
         [DataMember(Name = "temperature_fahrenheit", IsRequired = false, EmitDefaultValue = false)]
         public float TemperatureFahrenheit { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -12957,6 +17068,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// The name of a device was changed.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceNameChanged_model")]
     public class EventDeviceNameChanged : Event
     {
@@ -12992,6 +17106,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -12999,36 +17116,66 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// The new name of the affected device.
+        /// </summary>
         [DataMember(Name = "device_name", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceName { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.name_changed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13052,6 +17199,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A camera was activated, for example, by motion detection.
+    /// </summary>
     [DataContract(Name = "seamModel_eventCameraActivated_model")]
     public class EventCameraActivated : Event
     {
@@ -13093,6 +17243,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// The reason the camera was activated.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum ActivationReasonEnum
         {
@@ -13103,6 +17256,9 @@ namespace Seam.Model
             MotionDetected = 1,
         }
 
+        /// <summary>
+        /// Sub-type of motion detected, if available.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum MotionSubTypeEnum
         {
@@ -13122,9 +17278,15 @@ namespace Seam.Model
             Other = 4,
         }
 
+        /// <summary>
+        /// The reason the camera was activated.
+        /// </summary>
         [DataMember(Name = "activation_reason", IsRequired = false, EmitDefaultValue = false)]
         public EventCameraActivated.ActivationReasonEnum ActivationReason { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -13132,42 +17294,78 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "camera.activated";
 
+        /// <summary>
+        /// URL to a thumbnail image captured at the time of activation.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// Sub-type of motion detected, if available.
+        /// </summary>
         [DataMember(Name = "motion_sub_type", IsRequired = false, EmitDefaultValue = false)]
         public EventCameraActivated.MotionSubTypeEnum? MotionSubType { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// URL to a short video clip captured at the time of activation.
+        /// </summary>
         [DataMember(Name = "video_url", IsRequired = false, EmitDefaultValue = false)]
         public string? VideoUrl { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13191,6 +17389,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A doorbell button was pressed on a device.
+    /// </summary>
     [DataContract(Name = "seamModel_eventDeviceDoorbellRang_model")]
     public class EventDeviceDoorbellRang : Event
     {
@@ -13228,6 +17429,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Custom metadata of the connected account, present when connected_account_id is provided.
+        /// </summary>
         [DataMember(
             Name = "connected_account_custom_metadata",
             IsRequired = false,
@@ -13235,39 +17439,72 @@ namespace Seam.Model
         )]
         public object? ConnectedAccountCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the connected account associated with the event.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// The customer key associated with the device, if any.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device, present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "device.doorbell_rang";
 
+        /// <summary>
+        /// URL to a thumbnail image captured at the time the doorbell was pressed.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// URL to a short video clip captured at the time the doorbell was pressed.
+        /// </summary>
         [DataMember(Name = "video_url", IsRequired = false, EmitDefaultValue = false)]
         public string? VideoUrl { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13291,6 +17528,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A phone device was deactivated.
+    /// </summary>
     [DataContract(Name = "seamModel_eventPhoneDeactivated_model")]
     public class EventPhoneDeactivated : Event
     {
@@ -13318,27 +17558,48 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Custom metadata of the device; present when device_id is provided.
+        /// </summary>
         [DataMember(Name = "device_custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object? DeviceCustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the affected phone device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "phone.deactivated";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13362,6 +17623,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A device was added or removed from a space.
+    /// </summary>
     [DataContract(Name = "seamModel_eventSpaceDeviceMembershipChanged_model")]
     public class EventSpaceDeviceMembershipChanged : Event
     {
@@ -13393,33 +17657,60 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of all ACS entrances currently attached to the space.
+        /// </summary>
         [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// IDs of all devices currently attached to the space.
+        /// </summary>
         [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> DeviceIds { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "space.device_membership_changed";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the affected space.
+        /// </summary>
         [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
         public string SpaceId { get; set; }
 
+        /// <summary>
+        /// Unique key for the space within the workspace.
+        /// </summary>
         [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
         public string? SpaceKey { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13443,6 +17734,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A space was created.
+    /// </summary>
     [DataContract(Name = "seamModel_eventSpaceCreated_model")]
     public class EventSpaceCreated : Event
     {
@@ -13474,33 +17768,60 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of all ACS entrances attached to the space when it was created.
+        /// </summary>
         [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// IDs of all devices attached to the space when it was created.
+        /// </summary>
         [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> DeviceIds { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "space.created";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the affected space.
+        /// </summary>
         [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
         public string SpaceId { get; set; }
 
+        /// <summary>
+        /// Unique key for the space within the workspace.
+        /// </summary>
         [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
         public string? SpaceKey { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13524,6 +17845,9 @@ namespace Seam.Model
         }
     }
 
+    /// <summary>
+    /// A space was deleted.
+    /// </summary>
     [DataContract(Name = "seamModel_eventSpaceDeleted_model")]
     public class EventSpaceDeleted : Event
     {
@@ -13555,33 +17879,60 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// IDs of all ACS entrances currently attached to the space when it was deleted.
+        /// </summary>
         [DataMember(Name = "acs_entrance_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AcsEntranceIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// IDs of all devices attached to the space when it was deleted.
+        /// </summary>
         [DataMember(Name = "device_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> DeviceIds { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "space.deleted";
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the affected space.
+        /// </summary>
         [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
         public string SpaceId { get; set; }
 
+        /// <summary>
+        /// Unique key for the space within the workspace.
+        /// </summary>
         [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
         public string? SpaceKey { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 
@@ -13631,18 +17982,33 @@ namespace Seam.Model
         [DataMember(Name = "event_type", IsRequired = true, EmitDefaultValue = false)]
         public override string EventType { get; } = "unrecognized";
 
+        /// <summary>
+        /// Date and time at which the event was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public override string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Human-readable description of the event. Persisted when the event is created (so the creating code, including a provider, can supply a tailored description) and otherwise derived from the event.
+        /// </summary>
         [DataMember(Name = "event_description", IsRequired = false, EmitDefaultValue = false)]
         public override string? EventDescription { get; set; }
 
+        /// <summary>
+        /// ID of the event.
+        /// </summary>
         [DataMember(Name = "event_id", IsRequired = false, EmitDefaultValue = false)]
         public override string EventId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the event occurred.
+        /// </summary>
         [DataMember(Name = "occurred_at", IsRequired = false, EmitDefaultValue = false)]
         public override string OccurredAt { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the event.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public override string WorkspaceId { get; set; }
 

--- a/output/csharp/src/Seam/Model/InstantKey.cs
+++ b/output/csharp/src/Seam/Model/InstantKey.cs
@@ -8,6 +8,11 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a Seam Instant Key. For issuing Bluetooth mobile keys, Instant Keys are the fastest way to share access. With a single API call, you can create a mobile key and send it through text or email or embed it in your own app.
+    ///
+    /// There’s no app to install, nor account to create. Your user just taps a link and gets a lightweight, native-feeling experience using iOS App Clip or Instant Apps on Android. Further, Instant Keys work offline, so even in areas with poor cellular or Wi-Fi, like elevator banks or concrete-walled hallways, the Instant Keys still work.
+    /// </summary>
     [DataContract(Name = "seamModel_instantKey_model")]
     public class InstantKey
     {
@@ -37,15 +42,27 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// ID of the client session associated with the Instant Key.
+        /// </summary>
         [DataMember(Name = "client_session_id", IsRequired = false, EmitDefaultValue = false)]
         public string ClientSessionId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the Instant Key was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Customization applied to the Instant Key UI.
+        /// </summary>
         [DataMember(Name = "customization", IsRequired = false, EmitDefaultValue = false)]
         public InstantKeyCustomization? Customization { get; set; }
 
+        /// <summary>
+        /// ID of the customization profile associated with the Instant Key.
+        /// </summary>
         [DataMember(
             Name = "customization_profile_id",
             IsRequired = false,
@@ -53,18 +70,33 @@ namespace Seam.Model
         )]
         public string? CustomizationProfileId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the Instant Key expires.
+        /// </summary>
         [DataMember(Name = "expires_at", IsRequired = false, EmitDefaultValue = false)]
         public string ExpiresAt { get; set; }
 
+        /// <summary>
+        /// ID of the Instant Key.
+        /// </summary>
         [DataMember(Name = "instant_key_id", IsRequired = false, EmitDefaultValue = false)]
         public string InstantKeyId { get; set; }
 
+        /// <summary>
+        /// Shareable URL for the Instant Key. Use the URL to deliver the Instant Key to your user through a link in a text message or email or by embedding it in your web app.
+        /// </summary>
         [DataMember(Name = "instant_key_url", IsRequired = false, EmitDefaultValue = false)]
         public string InstantKeyUrl { get; set; }
 
+        /// <summary>
+        /// ID of the user identity associated with the Instant Key.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string UserIdentityId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the Instant Key.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -105,12 +137,21 @@ namespace Seam.Model
             SecondaryColor = secondaryColor;
         }
 
+        /// <summary>
+        /// URL of the logo displayed on the Instant Key.
+        /// </summary>
         [DataMember(Name = "logo_url", IsRequired = false, EmitDefaultValue = false)]
         public string? LogoUrl { get; set; }
 
+        /// <summary>
+        /// Primary color used in the Instant Key UI.
+        /// </summary>
         [DataMember(Name = "primary_color", IsRequired = false, EmitDefaultValue = false)]
         public string? PrimaryColor { get; set; }
 
+        /// <summary>
+        /// Secondary color used in the Instant Key UI.
+        /// </summary>
         [DataMember(Name = "secondary_color", IsRequired = false, EmitDefaultValue = false)]
         public string? SecondaryColor { get; set; }
 

--- a/output/csharp/src/Seam/Model/NoiseThreshold.cs
+++ b/output/csharp/src/Seam/Model/NoiseThreshold.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+    /// </summary>
     [DataContract(Name = "seamModel_noiseThreshold_model")]
     public class NoiseThreshold
     {
@@ -33,15 +36,27 @@ namespace Seam.Model
             StartsDailyAt = startsDailyAt;
         }
 
+        /// <summary>
+        /// Unique identifier for the device that contains the noise threshold.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Time at which the noise threshold should become inactive daily.
+        /// </summary>
         [DataMember(Name = "ends_daily_at", IsRequired = false, EmitDefaultValue = false)]
         public string EndsDailyAt { get; set; }
 
+        /// <summary>
+        /// Name of the noise threshold.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Noise level in decibels for the noise threshold.
+        /// </summary>
         [DataMember(
             Name = "noise_threshold_decibels",
             IsRequired = false,
@@ -49,12 +64,21 @@ namespace Seam.Model
         )]
         public float NoiseThresholdDecibels { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the noise threshold.
+        /// </summary>
         [DataMember(Name = "noise_threshold_id", IsRequired = false, EmitDefaultValue = false)]
         public string NoiseThresholdId { get; set; }
 
+        /// <summary>
+        /// Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).
+        /// </summary>
         [DataMember(Name = "noise_threshold_nrs", IsRequired = false, EmitDefaultValue = false)]
         public float? NoiseThresholdNrs { get; set; }
 
+        /// <summary>
+        /// Time at which the noise threshold should become active daily.
+        /// </summary>
         [DataMember(Name = "starts_daily_at", IsRequired = false, EmitDefaultValue = false)]
         public string StartsDailyAt { get; set; }
 

--- a/output/csharp/src/Seam/Model/Phone.cs
+++ b/output/csharp/src/Seam/Model/Phone.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an app user&apos;s mobile phone.
+    /// </summary>
     [DataContract(Name = "seamModel_phone_model")]
     public class Phone
     {
@@ -39,6 +42,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Type of the phone device, such as `ios_phone` or `android_phone`.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DeviceTypeEnum
         {
@@ -52,33 +58,63 @@ namespace Seam.Model
             AndroidPhone = 2,
         }
 
+        /// <summary>
+        /// Date and time at which the phone was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Optional [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.
+        /// </summary>
         [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object CustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the phone.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Type of the phone device, such as `ios_phone` or `android_phone`.
+        /// </summary>
         [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
         public Phone.DeviceTypeEnum DeviceType { get; set; }
 
+        /// <summary>
+        /// Display name of the phone. Defaults to `nickname` (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the phone easily, especially when there are numerous phones.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Errors associated with the phone.
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<PhoneErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Optional nickname to describe the phone, settable through Seam.
+        /// </summary>
         [DataMember(Name = "nickname", IsRequired = false, EmitDefaultValue = false)]
         public string? Nickname { get; set; }
 
+        /// <summary>
+        /// Properties of the phone.
+        /// </summary>
         [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
         public PhoneProperties Properties { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the phone.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<PhoneWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the phone.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -119,12 +155,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
@@ -165,6 +210,9 @@ namespace Seam.Model
             SaltoSpaceCredentialServiceMetadata = saltoSpaceCredentialServiceMetadata;
         }
 
+        /// <summary>
+        /// ASSA ABLOY Credential Service metadata for the phone.
+        /// </summary>
         [DataMember(
             Name = "assa_abloy_credential_service_metadata",
             IsRequired = false,
@@ -172,6 +220,9 @@ namespace Seam.Model
         )]
         public PhonePropertiesAssaAbloyCredentialServiceMetadata? AssaAbloyCredentialServiceMetadata { get; set; }
 
+        /// <summary>
+        /// Salto Space credential service metadata for the phone.
+        /// </summary>
         [DataMember(
             Name = "salto_space_credential_service_metadata",
             IsRequired = false,
@@ -214,9 +265,15 @@ namespace Seam.Model
             HasActiveEndpoint = hasActiveEndpoint;
         }
 
+        /// <summary>
+        /// Endpoints associated with the phone.
+        /// </summary>
         [DataMember(Name = "endpoints", IsRequired = false, EmitDefaultValue = false)]
         public List<PhonePropertiesAssaAbloyCredentialServiceMetadataEndpoints>? Endpoints { get; set; }
 
+        /// <summary>
+        /// Indicates whether the credential service has active endpoints associated with the phone.
+        /// </summary>
         [DataMember(Name = "has_active_endpoint", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasActiveEndpoint { get; set; }
 
@@ -257,9 +314,15 @@ namespace Seam.Model
             IsActive = isActive;
         }
 
+        /// <summary>
+        /// ID of the associated endpoint.
+        /// </summary>
         [DataMember(Name = "endpoint_id", IsRequired = false, EmitDefaultValue = false)]
         public string? EndpointId { get; set; }
 
+        /// <summary>
+        /// Indicated whether the endpoint is active.
+        /// </summary>
         [DataMember(Name = "is_active", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsActive { get; set; }
 
@@ -294,6 +357,9 @@ namespace Seam.Model
             HasActivePhone = hasActivePhone;
         }
 
+        /// <summary>
+        /// Indicates whether the credential service has an active associated phone.
+        /// </summary>
         [DataMember(Name = "has_active_phone", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasActivePhone { get; set; }
 
@@ -334,12 +400,21 @@ namespace Seam.Model
             WarningCode = warningCode;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the warning.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Detailed description of the warning.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of warning.
+        /// </summary>
         [DataMember(Name = "warning_code", IsRequired = false, EmitDefaultValue = false)]
         public string WarningCode { get; set; }
 

--- a/output/csharp/src/Seam/Model/Space.cs
+++ b/output/csharp/src/Seam/Model/Space.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a space that is a logical grouping of devices and entrances. You can assign access to an entire space, thereby making granting access more efficient.
+    /// </summary>
     [DataContract(Name = "seamModel_space_model")]
     public class Space
     {
@@ -41,36 +44,69 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Number of entrances in the space.
+        /// </summary>
         [DataMember(Name = "acs_entrance_count", IsRequired = false, EmitDefaultValue = false)]
         public float AcsEntranceCount { get; set; }
 
+        /// <summary>
+        /// Date and time at which the space was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Reservation/stay-related defaults for the space. Also carries the provider/PMS-supplied name under a `&lt;connector_type&gt;_name` key (e.g. `guesty_name`), which Seam preserves when you rename the space (read-only — managed by Seam).
+        /// </summary>
         [DataMember(Name = "customer_data", IsRequired = false, EmitDefaultValue = false)]
         public SpaceCustomerData? CustomerData { get; set; }
 
+        /// <summary>
+        /// Customer key associated with the space.
+        /// </summary>
         [DataMember(Name = "customer_key", IsRequired = false, EmitDefaultValue = false)]
         public string? CustomerKey { get; set; }
 
+        /// <summary>
+        /// Number of devices in the space.
+        /// </summary>
         [DataMember(Name = "device_count", IsRequired = false, EmitDefaultValue = false)]
         public float DeviceCount { get; set; }
 
+        /// <summary>
+        /// Display name for the space.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Geographic coordinates (latitude and longitude) of the space.
+        /// </summary>
         [DataMember(Name = "geolocation", IsRequired = false, EmitDefaultValue = false)]
         public SpaceGeolocation? Geolocation { get; set; }
 
+        /// <summary>
+        /// Name of the space.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// ID of the space.
+        /// </summary>
         [DataMember(Name = "space_id", IsRequired = false, EmitDefaultValue = false)]
         public string SpaceId { get; set; }
 
+        /// <summary>
+        /// Unique key for the space within the workspace.
+        /// </summary>
         [DataMember(Name = "space_key", IsRequired = false, EmitDefaultValue = false)]
         public string? SpaceKey { get; set; }
 
+        /// <summary>
+        /// ID of the workspace associated with the space.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -113,15 +149,27 @@ namespace Seam.Model
             TimeZone = timeZone;
         }
 
+        /// <summary>
+        /// Postal address for the space.
+        /// </summary>
         [DataMember(Name = "address", IsRequired = false, EmitDefaultValue = false)]
         public string? Address { get; set; }
 
+        /// <summary>
+        /// Default check-in time for reservations at the space, as HH:mm or HH:mm:ss.
+        /// </summary>
         [DataMember(Name = "default_checkin_time", IsRequired = false, EmitDefaultValue = false)]
         public string? DefaultCheckinTime { get; set; }
 
+        /// <summary>
+        /// Default check-out time for reservations at the space, as HH:mm or HH:mm:ss.
+        /// </summary>
         [DataMember(Name = "default_checkout_time", IsRequired = false, EmitDefaultValue = false)]
         public string? DefaultCheckoutTime { get; set; }
 
+        /// <summary>
+        /// IANA time zone for the space, e.g. America/Los_Angeles.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
@@ -157,9 +205,15 @@ namespace Seam.Model
             Longitude = longitude;
         }
 
+        /// <summary>
+        /// Latitude of the space, in decimal degrees.
+        /// </summary>
         [DataMember(Name = "latitude", IsRequired = false, EmitDefaultValue = false)]
         public float Latitude { get; set; }
 
+        /// <summary>
+        /// Longitude of the space, in decimal degrees.
+        /// </summary>
         [DataMember(Name = "longitude", IsRequired = false, EmitDefaultValue = false)]
         public float Longitude { get; set; }
 

--- a/output/csharp/src/Seam/Model/ThermostatDailyProgram.cs
+++ b/output/csharp/src/Seam/Model/ThermostatDailyProgram.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a thermostat daily program, consisting of a set of periods, each of which has a starting time and the key that identifies the climate preset to apply at the starting time.
+    /// </summary>
     [DataContract(Name = "seamModel_thermostatDailyProgram_model")]
     public class ThermostatDailyProgram
     {
@@ -31,18 +34,33 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Date and time at which the thermostat daily program was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat device on which the thermostat daily program is configured.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the thermostat daily program.
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Array of thermostat daily program periods.
+        /// </summary>
         [DataMember(Name = "periods", IsRequired = false, EmitDefaultValue = false)]
         public List<ThermostatDailyProgramPeriods> Periods { get; set; }
 
+        /// <summary>
+        /// ID of the thermostat daily program.
+        /// </summary>
         [DataMember(
             Name = "thermostat_daily_program_id",
             IsRequired = false,
@@ -50,6 +68,9 @@ namespace Seam.Model
         )]
         public string ThermostatDailyProgramId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the thermostat daily program.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -88,9 +109,15 @@ namespace Seam.Model
             StartsAtTime = startsAtTime;
         }
 
+        /// <summary>
+        /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// Time at which the thermostat daily program period starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at_time", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAtTime { get; set; }
 

--- a/output/csharp/src/Seam/Model/ThermostatSchedule.cs
+++ b/output/csharp/src/Seam/Model/ThermostatSchedule.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.
+    /// </summary>
     [DataContract(Name = "seamModel_thermostatSchedule_model")]
     public class ThermostatSchedule
     {
@@ -41,24 +44,45 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "climate_preset_key", IsRequired = false, EmitDefaultValue = false)]
         public string ClimatePresetKey { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<ThermostatScheduleErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Indicates whether a person at the thermostat can change the thermostat&apos;s settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.
+        /// </summary>
         [DataMember(Name = "is_override_allowed", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOverrideAllowed { get; set; }
 
+        /// <summary>
+        /// Number of minutes for which a person at the thermostat can change the thermostat&apos;s settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).
+        /// </summary>
         [DataMember(
             Name = "max_override_period_minutes",
             IsRequired = false,
@@ -66,15 +90,27 @@ namespace Seam.Model
         )]
         public int? MaxOverridePeriodMinutes { get; set; }
 
+        /// <summary>
+        /// User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string StartsAt { get; set; }
 
+        /// <summary>
+        /// ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+        /// </summary>
         [DataMember(Name = "thermostat_schedule_id", IsRequired = false, EmitDefaultValue = false)]
         public string ThermostatScheduleId { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the thermostat schedule.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -115,12 +151,21 @@ namespace Seam.Model
             Message = message;
         }
 
+        /// <summary>
+        /// Date and time at which Seam created the error.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier of the type of error. Enables quick recognition and categorization of the issue.
+        /// </summary>
         [DataMember(Name = "error_code", IsRequired = false, EmitDefaultValue = false)]
         public string ErrorCode { get; set; }
 
+        /// <summary>
+        /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 

--- a/output/csharp/src/Seam/Model/UnmanagedAccessCode.cs
+++ b/output/csharp/src/Seam/Model/UnmanagedAccessCode.cs
@@ -8,6 +8,19 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an [unmanaged smart lock access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes).
+    ///
+    /// An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.
+    ///
+    /// When you create an access code on a device in Seam, it is created as a managed access code. Access codes that exist on a device that were not created through Seam are considered unmanaged codes. We strictly limit the operations that can be performed on unmanaged codes.
+    ///
+    /// Prior to using Seam to manage your devices, you may have used another lock management system to manage the access codes on your devices. Where possible, we help you keep any existing access codes on devices and transition those codes to ones managed by your Seam workspace.
+    ///
+    /// Not all providers support unmanaged access codes. The following providers do not support unmanaged access codes:
+    ///
+    /// - [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)
+    /// </summary>
     [DataContract(Name = "seamModel_unmanagedAccessCode_model")]
     public class UnmanagedAccessCode
     {
@@ -165,12 +178,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "provider_issue";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -178,6 +197,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -220,12 +242,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_set_on_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -233,6 +261,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -275,12 +306,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "failed_to_remove_from_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -288,6 +325,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -334,12 +374,18 @@ namespace Seam.Model
                 UnmanagedAccessCodeId = unmanagedAccessCodeId;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "duplicate_code_on_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -347,6 +393,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// ID of the managed access code that conflicts with this managed access code, when Seam can identify it.
+            /// </summary>
             [DataMember(
                 Name = "managed_access_code_id",
                 IsRequired = false,
@@ -354,9 +403,15 @@ namespace Seam.Model
             )]
             public string? ManagedAccessCodeId { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// ID of the unmanaged access code that conflicts with this managed access code, when Seam can identify it.
+            /// </summary>
             [DataMember(
                 Name = "unmanaged_access_code_id",
                 IsRequired = false,
@@ -406,12 +461,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "no_space_for_access_code_on_device";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -419,6 +480,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -470,6 +534,9 @@ namespace Seam.Model
                 ModifiedFields = modifiedFields;
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ChangeTypeEnum
             {
@@ -483,15 +550,24 @@ namespace Seam.Model
                 Removed = 2,
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [DataMember(Name = "change_type", IsRequired = false, EmitDefaultValue = false)]
             public UnmanagedAccessCodeErrorsConflictingExternalModification.ChangeTypeEnum? ChangeType { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "conflicting_external_modification";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -499,9 +575,15 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// List of fields that were changed externally, with their previous and new values.
+            /// </summary>
             [DataMember(Name = "modified_fields", IsRequired = false, EmitDefaultValue = false)]
             public List<UnmanagedAccessCodeErrorsConflictingExternalModificationModifiedFields>? ModifiedFields { get; set; }
 
@@ -544,12 +626,21 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            /// </summary>
             [DataMember(Name = "field", IsRequired = false, EmitDefaultValue = false)]
             public string Field { get; set; }
 
+            /// <summary>
+            /// The previous value of the field.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public string? From { get; set; }
 
+            /// <summary>
+            /// The new value of the field.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public string? To { get; set; }
 
@@ -592,12 +683,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "access_code_inactive";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -605,6 +702,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -647,12 +747,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string? CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "insufficient_permissions";
 
+            /// <summary>
+            /// Indicates that this is an access code error.
+            /// </summary>
             [DataMember(
                 Name = "is_access_code_error",
                 IsRequired = false,
@@ -660,6 +766,9 @@ namespace Seam.Model
             )]
             public bool IsAccessCodeError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -704,12 +813,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "account_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -717,9 +832,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -767,12 +888,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -780,9 +907,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -827,12 +960,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "dormakaba_sites_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -840,9 +979,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -885,15 +1030,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_offline";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -936,15 +1090,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_removed";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -987,15 +1150,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "hub_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1038,15 +1210,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1089,15 +1270,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "empty_backup_access_code_pool";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1140,15 +1330,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "august_lock_not_authorized";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1191,15 +1390,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "missing_device_credentials";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1242,15 +1450,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "auxiliary_heat_running";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1293,15 +1510,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "subscription_required";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1346,15 +1572,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "bridge_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -1362,6 +1597,9 @@ namespace Seam.Model
             )]
             public bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1403,6 +1641,9 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1426,6 +1667,9 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Current status of the access code within the operational lifecycle. `set` indicates that the code is active and operational. `unset` indicates that the code exists on the provider but is not usable on the device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum StatusEnum
         {
@@ -1439,6 +1683,9 @@ namespace Seam.Model
             Unset = 2,
         }
 
+        /// <summary>
+        /// Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum TypeEnum
         {
@@ -1527,9 +1774,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1576,9 +1829,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1632,6 +1891,9 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [JsonConverter(typeof(SafeStringEnumConverter))]
             public enum ChangeTypeEnum
             {
@@ -1645,15 +1907,27 @@ namespace Seam.Model
                 Removed = 2,
             }
 
+            /// <summary>
+            /// Indicates the type of external modification. `modified` means the code&apos;s PIN or schedule was changed. `removed` means the code was deleted from the device.
+            /// </summary>
             [DataMember(Name = "change_type", IsRequired = false, EmitDefaultValue = false)]
             public UnmanagedAccessCodeWarningsExternalModificationInEffect.ChangeTypeEnum? ChangeType { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
+            /// <summary>
+            /// List of fields that were changed externally, with their previous and new values.
+            /// </summary>
             [DataMember(Name = "modified_fields", IsRequired = false, EmitDefaultValue = false)]
             public List<UnmanagedAccessCodeWarningsExternalModificationInEffectModifiedFields>? ModifiedFields { get; set; }
 
@@ -1699,12 +1973,21 @@ namespace Seam.Model
                 To = to;
             }
 
+            /// <summary>
+            /// The name of the field that was changed (e.g. `code`, `starts_at`, `ends_at`).
+            /// </summary>
             [DataMember(Name = "field", IsRequired = false, EmitDefaultValue = false)]
             public string Field { get; set; }
 
+            /// <summary>
+            /// The previous value of the field.
+            /// </summary>
             [DataMember(Name = "from", IsRequired = false, EmitDefaultValue = false)]
             public string? From { get; set; }
 
+            /// <summary>
+            /// The new value of the field.
+            /// </summary>
             [DataMember(Name = "to", IsRequired = false, EmitDefaultValue = false)]
             public string? To { get; set; }
 
@@ -1745,9 +2028,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1794,9 +2083,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1843,9 +2138,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1892,9 +2193,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1939,9 +2246,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1985,9 +2298,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2031,9 +2350,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2080,9 +2405,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2129,9 +2460,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string? CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2155,12 +2492,21 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Unique identifier for the access code.
+        /// </summary>
         [DataMember(Name = "access_code_id", IsRequired = false, EmitDefaultValue = false)]
         public string AccessCodeId { get; set; }
 
+        /// <summary>
+        /// Indicates that Seam cannot convert this unmanaged access code to a managed access code. Some providers do not support management of unmanaged access codes through API integrations.
+        /// </summary>
         [DataMember(Name = "cannot_be_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool? CannotBeManaged { get; set; }
 
+        /// <summary>
+        /// Indicates that Seam cannot delete this unmanaged access code through the provider. If this access code needs to be deleted, it will only be possible from the manufacturer app.
+        /// </summary>
         [DataMember(
             Name = "cannot_delete_unmanaged_access_code",
             IsRequired = false,
@@ -2168,15 +2514,27 @@ namespace Seam.Model
         )]
         public bool? CannotDeleteUnmanagedAccessCode { get; set; }
 
+        /// <summary>
+        /// Code used for access. Typically, a numeric or alphanumeric string.
+        /// </summary>
         [DataMember(Name = "code", IsRequired = false, EmitDefaultValue = false)]
         public string? Code { get; set; }
 
+        /// <summary>
+        /// Date and time at which the access code was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the device associated with the access code.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Metadata for a dormakaba Oracode unmanaged access code. Only present for unmanaged access codes from dormakaba Oracode devices.
+        /// </summary>
         [DataMember(
             Name = "dormakaba_oracode_metadata",
             IsRequired = false,
@@ -2184,30 +2542,57 @@ namespace Seam.Model
         )]
         public UnmanagedAccessCodeDormakabaOracodeMetadata? DormakabaOracodeMetadata { get; set; }
 
+        /// <summary>
+        /// Date and time after which the time-bound access code becomes inactive.
+        /// </summary>
         [DataMember(Name = "ends_at", IsRequired = false, EmitDefaultValue = false)]
         public string? EndsAt { get; set; }
 
+        /// <summary>
+        /// Errors associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<UnmanagedAccessCodeErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Indicates that Seam does not manage the access code.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Name of the access code. Enables administrators and users to identify the access code easily, especially when there are numerous access codes. Note that the name provided on Seam is used to identify the code on Seam and is not necessarily the name that will appear in the lock provider&apos;s app or on the device. This is because lock providers may have constraints on names, such as length, uniqueness, or characters that can be used. In addition, some lock providers may break down names into components such as `first_name` and `last_name`. To provide a consistent experience, Seam identifies the code on Seam by its name but may modify the name that appears on the lock provider&apos;s app or on the device. For example, Seam may add additional characters or truncate the name to meet provider constraints. To help your users identify codes set by Seam, Seam provides the name exactly as it appears on the lock provider&apos;s app or on the device as a separate property called `appearance`. This is an object with a `name` property and, optionally, `first_name` and `last_name` properties (for providers that break down a name into components).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string? Name { get; set; }
 
+        /// <summary>
+        /// Date and time at which the time-bound access code becomes active.
+        /// </summary>
         [DataMember(Name = "starts_at", IsRequired = false, EmitDefaultValue = false)]
         public string? StartsAt { get; set; }
 
+        /// <summary>
+        /// Current status of the access code within the operational lifecycle. `set` indicates that the code is active and operational. `unset` indicates that the code exists on the provider but is not usable on the device.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedAccessCode.StatusEnum Status { get; set; }
 
+        /// <summary>
+        /// Type of the access code. `ongoing` access codes are active continuously until deactivated manually. `time_bound` access codes have a specific duration.
+        /// </summary>
         [DataMember(Name = "type", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedAccessCode.TypeEnum Type { get; set; }
 
+        /// <summary>
+        /// Warnings associated with the [access code](https://docs.seam.co/low-level-apis/smart-locks/access-codes).
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<UnmanagedAccessCodeWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the Seam workspace associated with the access code.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -2258,27 +2643,51 @@ namespace Seam.Model
             UserLevelName = userLevelName;
         }
 
+        /// <summary>
+        /// Indicates whether the stay can be cancelled via the Dormakaba Oracode API.
+        /// </summary>
         [DataMember(Name = "is_cancellable", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsCancellable { get; set; }
 
+        /// <summary>
+        /// Indicates whether early check-in is available for this stay.
+        /// </summary>
         [DataMember(Name = "is_early_checkin_able", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsEarlyCheckinAble { get; set; }
 
+        /// <summary>
+        /// Indicates whether the stay can be extended via the Dormakaba Oracode API.
+        /// </summary>
         [DataMember(Name = "is_extendable", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsExtendable { get; set; }
 
+        /// <summary>
+        /// Indicates whether the access code can be overridden. When false, the maximum number of overrides has been reached.
+        /// </summary>
         [DataMember(Name = "is_overridable", IsRequired = false, EmitDefaultValue = false)]
         public bool? IsOverridable { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode site name associated with this access code.
+        /// </summary>
         [DataMember(Name = "site_name", IsRequired = false, EmitDefaultValue = false)]
         public string? SiteName { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode stay ID associated with this access code.
+        /// </summary>
         [DataMember(Name = "stay_id", IsRequired = false, EmitDefaultValue = false)]
         public float? StayId { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode user level ID associated with this access code.
+        /// </summary>
         [DataMember(Name = "user_level_id", IsRequired = false, EmitDefaultValue = false)]
         public string? UserLevelId { get; set; }
 
+        /// <summary>
+        /// Dormakaba Oracode user level name associated with this access code.
+        /// </summary>
         [DataMember(Name = "user_level_name", IsRequired = false, EmitDefaultValue = false)]
         public string? UserLevelName { get; set; }
 

--- a/output/csharp/src/Seam/Model/UnmanagedDevice.cs
+++ b/output/csharp/src/Seam/Model/UnmanagedDevice.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/low-level-apis/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+    /// </summary>
     [DataContract(Name = "seamModel_unmanagedDevice_model")]
     public class UnmanagedDevice
     {
@@ -85,6 +88,9 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum CapabilitiesSupportedEnum
         {
@@ -110,6 +116,9 @@ namespace Seam.Model
             Phone = 6,
         }
 
+        /// <summary>
+        /// Type of the device.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum DeviceTypeEnum
         {
@@ -320,12 +329,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "account_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -333,9 +348,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -382,12 +403,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "salto_ks_subscription_limit_exceeded";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -395,9 +422,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -442,12 +475,18 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "dormakaba_sites_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -455,9 +494,15 @@ namespace Seam.Model
             )]
             public bool IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Indicates that the error is not a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -500,15 +545,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_offline";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -551,15 +605,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_removed";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -602,15 +665,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "hub_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -653,15 +725,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "device_disconnected";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -704,15 +785,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "empty_backup_access_code_pool";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -755,15 +845,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "august_lock_not_authorized";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -806,15 +905,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "missing_device_credentials";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -857,15 +965,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "auxiliary_heat_running";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -908,15 +1025,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "subscription_required";
 
+            /// <summary>
+            /// Indicates that the error is a device error.
+            /// </summary>
             [DataMember(Name = "is_device_error", IsRequired = false, EmitDefaultValue = false)]
             public bool IsDeviceError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -961,15 +1087,24 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "bridge_disconnected";
 
+            /// <summary>
+            /// Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
+            /// </summary>
             [DataMember(Name = "is_bridge_error", IsRequired = false, EmitDefaultValue = false)]
             public bool? IsBridgeError { get; set; }
 
+            /// <summary>
+            /// Indicates whether the error is related specifically to the connected account.
+            /// </summary>
             [DataMember(
                 Name = "is_connected_account_error",
                 IsRequired = false,
@@ -977,6 +1112,9 @@ namespace Seam.Model
             )]
             public bool? IsConnectedAccountError { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1020,9 +1158,15 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1182,9 +1326,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1228,9 +1378,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1276,9 +1432,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1325,9 +1487,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1372,9 +1540,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1418,9 +1592,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1464,9 +1644,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1510,9 +1696,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1556,9 +1748,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1602,9 +1800,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1648,9 +1852,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1694,9 +1904,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1740,9 +1956,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1789,9 +2011,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1839,9 +2067,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1886,9 +2120,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1932,9 +2172,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -1978,9 +2224,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2024,9 +2276,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2070,9 +2328,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2116,9 +2380,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2165,9 +2435,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2212,9 +2488,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2258,9 +2540,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2304,9 +2592,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2350,9 +2644,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2400,6 +2700,9 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Number of active access codes on the device when the warning was set.
+            /// </summary>
             [DataMember(
                 Name = "active_access_code_count",
                 IsRequired = false,
@@ -2407,9 +2710,15 @@ namespace Seam.Model
             )]
             public int ActiveAccessCodeCount { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Maximum number of active access codes supported by the device.
+            /// </summary>
             [DataMember(
                 Name = "max_active_access_code_count",
                 IsRequired = false,
@@ -2417,6 +2726,9 @@ namespace Seam.Model
             )]
             public int MaxActiveAccessCodeCount { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2460,9 +2772,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2509,9 +2827,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -2535,18 +2859,33 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Indicates whether the lock supports configuring automatic locking.
+        /// </summary>
         [DataMember(Name = "can_configure_auto_lock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanConfigureAutoLock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports cooling.
+        /// </summary>
         [DataMember(Name = "can_hvac_cool", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacCool { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports heating.
+        /// </summary>
         [DataMember(Name = "can_hvac_heat", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacHeat { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports simultaneous heating and cooling.
+        /// </summary>
         [DataMember(Name = "can_hvac_heat_cool", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanHvacHeatCool { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports programming offline access codes.
+        /// </summary>
         [DataMember(
             Name = "can_program_offline_access_codes",
             IsRequired = false,
@@ -2554,6 +2893,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramOfflineAccessCodes { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports programming online access codes.
+        /// </summary>
         [DataMember(
             Name = "can_program_online_access_codes",
             IsRequired = false,
@@ -2561,6 +2903,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramOnlineAccessCodes { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports different climate programs for each day of the week.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_different_each_day",
             IsRequired = false,
@@ -2568,6 +2913,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsDifferentEachDay { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports a single climate program applied to every day.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_same_each_day",
             IsRequired = false,
@@ -2575,6 +2923,9 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsSameEachDay { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports weekday/weekend climate programs.
+        /// </summary>
         [DataMember(
             Name = "can_program_thermostat_programs_as_weekday_weekend",
             IsRequired = false,
@@ -2582,12 +2933,21 @@ namespace Seam.Model
         )]
         public bool? CanProgramThermostatProgramsAsWeekdayWeekend { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports remote locking.
+        /// </summary>
         [DataMember(Name = "can_remotely_lock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanRemotelyLock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports remote unlocking.
+        /// </summary>
         [DataMember(Name = "can_remotely_unlock", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanRemotelyUnlock { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat supports running climate programs.
+        /// </summary>
         [DataMember(
             Name = "can_run_thermostat_programs",
             IsRequired = false,
@@ -2595,9 +2955,15 @@ namespace Seam.Model
         )]
         public bool? CanRunThermostatPrograms { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating connection in a sandbox.
+        /// </summary>
         [DataMember(Name = "can_simulate_connection", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanSimulateConnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating disconnection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_disconnection",
             IsRequired = false,
@@ -2605,6 +2971,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateDisconnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the hub supports simulating connection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_hub_connection",
             IsRequired = false,
@@ -2612,6 +2981,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateHubConnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the hub supports simulating disconnection in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_hub_disconnection",
             IsRequired = false,
@@ -2619,6 +2991,9 @@ namespace Seam.Model
         )]
         public bool? CanSimulateHubDisconnection { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating a paid subscription in a sandbox.
+        /// </summary>
         [DataMember(
             Name = "can_simulate_paid_subscription",
             IsRequired = false,
@@ -2626,48 +3001,93 @@ namespace Seam.Model
         )]
         public bool? CanSimulatePaidSubscription { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device supports simulating removal in a sandbox.
+        /// </summary>
         [DataMember(Name = "can_simulate_removal", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanSimulateRemoval { get; set; }
 
+        /// <summary>
+        /// Indicates whether the thermostat can be turned off.
+        /// </summary>
         [DataMember(Name = "can_turn_off_hvac", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanTurnOffHvac { get; set; }
 
+        /// <summary>
+        /// Indicates whether the lock supports unlocking with an access code.
+        /// </summary>
         [DataMember(Name = "can_unlock_with_code", IsRequired = false, EmitDefaultValue = false)]
         public bool? CanUnlockWithCode { get; set; }
 
+        /// <summary>
+        /// Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
+        /// </summary>
         [DataMember(Name = "capabilities_supported", IsRequired = false, EmitDefaultValue = false)]
         public List<UnmanagedDevice.CapabilitiesSupportedEnum> CapabilitiesSupported { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the account associated with the device.
+        /// </summary>
         [DataMember(Name = "connected_account_id", IsRequired = false, EmitDefaultValue = false)]
         public string ConnectedAccountId { get; set; }
 
+        /// <summary>
+        /// Date and time at which the device object was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.
+        /// </summary>
         [DataMember(Name = "custom_metadata", IsRequired = false, EmitDefaultValue = false)]
         public object CustomMetadata { get; set; }
 
+        /// <summary>
+        /// ID of the device.
+        /// </summary>
         [DataMember(Name = "device_id", IsRequired = false, EmitDefaultValue = false)]
         public string DeviceId { get; set; }
 
+        /// <summary>
+        /// Type of the device.
+        /// </summary>
         [DataMember(Name = "device_type", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDevice.DeviceTypeEnum DeviceType { get; set; }
 
+        /// <summary>
+        /// Array of errors associated with the device. Each error object within the array contains two fields: `error_code` and `message`. `error_code` is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<UnmanagedDeviceErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Indicates that Seam does not manage the device.
+        /// </summary>
         [DataMember(Name = "is_managed", IsRequired = false, EmitDefaultValue = false)]
         public bool IsManaged { get; set; }
 
+        /// <summary>
+        /// Location information for the device.
+        /// </summary>
         [DataMember(Name = "location", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDeviceLocation? Location { get; set; }
 
+        /// <summary>
+        /// properties of the device.
+        /// </summary>
         [DataMember(Name = "properties", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDeviceProperties Properties { get; set; }
 
+        /// <summary>
+        /// Array of warnings associated with the device. Each warning object within the array contains two fields: `warning_code` and `message`. `warning_code` is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. `message` provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<UnmanagedDeviceWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the Seam workspace associated with the device.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -2708,12 +3128,22 @@ namespace Seam.Model
             Timezone = timezone;
         }
 
+        /// <summary>
+        /// Name of the device location.
+        /// </summary>
         [DataMember(Name = "location_name", IsRequired = false, EmitDefaultValue = false)]
         public string? LocationName { get; set; }
 
+        /// <summary>
+        /// Time zone of the device location.
+        /// </summary>
         [DataMember(Name = "time_zone", IsRequired = false, EmitDefaultValue = false)]
         public string? TimeZone { get; set; }
 
+        /// <summary>
+        /// Time zone of the device location.
+        /// </summary>
+        [Obsolete("Use `time_zone` instead.")]
         [DataMember(Name = "timezone", IsRequired = false, EmitDefaultValue = false)]
         public string? Timezone { get; set; }
 
@@ -2770,30 +3200,59 @@ namespace Seam.Model
             OnlineAccessCodesEnabled = onlineAccessCodesEnabled;
         }
 
+        /// <summary>
+        /// Accessory keypad properties and state.
+        /// </summary>
         [DataMember(Name = "accessory_keypad", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDevicePropertiesAccessoryKeypad? AccessoryKeypad { get; set; }
 
+        /// <summary>
+        /// Represents the current status of the battery charge level.
+        /// </summary>
         [DataMember(Name = "battery", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDevicePropertiesBattery? Battery { get; set; }
 
+        /// <summary>
+        /// Indicates the battery level of the device as a decimal value between 0 and 1, inclusive.
+        /// </summary>
         [DataMember(Name = "battery_level", IsRequired = false, EmitDefaultValue = false)]
         public float? BatteryLevel { get; set; }
 
+        /// <summary>
+        /// Alt text for the device image.
+        /// </summary>
         [DataMember(Name = "image_alt_text", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageAltText { get; set; }
 
+        /// <summary>
+        /// Image URL for the device.
+        /// </summary>
         [DataMember(Name = "image_url", IsRequired = false, EmitDefaultValue = false)]
         public string? ImageUrl { get; set; }
 
+        /// <summary>
+        /// Manufacturer of the device. When a device, such as a smart lock, is connected through a smart hub, the manufacturer of the device might be different from that of the smart hub.
+        /// </summary>
         [DataMember(Name = "manufacturer", IsRequired = false, EmitDefaultValue = false)]
         public string? Manufacturer { get; set; }
 
+        /// <summary>
+        /// Device model-related properties.
+        /// </summary>
         [DataMember(Name = "model", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDevicePropertiesModel Model { get; set; }
 
+        /// <summary>
+        /// Name of the device.
+        /// </summary>
+        [Obsolete("use device.display_name instead")]
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Indicates whether it is currently possible to use offline access codes for the device.
+        /// </summary>
+        [Obsolete("use device.can_program_offline_access_codes")]
         [DataMember(
             Name = "offline_access_codes_enabled",
             IsRequired = false,
@@ -2801,9 +3260,16 @@ namespace Seam.Model
         )]
         public bool? OfflineAccessCodesEnabled { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device is online.
+        /// </summary>
         [DataMember(Name = "online", IsRequired = false, EmitDefaultValue = false)]
         public bool Online { get; set; }
 
+        /// <summary>
+        /// Indicates whether it is currently possible to use online access codes for the device.
+        /// </summary>
+        [Obsolete("use device.can_program_online_access_codes")]
         [DataMember(
             Name = "online_access_codes_enabled",
             IsRequired = false,
@@ -2846,9 +3312,15 @@ namespace Seam.Model
             IsConnected = isConnected;
         }
 
+        /// <summary>
+        /// Keypad battery properties.
+        /// </summary>
         [DataMember(Name = "battery", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDevicePropertiesAccessoryKeypadBattery? Battery { get; set; }
 
+        /// <summary>
+        /// Indicates if an accessory keypad is connected to the device.
+        /// </summary>
         [DataMember(Name = "is_connected", IsRequired = false, EmitDefaultValue = false)]
         public bool IsConnected { get; set; }
 
@@ -2921,6 +3393,9 @@ namespace Seam.Model
             Status = status;
         }
 
+        /// <summary>
+        /// Represents the current status of the battery charge level. Values are `critical`, which indicates an extremely low level, suggesting imminent shutdown or an urgent need for charging; `low`, which signifies that the battery is under the preferred threshold and should be charged soon; `good`, which denotes a satisfactory charge level, adequate for normal use without the immediate need for recharging; and `full`, which represents a battery that is fully charged, providing the maximum duration of usage.
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum StatusEnum
         {
@@ -2940,9 +3415,15 @@ namespace Seam.Model
             Full = 4,
         }
 
+        /// <summary>
+        /// Battery charge level as a value between 0 and 1, inclusive.
+        /// </summary>
         [DataMember(Name = "level", IsRequired = false, EmitDefaultValue = false)]
         public float Level { get; set; }
 
+        /// <summary>
+        /// Represents the current status of the battery charge level. Values are `critical`, which indicates an extremely low level, suggesting imminent shutdown or an urgent need for charging; `low`, which signifies that the battery is under the preferred threshold and should be charged soon; `good`, which denotes a satisfactory charge level, adequate for normal use without the immediate need for recharging; and `full`, which represents a battery that is fully charged, providing the maximum duration of usage.
+        /// </summary>
         [DataMember(Name = "status", IsRequired = false, EmitDefaultValue = false)]
         public UnmanagedDevicePropertiesBattery.StatusEnum Status { get; set; }
 
@@ -2991,6 +3472,7 @@ namespace Seam.Model
             OnlineAccessCodesSupported = onlineAccessCodesSupported;
         }
 
+        [Obsolete("use device.properties.model.can_connect_accessory_keypad")]
         [DataMember(
             Name = "accessory_keypad_supported",
             IsRequired = false,
@@ -2998,6 +3480,9 @@ namespace Seam.Model
         )]
         public bool? AccessoryKeypadSupported { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device can connect a accessory keypad.
+        /// </summary>
         [DataMember(
             Name = "can_connect_accessory_keypad",
             IsRequired = false,
@@ -3005,12 +3490,21 @@ namespace Seam.Model
         )]
         public bool? CanConnectAccessoryKeypad { get; set; }
 
+        /// <summary>
+        /// Display name of the device model.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Indicates whether the device has a built in accessory keypad.
+        /// </summary>
         [DataMember(Name = "has_built_in_keypad", IsRequired = false, EmitDefaultValue = false)]
         public bool? HasBuiltInKeypad { get; set; }
 
+        /// <summary>
+        /// Display name that corresponds to the manufacturer-specific terminology for the device.
+        /// </summary>
         [DataMember(
             Name = "manufacturer_display_name",
             IsRequired = false,
@@ -3018,6 +3512,7 @@ namespace Seam.Model
         )]
         public string ManufacturerDisplayName { get; set; }
 
+        [Obsolete("use device.can_program_offline_access_codes.")]
         [DataMember(
             Name = "offline_access_codes_supported",
             IsRequired = false,
@@ -3025,6 +3520,7 @@ namespace Seam.Model
         )]
         public bool? OfflineAccessCodesSupported { get; set; }
 
+        [Obsolete("use device.can_program_online_access_codes.")]
         [DataMember(
             Name = "online_access_codes_supported",
             IsRequired = false,

--- a/output/csharp/src/Seam/Model/UserIdentity.cs
+++ b/output/csharp/src/Seam/Model/UserIdentity.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
+    /// </summary>
     [DataContract(Name = "seamModel_userIdentity_model")]
     public class UserIdentity
     {
@@ -83,18 +86,30 @@ namespace Seam.Model
                 Message = message;
             }
 
+            /// <summary>
+            /// ID of the access system that the user identity is associated with.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public override string AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that has an issue.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public override string AcsUserId { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "issue_with_acs_user";
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -142,15 +157,27 @@ namespace Seam.Model
             [DataMember(Name = "error_code", IsRequired = true, EmitDefaultValue = false)]
             public override string ErrorCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// ID of the access system that the user identity is associated with.
+            /// </summary>
             [DataMember(Name = "acs_system_id", IsRequired = false, EmitDefaultValue = false)]
             public override string AcsSystemId { get; set; }
 
+            /// <summary>
+            /// ID of the access system user that has an issue.
+            /// </summary>
             [DataMember(Name = "acs_user_id", IsRequired = false, EmitDefaultValue = false)]
             public override string AcsUserId { get; set; }
 
+            /// <summary>
+            /// Date and time at which Seam created the error.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the error. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -209,9 +236,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -258,9 +291,15 @@ namespace Seam.Model
                 WarningCode = warningCode;
             }
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -308,9 +347,15 @@ namespace Seam.Model
             [DataMember(Name = "warning_code", IsRequired = true, EmitDefaultValue = false)]
             public override string WarningCode { get; } = "unrecognized";
 
+            /// <summary>
+            /// Date and time at which Seam created the warning.
+            /// </summary>
             [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
             public override string CreatedAt { get; set; }
 
+            /// <summary>
+            /// Detailed description of the warning. Provides insights into the issue and potentially how to rectify it.
+            /// </summary>
             [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
             public override string Message { get; set; }
 
@@ -334,36 +379,69 @@ namespace Seam.Model
             }
         }
 
+        /// <summary>
+        /// Array of access system user IDs associated with the user identity.
+        /// </summary>
         [DataMember(Name = "acs_user_ids", IsRequired = false, EmitDefaultValue = false)]
         public List<string> AcsUserIds { get; set; }
 
+        /// <summary>
+        /// Date and time at which the user identity was created.
+        /// </summary>
         [DataMember(Name = "created_at", IsRequired = false, EmitDefaultValue = false)]
         public string CreatedAt { get; set; }
 
+        /// <summary>
+        /// Display name for the user identity.
+        /// </summary>
         [DataMember(Name = "display_name", IsRequired = false, EmitDefaultValue = false)]
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Unique email address for the user identity.
+        /// </summary>
         [DataMember(Name = "email_address", IsRequired = false, EmitDefaultValue = false)]
         public string? EmailAddress { get; set; }
 
+        /// <summary>
+        /// Array of errors associated with the user identity. Each error object within the array contains fields like &quot;error_code&quot; and &quot;message.&quot; &quot;error_code&quot; is a string that uniquely identifies the type of error, enabling quick recognition and categorization of the issue. &quot;message&quot; provides a more detailed description of the error, offering insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "errors", IsRequired = false, EmitDefaultValue = false)]
         public List<UserIdentityErrors> Errors { get; set; }
 
+        /// <summary>
+        /// Full name of the user associated with the user identity.
+        /// </summary>
         [DataMember(Name = "full_name", IsRequired = false, EmitDefaultValue = false)]
         public string? FullName { get; set; }
 
+        /// <summary>
+        /// Unique phone number for the user identity in [E.164 format](https://www.itu.int/rec/T-REC-E.164/en) (for example, +15555550100).
+        /// </summary>
         [DataMember(Name = "phone_number", IsRequired = false, EmitDefaultValue = false)]
         public string? PhoneNumber { get; set; }
 
+        /// <summary>
+        /// ID of the user identity.
+        /// </summary>
         [DataMember(Name = "user_identity_id", IsRequired = false, EmitDefaultValue = false)]
         public string UserIdentityId { get; set; }
 
+        /// <summary>
+        /// Unique key for the user identity.
+        /// </summary>
         [DataMember(Name = "user_identity_key", IsRequired = false, EmitDefaultValue = false)]
         public string? UserIdentityKey { get; set; }
 
+        /// <summary>
+        /// Array of warnings associated with the user identity. Each warning object within the array contains two fields: &quot;warning_code&quot; and &quot;message.&quot; &quot;warning_code&quot; is a string that uniquely identifies the type of warning, enabling quick recognition and categorization of the issue. &quot;message&quot; provides a more detailed description of the warning, offering insights into the issue and potentially how to rectify it.
+        /// </summary>
         [DataMember(Name = "warnings", IsRequired = false, EmitDefaultValue = false)]
         public List<UserIdentityWarnings> Warnings { get; set; }
 
+        /// <summary>
+        /// ID of the workspace that contains the user identity.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 

--- a/output/csharp/src/Seam/Model/Webhook.cs
+++ b/output/csharp/src/Seam/Model/Webhook.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a [webhook](https://docs.seam.co/developer-tools/webhooks) that enables you to receive notifications of events. When you create a webhook, specify the endpoint URL at which you want to receive events and the set of event types that you want to receive.
+    /// </summary>
     [DataContract(Name = "seamModel_webhook_model")]
     public class Webhook
     {
@@ -27,15 +30,27 @@ namespace Seam.Model
             WebhookId = webhookId;
         }
 
+        /// <summary>
+        /// Types of events that the [webhook](https://docs.seam.co/developer-tools/webhooks) should receive.
+        /// </summary>
         [DataMember(Name = "event_types", IsRequired = false, EmitDefaultValue = false)]
         public List<string>? EventTypes { get; set; }
 
+        /// <summary>
+        /// Secret associated with the [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         [DataMember(Name = "secret", IsRequired = false, EmitDefaultValue = false)]
         public string? Secret { get; set; }
 
+        /// <summary>
+        /// URL for the [webhook](https://docs.seam.co/developer-tools/webhooks).
+        /// </summary>
         [DataMember(Name = "url", IsRequired = false, EmitDefaultValue = false)]
         public string Url { get; set; }
 
+        /// <summary>
+        /// ID of the webhook.
+        /// </summary>
         [DataMember(Name = "webhook_id", IsRequired = false, EmitDefaultValue = false)]
         public string WebhookId { get; set; }
 

--- a/output/csharp/src/Seam/Model/Workspace.cs
+++ b/output/csharp/src/Seam/Model/Workspace.cs
@@ -8,6 +8,9 @@ using Seam.Model;
 
 namespace Seam.Model
 {
+    /// <summary>
+    /// Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).
+    /// </summary>
     [DataContract(Name = "seamModel_workspace_model")]
     public class Workspace
     {
@@ -39,9 +42,13 @@ namespace Seam.Model
             WorkspaceId = workspaceId;
         }
 
+        /// <summary>
+        /// Company name associated with the [workspace](https://docs.seam.co/core-concepts/workspaces).
+        /// </summary>
         [DataMember(Name = "company_name", IsRequired = false, EmitDefaultValue = false)]
         public string CompanyName { get; set; }
 
+        [Obsolete("Use `company_name` instead.")]
         [DataMember(Name = "connect_partner_name", IsRequired = false, EmitDefaultValue = false)]
         public string? ConnectPartnerName { get; set; }
 
@@ -52,6 +59,9 @@ namespace Seam.Model
         )]
         public WorkspaceConnectWebviewCustomization ConnectWebviewCustomization { get; set; }
 
+        /// <summary>
+        /// Indicates whether publishable key authentication is enabled for this workspace.
+        /// </summary>
         [DataMember(
             Name = "is_publishable_key_auth_enabled",
             IsRequired = false,
@@ -59,21 +69,39 @@ namespace Seam.Model
         )]
         public bool IsPublishableKeyAuthEnabled { get; set; }
 
+        /// <summary>
+        /// Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).
+        /// </summary>
         [DataMember(Name = "is_sandbox", IsRequired = false, EmitDefaultValue = false)]
         public bool IsSandbox { get; set; }
 
+        /// <summary>
+        /// Indicates whether the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is suspended. Seam suspends sandbox workspaces that have not been accessed in 14 days.
+        /// </summary>
         [DataMember(Name = "is_suspended", IsRequired = false, EmitDefaultValue = false)]
         public bool IsSuspended { get; set; }
 
+        /// <summary>
+        /// Name of the [workspace](https://docs.seam.co/core-concepts/workspaces).
+        /// </summary>
         [DataMember(Name = "name", IsRequired = false, EmitDefaultValue = false)]
         public string Name { get; set; }
 
+        /// <summary>
+        /// ID of the organization to which the workspace belongs, or `null` if the workspace is not assigned to an organization.
+        /// </summary>
         [DataMember(Name = "organization_id", IsRequired = false, EmitDefaultValue = false)]
         public string? OrganizationId { get; set; }
 
+        /// <summary>
+        /// Publishable key for the [workspace](https://docs.seam.co/core-concepts/workspaces). This key is used to identify the workspace in client-side applications.
+        /// </summary>
         [DataMember(Name = "publishable_key", IsRequired = false, EmitDefaultValue = false)]
         public string? PublishableKey { get; set; }
 
+        /// <summary>
+        /// ID of the workspace.
+        /// </summary>
         [DataMember(Name = "workspace_id", IsRequired = false, EmitDefaultValue = false)]
         public string WorkspaceId { get; set; }
 
@@ -118,6 +146,9 @@ namespace Seam.Model
             SuccessMessage = successMessage;
         }
 
+        /// <summary>
+        /// Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+        /// </summary>
         [JsonConverter(typeof(SafeStringEnumConverter))]
         public enum LogoShapeEnum
         {
@@ -131,15 +162,27 @@ namespace Seam.Model
             Square = 2,
         }
 
+        /// <summary>
+        /// URL of the inviter logo for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+        /// </summary>
         [DataMember(Name = "inviter_logo_url", IsRequired = false, EmitDefaultValue = false)]
         public string? InviterLogoUrl { get; set; }
 
+        /// <summary>
+        /// Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+        /// </summary>
         [DataMember(Name = "logo_shape", IsRequired = false, EmitDefaultValue = false)]
         public WorkspaceConnectWebviewCustomization.LogoShapeEnum? LogoShape { get; set; }
 
+        /// <summary>
+        /// Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+        /// </summary>
         [DataMember(Name = "primary_button_color", IsRequired = false, EmitDefaultValue = false)]
         public string? PrimaryButtonColor { get; set; }
 
+        /// <summary>
+        /// Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+        /// </summary>
         [DataMember(
             Name = "primary_button_text_color",
             IsRequired = false,
@@ -147,6 +190,9 @@ namespace Seam.Model
         )]
         public string? PrimaryButtonTextColor { get; set; }
 
+        /// <summary>
+        /// Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).
+        /// </summary>
         [DataMember(Name = "success_message", IsRequired = false, EmitDefaultValue = false)]
         public string? SuccessMessage { get; set; }
 

--- a/output/csharp/src/Seam/Seam.csproj
+++ b/output/csharp/src/Seam/Seam.csproj
@@ -7,7 +7,7 @@
 
   <PackageId>Seam</PackageId>
 
-  <PackageVersion>0.97.0</PackageVersion>
+  <PackageVersion>0.98.0</PackageVersion>
 
   <Authors>Seam</Authors>
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,5 +1,25 @@
 import test from 'ava'
 
+import { csDoc, csString } from '../codegen/lib/handlebars-helpers.js'
+
 test('basic test', (t) => {
   t.pass()
+})
+
+test('csDoc emits escaped C# XML documentation for multiline prose', (t) => {
+  t.is(
+    csDoc('Use <device> & "account".\nSecond line.'),
+    [
+      '/// <summary>',
+      '/// Use &lt;device&gt; &amp; &quot;account&quot;.',
+      '/// Second line.',
+      '/// </summary>',
+    ].join('\n'),
+  )
+  t.is(csDoc('  '), '')
+})
+
+test('csString escapes schema deprecation messages', (t) => {
+  t.is(csString('Use "new" at C:\\sdk'), 'Use \\"new\\" at C:\\\\sdk')
+  t.is(csString(), 'Deprecated.')
 })


### PR DESCRIPTION
### Motivation

- Emit C# XML documentation comments and `[Obsolete]` attributes in generated SDK code by using schema prose and deprecation reasons so consumers get richer API docs and deprecation guidance.

### Description

- Add a `documentation` Handlebars partial and include it in templates to render `/// <summary>` XML docs and `[Obsolete]` attributes before classes, enums, properties, and API methods using new helpers.
- Introduce `csDoc` and `csString` helpers in `handlebars-helpers.ts` to escape and format schema text for C# XML comments and string literals, and wire them into templates.
- Extend the model builder in `build-model.ts` to carry `documentation` and `obsoleteMessage` fields (and richer enum value metadata via `EnumValue`) through normalization and class/enum/route construction so templates can render docs and deprecations; update `class-model.ts` types accordingly.
- Regenerate C# output templates to include documentation everywhere (many `output/csharp/src/Seam/Api/*.cs` files updated accordingly).

### Testing

- Regenerated the C# SDK sources with the updated generator and verified the files were produced with XML docs and `[Obsolete]` annotations (diff contains many updated `output/csharp` files). 
- Ran the TypeScript build and tests (`npm run build` and `npm test`) for the codegen package and confirmed they succeeded with no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68d3c532108329a3fa8573d29e170f)