### PR TITLE
fix: Guard against null response data instead of throwing NullReferenceException

### DIFF
--- a/codegen/layouts/partials/route-methods.hbs
+++ b/codegen/layouts/partials/route-methods.hbs
@@ -6,7 +6,7 @@ requestOptions.Data = request;
 {{#if isVoid}}
 _seam.Post<object>("{{path}}", requestOptions);
 {{else}}
-return _seam.Post<{{responseTypeArg}}>("{{path}}", requestOptions).Data.{{returnProp}};
+return _seam.Post<{{responseTypeArg}}>("{{path}}", requestOptions).EnsureData("{{path}}").{{returnProp}};
 {{/if}}
 }
 
@@ -28,7 +28,7 @@ requestOptions.Data = request;
 {{#if isVoid}}
 await _seam.PostAsync<object>("{{path}}", requestOptions);
 {{else}}
-return (await _seam.PostAsync<{{responseTypeArg}}>("{{path}}", requestOptions)).Data.{{returnProp}};
+return (await _seam.PostAsync<{{responseTypeArg}}>("{{path}}", requestOptions)).EnsureData("{{path}}").{{returnProp}};
 {{/if}}
 }
 

--- a/output/csharp/src/Seam.Test/Client/ApiResponseTests.cs
+++ b/output/csharp/src/Seam.Test/Client/ApiResponseTests.cs
@@ -1,0 +1,50 @@
+namespace Seam.Test;
+
+using System.Net;
+using Seam.Client;
+
+public class ApiResponseTests
+{
+    [Fact]
+    public void EnsureDataReturnsDataWhenPresent()
+    {
+        var data = new Api.Locks.ListResponse(devices: new List<Model.Device>());
+        var response = new ApiResponse<Api.Locks.ListResponse>(HttpStatusCode.OK, data, "{}");
+
+        Assert.Same(data, response.EnsureData("/locks/list"));
+    }
+
+    [Fact]
+    public void EnsureDataThrowsSeamExceptionWhenDataIsNull()
+    {
+        var headers = new Multimap<string, string> { { "seam-request-id", "req-123" } };
+        var response = new ApiResponse<Api.Locks.ListResponse>(
+            HttpStatusCode.OK,
+            headers,
+            null!,
+            "<html>unexpected body</html>"
+        );
+
+        var exception = Assert.Throws<SeamException>(() => response.EnsureData("/locks/list"));
+
+        Assert.Equal(200, exception.ErrorCode);
+        Assert.Contains("/locks/list", exception.Message);
+        Assert.Contains("HTTP 200", exception.Message);
+        Assert.Equal("<html>unexpected body</html>", exception.ErrorContent);
+        Assert.Equal(headers, exception.Headers);
+    }
+
+    [Fact]
+    public void EnsureDataIncludesErrorTextInMessageWhenSet()
+    {
+        var response = new ApiResponse<Api.Locks.ListResponse>(HttpStatusCode.OK, null!, "not json")
+        {
+            ErrorText = "Error deserializing response",
+        };
+
+        var exception = Assert.Throws<SeamException>(() => response.EnsureData("/locks/list"));
+
+        Assert.Contains("Error deserializing response", exception.Message);
+        Assert.Equal("not json", exception.ErrorContent);
+    }
+}

--- a/output/csharp/src/Seam/Api/AccessCodes.cs
+++ b/output/csharp/src/Seam/Api/AccessCodes.cs
@@ -281,7 +281,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/access_codes/create", requestOptions)
-                .Data.AccessCode;
+                .EnsureData("/access_codes/create")
+                .AccessCode;
         }
 
         /// <summary>
@@ -336,7 +337,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CreateResponse>("/access_codes/create", requestOptions))
-                .Data
+                .EnsureData("/access_codes/create")
                 .AccessCode;
         }
 
@@ -620,7 +621,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateMultipleResponse>("/access_codes/create_multiple", requestOptions)
-                .Data.AccessCodes;
+                .EnsureData("/access_codes/create_multiple")
+                .AccessCodes;
         }
 
         /// <summary>
@@ -693,7 +695,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_codes/create_multiple")
                 .AccessCodes;
         }
 
@@ -915,7 +917,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GenerateCodeResponse>("/access_codes/generate_code", requestOptions)
-                .Data.GeneratedCode;
+                .EnsureData("/access_codes/generate_code")
+                .GeneratedCode;
         }
 
         /// <summary>
@@ -939,7 +942,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_codes/generate_code")
                 .GeneratedCode;
         }
 
@@ -1055,7 +1058,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/access_codes/get", requestOptions).Data.AccessCode;
+            return _seam
+                .Post<GetResponse>("/access_codes/get", requestOptions)
+                .EnsureData("/access_codes/get")
+                .AccessCode;
         }
 
         /// <summary>
@@ -1082,7 +1088,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/access_codes/get", requestOptions))
-                .Data
+                .EnsureData("/access_codes/get")
                 .AccessCode;
         }
 
@@ -1264,7 +1270,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/access_codes/list", requestOptions).Data.AccessCodes;
+            return _seam
+                .Post<ListResponse>("/access_codes/list", requestOptions)
+                .EnsureData("/access_codes/list")
+                .AccessCodes;
         }
 
         /// <summary>
@@ -1311,7 +1320,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/access_codes/list", requestOptions))
-                .Data
+                .EnsureData("/access_codes/list")
                 .AccessCodes;
         }
 
@@ -1448,7 +1457,8 @@ namespace Seam.Api
                     "/access_codes/pull_backup_access_code",
                     requestOptions
                 )
-                .Data.AccessCode;
+                .EnsureData("/access_codes/pull_backup_access_code")
+                .AccessCode;
         }
 
         /// <summary>
@@ -1490,7 +1500,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_codes/pull_backup_access_code")
                 .AccessCode;
         }
 

--- a/output/csharp/src/Seam/Api/AccessGrants.cs
+++ b/output/csharp/src/Seam/Api/AccessGrants.cs
@@ -414,7 +414,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/access_grants/create", requestOptions)
-                .Data.AccessGrant;
+                .EnsureData("/access_grants/create")
+                .AccessGrant;
         }
 
         /// <summary>
@@ -467,7 +468,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CreateResponse>("/access_grants/create", requestOptions))
-                .Data
+                .EnsureData("/access_grants/create")
                 .AccessGrant;
         }
 
@@ -682,7 +683,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/access_grants/get", requestOptions).Data.AccessGrant;
+            return _seam
+                .Post<GetResponse>("/access_grants/get", requestOptions)
+                .EnsureData("/access_grants/get")
+                .AccessGrant;
         }
 
         /// <summary>
@@ -703,7 +707,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/access_grants/get", requestOptions))
-                .Data
+                .EnsureData("/access_grants/get")
                 .AccessGrant;
         }
 
@@ -890,7 +894,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetRelatedResponse>("/access_grants/get_related", requestOptions)
-                .Data.Batch;
+                .EnsureData("/access_grants/get_related")
+                .Batch;
         }
 
         /// <summary>
@@ -926,7 +931,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_grants/get_related")
                 .Batch;
         }
 
@@ -1134,7 +1139,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/access_grants/list", requestOptions)
-                .Data.AccessGrants;
+                .EnsureData("/access_grants/list")
+                .AccessGrants;
         }
 
         /// <summary>
