### PR TITLE
feat: default requests to a 30 second timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ Console.WriteLine("First Device Name: " + myDevices[0].Properties.Name);
 var accessCode = seam.AccessCodes.Create(deviceId: myDevices[0].DeviceId, code: "1234");
 ```
 
+## Advanced Usage
+
+### Setting the request timeout
+
+Requests time out after 30 seconds by default.
+Pass the `timeout` option, in milliseconds, to override this:
+
+```csharp
+var seam = new SeamClient(apiToken: "YOUR_API_KEY", timeout: 60000);
+```
+
+The default may also be changed for every client at once:
+
+```csharp
+GlobalSeamRequestConfiguration.Instance.Timeout = 60000;
+```
+
 ## Development and Testing
 
 ### Quickstart

--- a/output/csharp/src/Seam.Test/Client/TimeoutTests.cs
+++ b/output/csharp/src/Seam.Test/Client/TimeoutTests.cs
@@ -1,0 +1,56 @@
+namespace Seam.Test;
+
+using Seam.Client;
+
+public class TimeoutTests
+{
+    [Fact]
+    public void DefaultTimeoutIs30Seconds()
+    {
+        Assert.Equal(30000, SeamRequestConfiguration.DefaultTimeout);
+    }
+
+    [Fact]
+    public void NewConfigurationUsesTheDefaultTimeout()
+    {
+        var configuration = new SeamRequestConfiguration();
+
+        Assert.Equal(SeamRequestConfiguration.DefaultTimeout, configuration.Timeout);
+    }
+
+    [Fact]
+    public void GlobalConfigurationUsesTheDefaultTimeout()
+    {
+        Assert.Equal(
+            SeamRequestConfiguration.DefaultTimeout,
+            GlobalSeamRequestConfiguration.Instance.Timeout
+        );
+    }
+
+    [Fact]
+    public void ConfigurationTimeoutCanBeOverridden()
+    {
+        var configuration = new SeamRequestConfiguration { Timeout = 60000 };
+
+        Assert.Equal(60000, configuration.Timeout);
+    }
+
+    [Fact]
+    public void MergedConfigurationTakesTheTimeoutFromTheSecondConfiguration()
+    {
+        var first = new SeamRequestConfiguration { Timeout = 60000 };
+        var second = new SeamRequestConfiguration { Timeout = 5000 };
+
+        var merged = SeamRequestConfiguration.MergeConfigurations(first, second);
+
+        Assert.Equal(5000, merged.Timeout);
+    }
+
+    [Fact]
+    public void ClientAcceptsATimeout()
+    {
+        var seam = new SeamClient(apiToken: "seam_apikey_token", timeout: 60000);
+
+        Assert.NotNull(seam);
+    }
+}

--- a/output/csharp/src/Seam/Client/Seam.cs
+++ b/output/csharp/src/Seam/Client/Seam.cs
@@ -178,6 +178,7 @@ namespace Seam.Client
     {
         private readonly string _baseUrl;
         private readonly string _apiToken;
+        private readonly int? _timeout;
 
         /// <summary>
         /// Specifies the settings on a <see cref="JsonSerializer" /> object.
@@ -210,19 +211,22 @@ namespace Seam.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" />
         /// </summary>
-        /// <param name="basePath">The target service's base path in URL format.</param>
         /// <param name="apiToken">The target service's API Token.</param>
+        /// <param name="timeout">The request timeout in milliseconds. Defaults to
+        /// <see cref="SeamRequestConfiguration.DefaultTimeout" />.</param>
         /// <exception cref="ArgumentException"></exception>
-        public SeamClient(string apiToken)
-            : this(GlobalSeamRequestConfiguration.Instance.BasePath, apiToken) { }
+        public SeamClient(string apiToken, int? timeout = null)
+            : this(GlobalSeamRequestConfiguration.Instance.BasePath, apiToken, timeout) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" />
         /// </summary>
         /// <param name="basePath">The target service's base path in URL format.</param>
         /// <param name="apiToken">The target service's API Token.</param>
+        /// <param name="timeout">The request timeout in milliseconds. Defaults to
+        /// <see cref="SeamRequestConfiguration.DefaultTimeout" />.</param>
         /// <exception cref="ArgumentException"></exception>
-        public SeamClient(string basePath, string apiToken)
+        public SeamClient(string basePath, string apiToken, int? timeout = null)
         {
             if (string.IsNullOrEmpty(basePath))
                 throw new ArgumentException("basePath cannot be empty");
@@ -232,6 +236,7 @@ namespace Seam.Client
 
             _baseUrl = basePath;
             _apiToken = apiToken;
+            _timeout = timeout;
         }
 
         /// <summary>
@@ -499,11 +504,13 @@ namespace Seam.Client
                 }
             }
 
+            var timeout = _timeout ?? configuration.Timeout;
+
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
                 CookieContainer = cookies,
-                MaxTimeout = configuration.Timeout,
+                Timeout = timeout > 0 ? TimeSpan.FromMilliseconds(timeout) : (TimeSpan?)null,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 // UseDefaultCredentials = configuration.UseDefaultCredentials,
@@ -630,10 +637,12 @@ namespace Seam.Client
         {
             var baseUrl = _baseUrl;
 
+            var timeout = _timeout ?? configuration.Timeout;
+
             var clientOptions = new RestClientOptions(baseUrl)
             {
                 ClientCertificates = configuration.ClientCertificates,
-                MaxTimeout = configuration.Timeout,
+                Timeout = timeout > 0 ? TimeSpan.FromMilliseconds(timeout) : (TimeSpan?)null,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 ThrowOnAnyError = false,
@@ -1061,10 +1070,10 @@ namespace Seam.Client
     [Obsolete("Please use Seam.Client.SeamClient instead")]
     public class Seam : SeamClient
     {
-        public Seam(string apiToken)
-            : base(apiToken) { }
+        public Seam(string apiToken, int? timeout = null)
+            : base(apiToken, timeout) { }
 
-        public Seam(string basePath, string apiToken)
-            : base(basePath, apiToken) { }
+        public Seam(string basePath, string apiToken, int? timeout = null)
+            : base(basePath, apiToken, timeout) { }
     }
 }

--- a/output/csharp/src/Seam/Client/SeamRequestConfiguration.cs
+++ b/output/csharp/src/Seam/Client/SeamRequestConfiguration.cs
@@ -26,6 +26,12 @@ namespace Seam.Client
         public const string Version = "1.0.0";
 
         /// <summary>
+        /// Default HTTP timeout (milliseconds) applied to every request.
+        /// </summary>
+        /// <value>Default HTTP timeout (milliseconds).</value>
+        public const int DefaultTimeout = 30000;
+
+        /// <summary>
         /// Identifier for ISO 8601 DateTime Format
         /// </summary>
         /// <remarks>See https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#Anchor_8 for more information.</remarks>
@@ -138,7 +144,7 @@ namespace Seam.Client
             { };
 
             // Setting Timeout has side effects (forces ApiClient creation).
-            Timeout = 100000;
+            Timeout = DefaultTimeout;
         }
 
         /// <summary>
@@ -221,7 +227,8 @@ namespace Seam.Client
         public virtual IDictionary<string, string> DefaultHeaders { get; set; }
 
         /// <summary>
-        /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Default to 100000 milliseconds.
+        /// Gets or sets the HTTP timeout (milliseconds) of ApiClient. Defaults to
+        /// <see cref="DefaultTimeout" /> milliseconds.
         /// </summary>
         public virtual int Timeout { get; set; }
 

--- a/output/csharp/src/Seam/README.md
+++ b/output/csharp/src/Seam/README.md
@@ -13,3 +13,20 @@ Console.WriteLine("First Device Name: " + myDevices[0].Properties.Name);
 
 var accessCode = seam.AccessCodes.Create(deviceId: myDevices[0].DeviceId, code: "1234");
 ```