@@ -1183,7 +1189,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/access_grants/list", requestOptions))
-                .Data
+                .EnsureData("/access_grants/list")
                 .AccessGrants;
         }
 
@@ -1412,7 +1418,8 @@ namespace Seam.Api
                     "/access_grants/request_access_methods",
                     requestOptions
                 )
-                .Data.AccessGrant;
+                .EnsureData("/access_grants/request_access_methods")
+                .AccessGrant;
         }
 
         /// <summary>
@@ -1446,7 +1453,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_grants/request_access_methods")
                 .AccessGrant;
         }
 

--- a/output/csharp/src/Seam/Api/AccessGroupsAcs.cs
+++ b/output/csharp/src/Seam/Api/AccessGroupsAcs.cs
@@ -294,7 +294,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/acs/access_groups/get", requestOptions)
-                .Data.AcsAccessGroup;
+                .EnsureData("/acs/access_groups/get")
+                .AcsAccessGroup;
         }
 
         /// <summary>
@@ -313,7 +314,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/acs/access_groups/get", requestOptions))
-                .Data
+                .EnsureData("/acs/access_groups/get")
                 .AcsAccessGroup;
         }
 
@@ -437,7 +438,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/acs/access_groups/list", requestOptions)
-                .Data.AcsAccessGroups;
+                .EnsureData("/acs/access_groups/list")
+                .AcsAccessGroups;
         }
 
         /// <summary>
@@ -468,7 +470,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/acs/access_groups/list", requestOptions))
-                .Data
+                .EnsureData("/acs/access_groups/list")
                 .AcsAccessGroups;
         }
 
@@ -583,7 +585,8 @@ namespace Seam.Api
                     "/acs/access_groups/list_accessible_entrances",
                     requestOptions
                 )
-                .Data.AcsEntrances;
+                .EnsureData("/acs/access_groups/list_accessible_entrances")
+                .AcsEntrances;
         }
 
         /// <summary>
@@ -611,7 +614,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/access_groups/list_accessible_entrances")
                 .AcsEntrances;
         }
 
@@ -715,7 +718,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListUsersResponse>("/acs/access_groups/list_users", requestOptions)
-                .Data.AcsUsers;
+                .EnsureData("/acs/access_groups/list_users")
+                .AcsUsers;
         }
 
         /// <summary>
@@ -739,7 +743,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/access_groups/list_users")
                 .AcsUsers;
         }
 

--- a/output/csharp/src/Seam/Api/AccessMethods.cs
+++ b/output/csharp/src/Seam/Api/AccessMethods.cs
@@ -111,7 +111,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<AssignCardResponse>("/access_methods/assign_card", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/access_methods/assign_card")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -140,7 +141,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_methods/assign_card")
                 .ActionAttempt;
         }
 
@@ -366,7 +367,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<EncodeResponse>("/access_methods/encode", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/access_methods/encode")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -387,7 +389,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<EncodeResponse>("/access_methods/encode", requestOptions))
-                .Data
+                .EnsureData("/access_methods/encode")
                 .ActionAttempt;
         }
 
@@ -490,7 +492,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/access_methods/get", requestOptions).Data.AccessMethod;
+            return _seam
+                .Post<GetResponse>("/access_methods/get", requestOptions)
+                .EnsureData("/access_methods/get")
+                .AccessMethod;
         }
 
         /// <summary>
@@ -509,7 +514,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/access_methods/get", requestOptions))
-                .Data
+                .EnsureData("/access_methods/get")
                 .AccessMethod;
         }
 
@@ -681,7 +686,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetRelatedResponse>("/access_methods/get_related", requestOptions)
-                .Data.Batch;
+                .EnsureData("/access_methods/get_related")
+                .Batch;
         }
 
         /// <summary>
@@ -715,7 +721,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_methods/get_related")
                 .Batch;
         }
 
@@ -867,7 +873,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/access_methods/list", requestOptions)
-                .Data.AccessMethods;
+                .EnsureData("/access_methods/list")
+                .AccessMethods;
         }
 
         /// <summary>
@@ -902,7 +909,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/access_methods/list", requestOptions))
-                .Data
+                .EnsureData("/access_methods/list")
                 .AccessMethods;
         }
 
@@ -1028,7 +1035,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<UnlockDoorResponse>("/access_methods/unlock_door", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/access_methods/unlock_door")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -1057,7 +1065,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_methods/unlock_door")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/ActionAttempts.cs
+++ b/output/csharp/src/Seam/Api/ActionAttempts.cs
@@ -104,7 +104,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/action_attempts/get", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/action_attempts/get")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -123,7 +124,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/action_attempts/get", requestOptions))
-                .Data
+                .EnsureData("/action_attempts/get")
                 .ActionAttempt;
         }
 
@@ -247,7 +248,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/action_attempts/list", requestOptions)
-                .Data.ActionAttempts;
+                .EnsureData("/action_attempts/list")
+                .ActionAttempts;
         }
 
         /// <summary>
@@ -278,7 +280,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/action_attempts/list", requestOptions))
-                .Data
+                .EnsureData("/action_attempts/list")
                 .ActionAttempts;
         }
 

--- a/output/csharp/src/Seam/Api/ClientSessions.cs
+++ b/output/csharp/src/Seam/Api/ClientSessions.cs
@@ -167,7 +167,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/client_sessions/create", requestOptions)
-                .Data.ClientSession;
+                .EnsureData("/client_sessions/create")
+                .ClientSession;
         }
 
         /// <summary>
@@ -208,7 +209,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<CreateResponse>("/client_sessions/create", requestOptions)
             )
-                .Data
+                .EnsureData("/client_sessions/create")
                 .ClientSession;
         }
 
@@ -414,7 +415,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/client_sessions/get", requestOptions)
-                .Data.ClientSession;
+                .EnsureData("/client_sessions/get")
+                .ClientSession;
         }
 
         /// <summary>
@@ -441,7 +443,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/client_sessions/get", requestOptions))
-                .Data
+                .EnsureData("/client_sessions/get")
                 .ClientSession;
         }
 
@@ -596,7 +598,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetOrCreateResponse>("/client_sessions/get_or_create", requestOptions)
-                .Data.ClientSession;
+                .EnsureData("/client_sessions/get_or_create")
+                .ClientSession;
         }
 
         /// <summary>
@@ -636,7 +639,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/client_sessions/get_or_create")
                 .ClientSession;
         }
 
@@ -945,7 +948,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/client_sessions/list", requestOptions)
-                .Data.ClientSessions;
+                .EnsureData("/client_sessions/list")
+                .ClientSessions;
         }
 
         /// <summary>
@@ -978,7 +982,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/client_sessions/list", requestOptions))
-                .Data
+                .EnsureData("/client_sessions/list")
                 .ClientSessions;
         }
 

--- a/output/csharp/src/Seam/Api/ConnectWebviews.cs
+++ b/output/csharp/src/Seam/Api/ConnectWebviews.cs
@@ -470,7 +470,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/connect_webviews/create", requestOptions)
-                .Data.ConnectWebview;
+                .EnsureData("/connect_webviews/create")
+                .ConnectWebview;
         }
 
         /// <summary>
@@ -527,7 +528,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<CreateResponse>("/connect_webviews/create", requestOptions)
             )
-                .Data
+                .EnsureData("/connect_webviews/create")
                 .ConnectWebview;
         }
 
@@ -743,7 +744,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/connect_webviews/get", requestOptions)
-                .Data.ConnectWebview;
+                .EnsureData("/connect_webviews/get")
+                .ConnectWebview;
         }
 
         /// <summary>
@@ -766,7 +768,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/connect_webviews/get", requestOptions))
-                .Data
+                .EnsureData("/connect_webviews/get")
                 .ConnectWebview;
         }
 
@@ -908,7 +910,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/connect_webviews/list", requestOptions)
-                .Data.ConnectWebviews;
+                .EnsureData("/connect_webviews/list")
+                .ConnectWebviews;
         }
 
         /// <summary>
@@ -943,7 +946,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/connect_webviews/list", requestOptions))
-                .Data
+                .EnsureData("/connect_webviews/list")
                 .ConnectWebviews;
         }
 

--- a/output/csharp/src/Seam/Api/ConnectedAccounts.cs
+++ b/output/csharp/src/Seam/Api/ConnectedAccounts.cs
@@ -207,7 +207,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/connected_accounts/get", requestOptions)
-                .Data.ConnectedAccount;
+                .EnsureData("/connected_accounts/get")
+                .ConnectedAccount;
         }
 
         /// <summary>
@@ -226,7 +227,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/connected_accounts/get", requestOptions))
-                .Data
+                .EnsureData("/connected_accounts/get")
                 .ConnectedAccount;
         }
 
@@ -379,7 +380,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/connected_accounts/list", requestOptions)
-                .Data.ConnectedAccounts;
+                .EnsureData("/connected_accounts/list")
+                .ConnectedAccounts;
         }
 
         /// <summary>
@@ -416,7 +418,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/connected_accounts/list", requestOptions))
-                .Data
+                .EnsureData("/connected_accounts/list")
                 .ConnectedAccounts;
         }
 

--- a/output/csharp/src/Seam/Api/CredentialsAcs.cs
+++ b/output/csharp/src/Seam/Api/CredentialsAcs.cs
@@ -544,7 +544,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/acs/credentials/create", requestOptions)
-                .Data.AcsCredential;
+                .EnsureData("/acs/credentials/create")
+                .AcsCredential;
         }
 
         /// <summary>
@@ -595,7 +596,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<CreateResponse>("/acs/credentials/create", requestOptions)
             )
-                .Data
+                .EnsureData("/acs/credentials/create")
                 .AcsCredential;
         }
 
@@ -801,7 +802,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/acs/credentials/get", requestOptions)
-                .Data.AcsCredential;
+                .EnsureData("/acs/credentials/get")
+                .AcsCredential;
         }
 
         /// <summary>
@@ -820,7 +822,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/acs/credentials/get", requestOptions))
-                .Data
+                .EnsureData("/acs/credentials/get")
                 .AcsCredential;
         }
 
@@ -980,7 +982,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/acs/credentials/list", requestOptions)
-                .Data.AcsCredentials;
+                .EnsureData("/acs/credentials/list")
+                .AcsCredentials;
         }
 
         /// <summary>
@@ -1019,7 +1022,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/acs/credentials/list", requestOptions))
-                .Data
+                .EnsureData("/acs/credentials/list")
                 .AcsCredentials;
         }
 
@@ -1142,7 +1145,8 @@ namespace Seam.Api
                     "/acs/credentials/list_accessible_entrances",
                     requestOptions
                 )
-                .Data.AcsEntrances;
+                .EnsureData("/acs/credentials/list_accessible_entrances")
+                .AcsEntrances;
         }
 
         /// <summary>
@@ -1170,7 +1174,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/credentials/list_accessible_entrances")
                 .AcsEntrances;
         }
 

--- a/output/csharp/src/Seam/Api/Customers.cs
+++ b/output/csharp/src/Seam/Api/Customers.cs
@@ -2793,7 +2793,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreatePortalResponse>("/customers/create_portal", requestOptions)
-                .Data.CustomerPortal;
+                .EnsureData("/customers/create_portal")
+                .CustomerPortal;
         }
 
         /// <summary>
@@ -2839,7 +2840,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/customers/create_portal")
                 .CustomerPortal;
         }
 

--- a/output/csharp/src/Seam/Api/DailyProgramsThermostats.cs
+++ b/output/csharp/src/Seam/Api/DailyProgramsThermostats.cs
@@ -173,7 +173,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/thermostats/daily_programs/create", requestOptions)
-                .Data.ThermostatDailyProgram;
+                .EnsureData("/thermostats/daily_programs/create")
+                .ThermostatDailyProgram;
         }
 
         /// <summary>
@@ -201,7 +202,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/daily_programs/create")
                 .ThermostatDailyProgram;
         }
 
@@ -458,7 +459,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<UpdateResponse>("/thermostats/daily_programs/update", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/thermostats/daily_programs/update")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -492,7 +494,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/daily_programs/update")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/Devices.cs
+++ b/output/csharp/src/Seam/Api/Devices.cs
@@ -111,7 +111,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/devices/get", requestOptions).Data.Device;
+            return _seam
+                .Post<GetResponse>("/devices/get", requestOptions)
+                .EnsureData("/devices/get")
+                .Device;
         }
 
         /// <summary>
@@ -133,7 +136,9 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return (await _seam.PostAsync<GetResponse>("/devices/get", requestOptions)).Data.Device;
+            return (await _seam.PostAsync<GetResponse>("/devices/get", requestOptions))
+                .EnsureData("/devices/get")
+                .Device;
         }
 
         /// <summary>
@@ -788,7 +793,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/devices/list", requestOptions).Data.Devices;
+            return _seam
+                .Post<ListResponse>("/devices/list", requestOptions)
+                .EnsureData("/devices/list")
+                .Devices;
         }
 
         /// <summary>
@@ -843,7 +851,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/devices/list", requestOptions))
-                .Data
+                .EnsureData("/devices/list")
                 .Devices;
         }
 
@@ -1019,7 +1027,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListDeviceProvidersResponse>("/devices/list_device_providers", requestOptions)
-                .Data.DeviceProviders;
+                .EnsureData("/devices/list_device_providers")
+                .DeviceProviders;
         }
 
         /// <summary>
@@ -1057,7 +1066,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/devices/list_device_providers")
                 .DeviceProviders;
         }
 

--- a/output/csharp/src/Seam/Api/EncodersAcs.cs
+++ b/output/csharp/src/Seam/Api/EncodersAcs.cs
@@ -122,7 +122,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<EncodeCredentialResponse>("/acs/encoders/encode_credential", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/acs/encoders/encode_credential")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -156,7 +157,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/encoders/encode_credential")
                 .ActionAttempt;
         }
 
@@ -264,7 +265,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/acs/encoders/get", requestOptions).Data.AcsEncoder;
+            return _seam
+                .Post<GetResponse>("/acs/encoders/get", requestOptions)
+                .EnsureData("/acs/encoders/get")
+                .AcsEncoder;
         }
 
         /// <summary>
@@ -283,7 +287,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/acs/encoders/get", requestOptions))
-                .Data
+                .EnsureData("/acs/encoders/get")
                 .AcsEncoder;
         }
 