+
+## Advanced Usage
+
+### Setting the request timeout
+
+Requests time out after 30 seconds by default.
+Pass the `timeout` option, in milliseconds, to override this:
+
+```csharp
+var seam = new SeamClient(apiToken: "YOUR_API_KEY", timeout: 60000);
+```
+
+The default may also be changed for every client at once:
+
+```csharp
+GlobalSeamRequestConfiguration.Instance.Timeout = 60000;
+```


### PR DESCRIPTION
Part of a four-SDK change adding a default HTTP timeout ([javascript-http](https://github.com/seamapi/javascript-http/pull/951), [ruby](https://github.com/seamapi/ruby/pull/540), [python](https://github.com/seamapi/python/pulls)).

## Problem

Unlike the other three SDKs, this one already had a timeout — but 100 seconds, an openapi-generator leftover rather than a deliberate choice, and far longer than the API's own request timeout.

## Changes

- Lower the default to 30 seconds behind a named `SeamRequestConfiguration.DefaultTimeout` constant, so the value reads as a decision instead of a generator artifact.
- Add a `timeout` parameter, in milliseconds, to `SeamClient` (and the obsolete `Seam` subclass) so it can be set per client.
- The per-client value takes precedence over `configuration.Timeout` in both `Exec` and `ExecAsync`; the configuration remains available for setting the default globally.

```csharp
var seam = new SeamClient(apiToken: "YOUR_API_KEY", timeout: 60000);

// Or globally
GlobalSeamRequestConfiguration.Instance.Timeout = 60000;
```

Files under `output/csharp/src/Seam/Client/` are checked in and hand-maintained rather than generated — the codegen only produces `Api/` and `Model/` — so no regeneration is needed.

## Behavior change

Requests that previously ran between 30 and 100 seconds will now fail. The `timeout` parameter and the global configuration are both opt-outs.

## Overload resolution

Both `SeamClient` constructors gain an optional `int? timeout = null`. This is source-compatible for every sensible call. The one call whose binding changes is `new SeamClient(someString, null)`, which now resolves to `(apiToken, timeout: null)` rather than `(basePath, apiToken: null)` — code that previously threw `ArgumentException("apiToken cannot be empty")` at runtime. Adding an optional parameter is a binary-breaking change, so consumers recompile against the new package as usual.

## Testing

**Unverified — CI is the first real run.** There is no .NET toolchain in my environment, so I could not build, test, or run `csharpier` on this branch. `output/csharp/src/Seam.Test/Client/TimeoutTests.cs` is new and covers the default constant, configuration defaults, merge precedence, and construction with an explicit timeout. Please expect a formatting fixup if csharpier disagrees with my hand-formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMgDauUA2R9u2THCHmMgv1)_