@@ -413,7 +417,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/acs/encoders/list", requestOptions).Data.AcsEncoders;
+            return _seam
+                .Post<ListResponse>("/acs/encoders/list", requestOptions)
+                .EnsureData("/acs/encoders/list")
+                .AcsEncoders;
         }
 
         /// <summary>
@@ -446,7 +453,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/acs/encoders/list", requestOptions))
-                .Data
+                .EnsureData("/acs/encoders/list")
                 .AcsEncoders;
         }
 
@@ -607,7 +614,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ScanCredentialResponse>("/acs/encoders/scan_credential", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/acs/encoders/scan_credential")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -639,7 +647,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/encoders/scan_credential")
                 .ActionAttempt;
         }
 
@@ -813,7 +821,8 @@ namespace Seam.Api
                     "/acs/encoders/scan_to_assign_credential",
                     requestOptions
                 )
-                .Data.ActionAttempt;
+                .EnsureData("/acs/encoders/scan_to_assign_credential")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -851,7 +860,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/encoders/scan_to_assign_credential")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/EntrancesAcs.cs
+++ b/output/csharp/src/Seam/Api/EntrancesAcs.cs
@@ -102,7 +102,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/acs/entrances/get", requestOptions).Data.AcsEntrance;
+            return _seam
+                .Post<GetResponse>("/acs/entrances/get", requestOptions)
+                .EnsureData("/acs/entrances/get")
+                .AcsEntrance;
         }
 
         /// <summary>
@@ -121,7 +124,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/acs/entrances/get", requestOptions))
-                .Data
+                .EnsureData("/acs/entrances/get")
                 .AcsEntrance;
         }
 
@@ -409,7 +412,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/acs/entrances/list", requestOptions)
-                .Data.AcsEntrances;
+                .EnsureData("/acs/entrances/list")
+                .AcsEntrances;
         }
 
         /// <summary>
@@ -452,7 +456,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/acs/entrances/list", requestOptions))
-                .Data
+                .EnsureData("/acs/entrances/list")
                 .AcsEntrances;
         }
 
@@ -604,7 +608,8 @@ namespace Seam.Api
                     "/acs/entrances/list_credentials_with_access",
                     requestOptions
                 )
-                .Data.AcsCredentials;
+                .EnsureData("/acs/entrances/list_credentials_with_access")
+                .AcsCredentials;
         }
 
         /// <summary>
@@ -638,7 +643,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/entrances/list_credentials_with_access")
                 .AcsCredentials;
         }
 
@@ -753,7 +758,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<UnlockResponse>("/acs/entrances/unlock", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/acs/entrances/unlock")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -777,7 +783,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<UnlockResponse>("/acs/entrances/unlock", requestOptions))
-                .Data
+                .EnsureData("/acs/entrances/unlock")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/Events.cs
+++ b/output/csharp/src/Seam/Api/Events.cs
@@ -120,7 +120,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/events/get", requestOptions).Data.Event;
+            return _seam
+                .Post<GetResponse>("/events/get", requestOptions)
+                .EnsureData("/events/get")
+                .Event;
         }
 
         /// <summary>
@@ -142,7 +145,9 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return (await _seam.PostAsync<GetResponse>("/events/get", requestOptions)).Data.Event;
+            return (await _seam.PostAsync<GetResponse>("/events/get", requestOptions))
+                .EnsureData("/events/get")
+                .Event;
         }
 
         /// <summary>
@@ -1167,7 +1172,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/events/list", requestOptions).Data.Events;
+            return _seam
+                .Post<ListResponse>("/events/list", requestOptions)
+                .EnsureData("/events/list")
+                .Events;
         }
 
         /// <summary>
@@ -1246,7 +1254,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/events/list", requestOptions))
-                .Data
+                .EnsureData("/events/list")
                 .Events;
         }
 

--- a/output/csharp/src/Seam/Api/InstantKeys.cs
+++ b/output/csharp/src/Seam/Api/InstantKeys.cs
@@ -185,7 +185,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/instant_keys/get", requestOptions).Data.InstantKey;
+            return _seam
+                .Post<GetResponse>("/instant_keys/get", requestOptions)
+                .EnsureData("/instant_keys/get")
+                .InstantKey;
         }
 
         /// <summary>
@@ -204,7 +207,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/instant_keys/get", requestOptions))
-                .Data
+                .EnsureData("/instant_keys/get")
                 .InstantKey;
         }
 
@@ -307,7 +310,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/instant_keys/list", requestOptions).Data.InstantKeys;
+            return _seam
+                .Post<ListResponse>("/instant_keys/list", requestOptions)
+                .EnsureData("/instant_keys/list")
+                .InstantKeys;
         }
 
         /// <summary>
@@ -326,7 +332,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/instant_keys/list", requestOptions))
-                .Data
+                .EnsureData("/instant_keys/list")
                 .InstantKeys;
         }
 

--- a/output/csharp/src/Seam/Api/Locks.cs
+++ b/output/csharp/src/Seam/Api/Locks.cs
@@ -126,7 +126,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ConfigureAutoLockResponse>("/locks/configure_auto_lock", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/locks/configure_auto_lock")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -160,7 +161,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/locks/configure_auto_lock")
                 .ActionAttempt;
         }
 
@@ -277,7 +278,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/locks/get", requestOptions).Data.Device;
+            return _seam
+                .Post<GetResponse>("/locks/get", requestOptions)
+                .EnsureData("/locks/get")
+                .Device;
         }
 
         /// <summary>
@@ -297,7 +301,9 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return (await _seam.PostAsync<GetResponse>("/locks/get", requestOptions)).Data.Device;
+            return (await _seam.PostAsync<GetResponse>("/locks/get", requestOptions))
+                .EnsureData("/locks/get")
+                .Device;
         }
 
         /// <summary>
@@ -822,7 +828,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/locks/list", requestOptions).Data.Devices;
+            return _seam
+                .Post<ListResponse>("/locks/list", requestOptions)
+                .EnsureData("/locks/list")
+                .Devices;
         }
 
         /// <summary>
@@ -877,7 +886,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/locks/list", requestOptions))
-                .Data
+                .EnsureData("/locks/list")
                 .Devices;
         }
 
@@ -1013,7 +1022,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<LockDoorResponse>("/locks/lock_door", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/locks/lock_door")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -1032,7 +1042,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<LockDoorResponse>("/locks/lock_door", requestOptions))
-                .Data
+                .EnsureData("/locks/lock_door")
                 .ActionAttempt;
         }
 
@@ -1130,7 +1140,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<UnlockDoorResponse>("/locks/unlock_door", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/locks/unlock_door")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -1149,7 +1160,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<UnlockDoorResponse>("/locks/unlock_door", requestOptions))
-                .Data
+                .EnsureData("/locks/unlock_door")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/NoiseSensors.cs
+++ b/output/csharp/src/Seam/Api/NoiseSensors.cs
@@ -282,7 +282,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/noise_sensors/list", requestOptions).Data.Devices;
+            return _seam
+                .Post<ListResponse>("/noise_sensors/list", requestOptions)
+                .EnsureData("/noise_sensors/list")
+                .Devices;
         }
 
         /// <summary>
@@ -337,7 +340,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/noise_sensors/list", requestOptions))
-                .Data
+                .EnsureData("/noise_sensors/list")
                 .Devices;
         }
 

--- a/output/csharp/src/Seam/Api/NoiseThresholdsNoiseSensors.cs
+++ b/output/csharp/src/Seam/Api/NoiseThresholdsNoiseSensors.cs
@@ -150,7 +150,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/noise_sensors/noise_thresholds/create", requestOptions)
-                .Data.NoiseThreshold;
+                .EnsureData("/noise_sensors/noise_thresholds/create")
+                .NoiseThreshold;
         }
 
         /// <summary>
@@ -190,7 +191,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/noise_sensors/noise_thresholds/create")
                 .NoiseThreshold;
         }
 
@@ -391,7 +392,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/noise_sensors/noise_thresholds/get", requestOptions)
-                .Data.NoiseThreshold;
+                .EnsureData("/noise_sensors/noise_thresholds/get")
+                .NoiseThreshold;
         }
 
         /// <summary>
@@ -415,7 +417,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/noise_sensors/noise_thresholds/get")
                 .NoiseThreshold;
         }
 
@@ -513,7 +515,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/noise_sensors/noise_thresholds/list", requestOptions)
-                .Data.NoiseThresholds;
+                .EnsureData("/noise_sensors/noise_thresholds/list")
+                .NoiseThresholds;
         }
 
         /// <summary>
@@ -537,7 +540,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/noise_sensors/noise_thresholds/list")
                 .NoiseThresholds;
         }
 

--- a/output/csharp/src/Seam/Api/Phones.cs
+++ b/output/csharp/src/Seam/Api/Phones.cs
@@ -178,7 +178,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/phones/get", requestOptions).Data.Phone;
+            return _seam
+                .Post<GetResponse>("/phones/get", requestOptions)
+                .EnsureData("/phones/get")
+                .Phone;
         }
 
         /// <summary>
@@ -196,7 +199,9 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return (await _seam.PostAsync<GetResponse>("/phones/get", requestOptions)).Data.Phone;
+            return (await _seam.PostAsync<GetResponse>("/phones/get", requestOptions))
+                .EnsureData("/phones/get")
+                .Phone;
         }
 
         /// <summary>
@@ -305,7 +310,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/phones/list", requestOptions).Data.Phones;
+            return _seam
+                .Post<ListResponse>("/phones/list", requestOptions)
+                .EnsureData("/phones/list")
+                .Phones;
         }
 
         /// <summary>
@@ -332,7 +340,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/phones/list", requestOptions))
-                .Data
+                .EnsureData("/phones/list")
                 .Phones;
         }
 

--- a/output/csharp/src/Seam/Api/SchedulesThermostats.cs
+++ b/output/csharp/src/Seam/Api/SchedulesThermostats.cs
@@ -158,7 +158,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/thermostats/schedules/create", requestOptions)
-                .Data.ThermostatSchedule;
+                .EnsureData("/thermostats/schedules/create")
+                .ThermostatSchedule;
         }
 
         /// <summary>
@@ -200,7 +201,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/schedules/create")
                 .ThermostatSchedule;
         }
 
@@ -402,7 +403,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/thermostats/schedules/get", requestOptions)
-                .Data.ThermostatSchedule;
+                .EnsureData("/thermostats/schedules/get")
+                .ThermostatSchedule;
         }
 
         /// <summary>
@@ -423,7 +425,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<GetResponse>("/thermostats/schedules/get", requestOptions)
             )
-                .Data
+                .EnsureData("/thermostats/schedules/get")
                 .ThermostatSchedule;
         }
 
@@ -532,7 +534,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/thermostats/schedules/list", requestOptions)
-                .Data.ThermostatSchedules;
+                .EnsureData("/thermostats/schedules/list")
+                .ThermostatSchedules;
         }
 
         /// <summary>
@@ -556,7 +559,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<ListResponse>("/thermostats/schedules/list", requestOptions)
             )
-                .Data
+                .EnsureData("/thermostats/schedules/list")
                 .ThermostatSchedules;
         }
 

--- a/output/csharp/src/Seam/Api/SimulateAccessCodes.cs
+++ b/output/csharp/src/Seam/Api/SimulateAccessCodes.cs
@@ -127,7 +127,8 @@ namespace Seam.Api
                     "/access_codes/simulate/create_unmanaged_access_code",
                     requestOptions
                 )
-                .Data.AccessCode;
+                .EnsureData("/access_codes/simulate/create_unmanaged_access_code")
+                .AccessCode;
         }
 
         /// <summary>
@@ -159,7 +160,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_codes/simulate/create_unmanaged_access_code")
                 .AccessCode;
         }
 

--- a/output/csharp/src/Seam/Api/SimulateLocks.cs
+++ b/output/csharp/src/Seam/Api/SimulateLocks.cs
@@ -111,7 +111,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<KeypadCodeEntryResponse>("/locks/simulate/keypad_code_entry", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/locks/simulate/keypad_code_entry")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -135,7 +136,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/locks/simulate/keypad_code_entry")
                 .ActionAttempt;
         }
 
@@ -243,7 +244,8 @@ namespace Seam.Api
                     "/locks/simulate/manual_lock_via_keypad",
                     requestOptions
                 )
-                .Data.ActionAttempt;
+                .EnsureData("/locks/simulate/manual_lock_via_keypad")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -269,7 +271,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/locks/simulate/manual_lock_via_keypad")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/SimulatePhones.cs
+++ b/output/csharp/src/Seam/Api/SimulatePhones.cs
@@ -300,7 +300,8 @@ namespace Seam.Api
                     "/phones/simulate/create_sandbox_phone",
                     requestOptions
                 )
-                .Data.Phone;
+                .EnsureData("/phones/simulate/create_sandbox_phone")
+                .Phone;
         }
 
         /// <summary>
@@ -336,7 +337,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/phones/simulate/create_sandbox_phone")
                 .Phone;
         }
 

--- a/output/csharp/src/Seam/Api/Spaces.cs
+++ b/output/csharp/src/Seam/Api/Spaces.cs
@@ -508,7 +508,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<CreateResponse>("/spaces/create", requestOptions).Data.Space;
+            return _seam
+                .Post<CreateResponse>("/spaces/create", requestOptions)
+                .EnsureData("/spaces/create")
+                .Space;
         }
 
         /// <summary>
@@ -545,7 +548,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CreateResponse>("/spaces/create", requestOptions))
-                .Data
+                .EnsureData("/spaces/create")
                 .Space;
         }
 
@@ -744,7 +747,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/spaces/get", requestOptions).Data.Space;
+            return _seam
+                .Post<GetResponse>("/spaces/get", requestOptions)
+                .EnsureData("/spaces/get")
+                .Space;
         }
 
         /// <summary>
@@ -762,7 +768,9 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return (await _seam.PostAsync<GetResponse>("/spaces/get", requestOptions)).Data.Space;
+            return (await _seam.PostAsync<GetResponse>("/spaces/get", requestOptions))
+                .EnsureData("/spaces/get")
+                .Space;
         }
 
         /// <summary>
@@ -927,7 +935,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetRelatedResponse>("/spaces/get_related", requestOptions).Data.Batch;
+            return _seam
+                .Post<GetRelatedResponse>("/spaces/get_related", requestOptions)
+                .EnsureData("/spaces/get_related")
+                .Batch;
         }
 
         /// <summary>
@@ -960,7 +971,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<GetRelatedResponse>("/spaces/get_related", requestOptions)
             )
-                .Data
+                .EnsureData("/spaces/get_related")
                 .Batch;
         }
 
@@ -1104,7 +1115,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/spaces/list", requestOptions).Data.Spaces;
+            return _seam
+                .Post<ListResponse>("/spaces/list", requestOptions)
+                .EnsureData("/spaces/list")
+                .Spaces;
         }
 
         /// <summary>
@@ -1137,7 +1151,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/spaces/list", requestOptions))
-                .Data
+                .EnsureData("/spaces/list")
                 .Spaces;
         }
 
@@ -1648,7 +1662,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<UpdateResponse>("/spaces/update", requestOptions).Data.Space;
+            return _seam
+                .Post<UpdateResponse>("/spaces/update", requestOptions)
+                .EnsureData("/spaces/update")
+                .Space;
         }
 
         /// <summary>
@@ -1683,7 +1700,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<UpdateResponse>("/spaces/update", requestOptions))
-                .Data
+                .EnsureData("/spaces/update")
                 .Space;
         }
 

--- a/output/csharp/src/Seam/Api/SystemsAcs.cs
+++ b/output/csharp/src/Seam/Api/SystemsAcs.cs
@@ -102,7 +102,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/acs/systems/get", requestOptions).Data.AcsSystem;
+            return _seam
+                .Post<GetResponse>("/acs/systems/get", requestOptions)
+                .EnsureData("/acs/systems/get")
+                .AcsSystem;
         }
 
         /// <summary>
@@ -121,7 +124,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/acs/systems/get", requestOptions))
-                .Data
+                .EnsureData("/acs/systems/get")
                 .AcsSystem;
         }
 
@@ -241,7 +244,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/acs/systems/list", requestOptions).Data.AcsSystems;
+            return _seam
+                .Post<ListResponse>("/acs/systems/list", requestOptions)
+                .EnsureData("/acs/systems/list")
+                .AcsSystems;
         }
 
         /// <summary>
@@ -274,7 +280,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/acs/systems/list", requestOptions))
-                .Data
+                .EnsureData("/acs/systems/list")
                 .AcsSystems;
         }
 
@@ -395,7 +401,8 @@ namespace Seam.Api
                     "/acs/systems/list_compatible_credential_manager_acs_systems",
                     requestOptions
                 )
-                .Data.AcsSystems;
+                .EnsureData("/acs/systems/list_compatible_credential_manager_acs_systems")
+                .AcsSystems;
         }
 
         /// <summary>
@@ -429,7 +436,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/systems/list_compatible_credential_manager_acs_systems")
                 .AcsSystems;
         }
 

--- a/output/csharp/src/Seam/Api/Thermostats.cs
+++ b/output/csharp/src/Seam/Api/Thermostats.cs
@@ -117,7 +117,8 @@ namespace Seam.Api
                     "/thermostats/activate_climate_preset",
                     requestOptions
                 )
-                .Data.ActionAttempt;
+                .EnsureData("/thermostats/activate_climate_preset")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/activate_climate_preset")
                 .ActionAttempt;
         }
 
@@ -283,7 +284,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<CoolResponse>("/thermostats/cool", requestOptions).Data.ActionAttempt;
+            return _seam
+                .Post<CoolResponse>("/thermostats/cool", requestOptions)
+                .EnsureData("/thermostats/cool")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -312,7 +316,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CoolResponse>("/thermostats/cool", requestOptions))
-                .Data
+                .EnsureData("/thermostats/cool")
                 .ActionAttempt;
         }
 
@@ -934,7 +938,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<HeatResponse>("/thermostats/heat", requestOptions).Data.ActionAttempt;
+            return _seam
+                .Post<HeatResponse>("/thermostats/heat", requestOptions)
+                .EnsureData("/thermostats/heat")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -963,7 +970,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<HeatResponse>("/thermostats/heat", requestOptions))
-                .Data
+                .EnsureData("/thermostats/heat")
                 .ActionAttempt;
         }
 
@@ -1123,7 +1130,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<HeatCoolResponse>("/thermostats/heat_cool", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/thermostats/heat_cool")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -1158,7 +1166,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<HeatCoolResponse>("/thermostats/heat_cool", requestOptions)
             )
-                .Data
+                .EnsureData("/thermostats/heat_cool")
                 .ActionAttempt;
         }
 
@@ -1486,7 +1494,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/thermostats/list", requestOptions).Data.Devices;
+            return _seam
+                .Post<ListResponse>("/thermostats/list", requestOptions)
+                .EnsureData("/thermostats/list")
+                .Devices;
         }
 
         /// <summary>
@@ -1541,7 +1552,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/thermostats/list", requestOptions))
-                .Data
+                .EnsureData("/thermostats/list")
                 .Devices;
         }
 
@@ -1675,7 +1686,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<OffResponse>("/thermostats/off", requestOptions).Data.ActionAttempt;
+            return _seam
+                .Post<OffResponse>("/thermostats/off", requestOptions)
+                .EnsureData("/thermostats/off")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -1694,7 +1708,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<OffResponse>("/thermostats/off", requestOptions))
-                .Data
+                .EnsureData("/thermostats/off")
                 .ActionAttempt;
         }
 
@@ -1954,7 +1968,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<SetFanModeResponse>("/thermostats/set_fan_mode", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/thermostats/set_fan_mode")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -1988,7 +2003,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/set_fan_mode")
                 .ActionAttempt;
         }
 
@@ -2175,7 +2190,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<SetHvacModeResponse>("/thermostats/set_hvac_mode", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/thermostats/set_hvac_mode")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -2215,7 +2231,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/set_hvac_mode")
                 .ActionAttempt;
         }
 
@@ -2928,7 +2944,8 @@ namespace Seam.Api
                     "/thermostats/update_weekly_program",
                     requestOptions
                 )
-                .Data.ActionAttempt;
+                .EnsureData("/thermostats/update_weekly_program")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -2974,7 +2991,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/thermostats/update_weekly_program")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Api/UnmanagedAccessCodes.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessCodes.cs
@@ -353,7 +353,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/access_codes/unmanaged/get", requestOptions)
-                .Data.AccessCode;
+                .EnsureData("/access_codes/unmanaged/get")
+                .AccessCode;
         }
 
         /// <summary>
@@ -382,7 +383,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<GetResponse>("/access_codes/unmanaged/get", requestOptions)
             )
-                .Data
+                .EnsureData("/access_codes/unmanaged/get")
                 .AccessCode;
         }
 
@@ -524,7 +525,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/access_codes/unmanaged/list", requestOptions)
-                .Data.AccessCodes;
+                .EnsureData("/access_codes/unmanaged/list")
+                .AccessCodes;
         }
 
         /// <summary>
@@ -559,7 +561,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<ListResponse>("/access_codes/unmanaged/list", requestOptions)
             )
-                .Data
+                .EnsureData("/access_codes/unmanaged/list")
                 .AccessCodes;
         }
 

--- a/output/csharp/src/Seam/Api/UnmanagedAccessGrants.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessGrants.cs
@@ -104,7 +104,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/access_grants/unmanaged/get", requestOptions)
-                .Data.AccessGrant;
+                .EnsureData("/access_grants/unmanaged/get")
+                .AccessGrant;
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<GetResponse>("/access_grants/unmanaged/get", requestOptions)
             )
-                .Data
+                .EnsureData("/access_grants/unmanaged/get")
                 .AccessGrant;
         }
 
@@ -265,7 +266,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/access_grants/unmanaged/list", requestOptions)
-                .Data.AccessGrants;
+                .EnsureData("/access_grants/unmanaged/list")
+                .AccessGrants;
         }
 
         /// <summary>
@@ -302,7 +304,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<ListResponse>("/access_grants/unmanaged/list", requestOptions)
             )
-                .Data
+                .EnsureData("/access_grants/unmanaged/list")
                 .AccessGrants;
         }
 

--- a/output/csharp/src/Seam/Api/UnmanagedAccessMethods.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedAccessMethods.cs
@@ -104,7 +104,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/access_methods/unmanaged/get", requestOptions)
-                .Data.AccessMethod;
+                .EnsureData("/access_methods/unmanaged/get")
+                .AccessMethod;
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<GetResponse>("/access_methods/unmanaged/get", requestOptions)
             )
-                .Data
+                .EnsureData("/access_methods/unmanaged/get")
                 .AccessMethod;
         }
 
@@ -249,7 +250,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/access_methods/unmanaged/list", requestOptions)
-                .Data.AccessMethods;
+                .EnsureData("/access_methods/unmanaged/list")
+                .AccessMethods;
         }
 
         /// <summary>
@@ -285,7 +287,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/access_methods/unmanaged/list")
                 .AccessMethods;
         }
 

--- a/output/csharp/src/Seam/Api/UnmanagedDevices.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedDevices.cs
@@ -113,7 +113,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/devices/unmanaged/get", requestOptions).Data.Device;
+            return _seam
+                .Post<GetResponse>("/devices/unmanaged/get", requestOptions)
+                .EnsureData("/devices/unmanaged/get")
+                .Device;
         }
 
         /// <summary>
@@ -140,7 +143,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/devices/unmanaged/get", requestOptions))
-                .Data
+                .EnsureData("/devices/unmanaged/get")
                 .Device;
         }
 
@@ -803,7 +806,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/devices/unmanaged/list", requestOptions).Data.Devices;
+            return _seam
+                .Post<ListResponse>("/devices/unmanaged/list", requestOptions)
+                .EnsureData("/devices/unmanaged/list")
+                .Devices;
         }
 
         /// <summary>
@@ -862,7 +868,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/devices/unmanaged/list", requestOptions))
-                .Data
+                .EnsureData("/devices/unmanaged/list")
                 .Devices;
         }
 

--- a/output/csharp/src/Seam/Api/UnmanagedUserIdentities.cs
+++ b/output/csharp/src/Seam/Api/UnmanagedUserIdentities.cs
@@ -104,7 +104,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/user_identities/unmanaged/get", requestOptions)
-                .Data.UserIdentity;
+                .EnsureData("/user_identities/unmanaged/get")
+                .UserIdentity;
         }
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<GetResponse>("/user_identities/unmanaged/get", requestOptions)
             )
-                .Data
+                .EnsureData("/user_identities/unmanaged/get")
                 .UserIdentity;
         }
 
@@ -249,7 +250,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/user_identities/unmanaged/list", requestOptions)
-                .Data.UserIdentities;
+                .EnsureData("/user_identities/unmanaged/list")
+                .UserIdentities;
         }
 
         /// <summary>
@@ -285,7 +287,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/user_identities/unmanaged/list")
                 .UserIdentities;
         }
 

--- a/output/csharp/src/Seam/Api/UserIdentities.cs
+++ b/output/csharp/src/Seam/Api/UserIdentities.cs
@@ -268,7 +268,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<CreateResponse>("/user_identities/create", requestOptions)
-                .Data.UserIdentity;
+                .EnsureData("/user_identities/create")
+                .UserIdentity;
         }
 
         /// <summary>
@@ -303,7 +304,7 @@ namespace Seam.Api
             return (
                 await _seam.PostAsync<CreateResponse>("/user_identities/create", requestOptions)
             )
-                .Data
+                .EnsureData("/user_identities/create")
                 .UserIdentity;
         }
 
@@ -515,7 +516,8 @@ namespace Seam.Api
                     "/user_identities/generate_instant_key",
                     requestOptions
                 )
-                .Data.InstantKey;
+                .EnsureData("/user_identities/generate_instant_key")
+                .InstantKey;
         }
 
         /// <summary>
@@ -549,7 +551,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/user_identities/generate_instant_key")
                 .InstantKey;
         }
 
@@ -663,7 +665,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<GetResponse>("/user_identities/get", requestOptions)
-                .Data.UserIdentity;
+                .EnsureData("/user_identities/get")
+                .UserIdentity;
         }
 
         /// <summary>
@@ -684,7 +687,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/user_identities/get", requestOptions))
-                .Data
+                .EnsureData("/user_identities/get")
                 .UserIdentity;
         }
 
@@ -931,7 +934,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListResponse>("/user_identities/list", requestOptions)
-                .Data.UserIdentities;
+                .EnsureData("/user_identities/list")
+                .UserIdentities;
         }
 
         /// <summary>
@@ -966,7 +970,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/user_identities/list", requestOptions))
-                .Data
+                .EnsureData("/user_identities/list")
                 .UserIdentities;
         }
 
@@ -1085,7 +1089,8 @@ namespace Seam.Api
                     "/user_identities/list_accessible_devices",
                     requestOptions
                 )
-                .Data.Devices;
+                .EnsureData("/user_identities/list_accessible_devices")
+                .Devices;
         }
 
         /// <summary>
@@ -1113,7 +1118,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/user_identities/list_accessible_devices")
                 .Devices;
         }
 
@@ -1218,7 +1223,8 @@ namespace Seam.Api
                     "/user_identities/list_accessible_entrances",
                     requestOptions
                 )
-                .Data.AcsEntrances;
+                .EnsureData("/user_identities/list_accessible_entrances")
+                .AcsEntrances;
         }
 
         /// <summary>
@@ -1246,7 +1252,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/user_identities/list_accessible_entrances")
                 .AcsEntrances;
         }
 
@@ -1350,7 +1356,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListAcsSystemsResponse>("/user_identities/list_acs_systems", requestOptions)
-                .Data.AcsSystems;
+                .EnsureData("/user_identities/list_acs_systems")
+                .AcsSystems;
         }
 
         /// <summary>
@@ -1374,7 +1381,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/user_identities/list_acs_systems")
                 .AcsSystems;
         }
 
@@ -1474,7 +1481,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ListAcsUsersResponse>("/user_identities/list_acs_users", requestOptions)
-                .Data.AcsUsers;
+                .EnsureData("/user_identities/list_acs_users")
+                .AcsUsers;
         }
 
         /// <summary>
@@ -1498,7 +1506,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/user_identities/list_acs_users")
                 .AcsUsers;
         }
 

--- a/output/csharp/src/Seam/Api/UsersAcs.cs
+++ b/output/csharp/src/Seam/Api/UsersAcs.cs
@@ -305,7 +305,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<CreateResponse>("/acs/users/create", requestOptions).Data.AcsUser;
+            return _seam
+                .Post<CreateResponse>("/acs/users/create", requestOptions)
+                .EnsureData("/acs/users/create")
+                .AcsUser;
         }
 
         /// <summary>
@@ -344,7 +347,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CreateResponse>("/acs/users/create", requestOptions))
-                .Data
+                .EnsureData("/acs/users/create")
                 .AcsUser;
         }
 
@@ -594,7 +597,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/acs/users/get", requestOptions).Data.AcsUser;
+            return _seam
+                .Post<GetResponse>("/acs/users/get", requestOptions)
+                .EnsureData("/acs/users/get")
+                .AcsUser;
         }
 
         /// <summary>
@@ -623,7 +629,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/acs/users/get", requestOptions))
-                .Data
+                .EnsureData("/acs/users/get")
                 .AcsUser;
         }
 
@@ -797,7 +803,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/acs/users/list", requestOptions).Data.AcsUsers;
+            return _seam
+                .Post<ListResponse>("/acs/users/list", requestOptions)
+                .EnsureData("/acs/users/list")
+                .AcsUsers;
         }
 
         /// <summary>
@@ -836,7 +845,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/acs/users/list", requestOptions))
-                .Data
+                .EnsureData("/acs/users/list")
                 .AcsUsers;
         }
 
@@ -977,7 +986,8 @@ namespace Seam.Api
                     "/acs/users/list_accessible_entrances",
                     requestOptions
                 )
-                .Data.AcsEntrances;
+                .EnsureData("/acs/users/list_accessible_entrances")
+                .AcsEntrances;
         }
 
         /// <summary>
@@ -1013,7 +1023,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/acs/users/list_accessible_entrances")
                 .AcsEntrances;
         }
 

--- a/output/csharp/src/Seam/Api/Webhooks.cs
+++ b/output/csharp/src/Seam/Api/Webhooks.cs
@@ -109,7 +109,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<CreateResponse>("/webhooks/create", requestOptions).Data.Webhook;
+            return _seam
+                .Post<CreateResponse>("/webhooks/create", requestOptions)
+                .EnsureData("/webhooks/create")
+                .Webhook;
         }
 
         /// <summary>
@@ -128,7 +131,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CreateResponse>("/webhooks/create", requestOptions))
-                .Data
+                .EnsureData("/webhooks/create")
                 .Webhook;
         }
 
@@ -303,7 +306,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/webhooks/get", requestOptions).Data.Webhook;
+            return _seam
+                .Post<GetResponse>("/webhooks/get", requestOptions)
+                .EnsureData("/webhooks/get")
+                .Webhook;
         }
 
         /// <summary>
@@ -322,7 +328,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/webhooks/get", requestOptions))
-                .Data
+                .EnsureData("/webhooks/get")
                 .Webhook;
         }
 
@@ -407,7 +413,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/webhooks/list", requestOptions).Data.Webhooks;
+            return _seam
+                .Post<ListResponse>("/webhooks/list", requestOptions)
+                .EnsureData("/webhooks/list")
+                .Webhooks;
         }
 
         /// <summary>
@@ -426,7 +435,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/webhooks/list", requestOptions))
-                .Data
+                .EnsureData("/webhooks/list")
                 .Webhooks;
         }
 

--- a/output/csharp/src/Seam/Api/Workspaces.cs
+++ b/output/csharp/src/Seam/Api/Workspaces.cs
@@ -291,7 +291,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<CreateResponse>("/workspaces/create", requestOptions).Data.Workspace;
+            return _seam
+                .Post<CreateResponse>("/workspaces/create", requestOptions)
+                .EnsureData("/workspaces/create")
+                .Workspace;
         }
 
         /// <summary>
@@ -334,7 +337,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<CreateResponse>("/workspaces/create", requestOptions))
-                .Data
+                .EnsureData("/workspaces/create")
                 .Workspace;
         }
 
@@ -445,7 +448,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<GetResponse>("/workspaces/get", requestOptions).Data.Workspace;
+            return _seam
+                .Post<GetResponse>("/workspaces/get", requestOptions)
+                .EnsureData("/workspaces/get")
+                .Workspace;
         }
 
         /// <summary>
@@ -464,7 +470,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<GetResponse>("/workspaces/get", requestOptions))
-                .Data
+                .EnsureData("/workspaces/get")
                 .Workspace;
         }
 
@@ -549,7 +555,10 @@ namespace Seam.Api
         {
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
-            return _seam.Post<ListResponse>("/workspaces/list", requestOptions).Data.Workspaces;
+            return _seam
+                .Post<ListResponse>("/workspaces/list", requestOptions)
+                .EnsureData("/workspaces/list")
+                .Workspaces;
         }
 
         /// <summary>
@@ -568,7 +577,7 @@ namespace Seam.Api
             var requestOptions = new RequestOptions();
             requestOptions.Data = request;
             return (await _seam.PostAsync<ListResponse>("/workspaces/list", requestOptions))
-                .Data
+                .EnsureData("/workspaces/list")
                 .Workspaces;
         }
 
@@ -655,7 +664,8 @@ namespace Seam.Api
             requestOptions.Data = request;
             return _seam
                 .Post<ResetSandboxResponse>("/workspaces/reset_sandbox", requestOptions)
-                .Data.ActionAttempt;
+                .EnsureData("/workspaces/reset_sandbox")
+                .ActionAttempt;
         }
 
         /// <summary>
@@ -679,7 +689,7 @@ namespace Seam.Api
                     requestOptions
                 )
             )
-                .Data
+                .EnsureData("/workspaces/reset_sandbox")
                 .ActionAttempt;
         }
 

--- a/output/csharp/src/Seam/Client/ApiResponse.cs
+++ b/output/csharp/src/Seam/Client/ApiResponse.cs
@@ -155,5 +155,35 @@ namespace Seam.Client
             : this(statusCode, data, null) { }
 
         #endregion Constructors
+
+        #region Methods
+
+        /// <summary>
+        /// Returns the deserialized response data, or throws a <see cref="SeamException"/>
+        /// carrying the HTTP status code, headers, and raw response body when the body is
+        /// missing or could not be deserialized into <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="path">The request path, used in the exception message.</param>
+        /// <returns>The deserialized response data.</returns>
+        /// <exception cref="SeamException">Thrown when the response data is null.</exception>
+        public T EnsureData(string path)
+        {
+            if (Data != null)
+            {
+                return Data;
+            }
+
+            var reason = string.IsNullOrEmpty(ErrorText)
+                ? "the response body is missing or could not be deserialized"
+                : ErrorText;
+            throw new SeamException(
+                (int)StatusCode,
+                string.Format("Error calling {0} (HTTP {1}): {2}", path, (int)StatusCode, reason),
+                RawContent,
+                Headers
+            );
+        }
+
+        #endregion Methods
     }
 }


### PR DESCRIPTION
Generated API methods dereferenced ApiResponse<T>.Data without checking
for null. When a response deserializes to null — an empty or null JSON
body, a non-JSON body on a 2xx/3xx status, or a RestSharp deserialization
error captured on the response — callers got an opaque
NullReferenceException with no HTTP diagnostics.

Add ApiResponse<T>.EnsureData(path), which returns the data or throws a
SeamException carrying the request path, HTTP status code, response
headers, and raw body, and update the codegen route template so every
generated endpoint uses it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Ck3swavz8q3cmv52MJ5DL